### PR TITLE
バージョンをpackage.jsonから取得する

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,6 +2,7 @@
 
 import { Command } from 'commander';
 
+import pkg from '../../package.json' with { type: 'json' };
 import { startServer } from '../server/server.js';
 
 import { validateCommitish } from './utils.js';
@@ -11,7 +12,7 @@ const program = new Command();
 program
   .name('reviewit')
   .description('A lightweight Git diff viewer with GitHub-like interface')
-  .version('0.1.0')
+  .version(pkg.version)
   .argument('[commit-ish]', 'Git commit, tag, branch, or HEAD~n reference (default: HEAD)', 'HEAD')
   .option('--port <port>', 'preferred port (auto-assigned if occupied)', parseInt)
   .option('--no-open', 'do not automatically open browser')


### PR DESCRIPTION
CLIの表示するバージョンが`package.json`のバージョンと異なっていたため、CLIが直接`package.json`からバージョンを読み込むように変更しました。

### 動作確認

最新リリース

```
❯ npx reviewit@latest  --version
Need to install the following packages:
reviewit@1.0.6
Ok to proceed? (y)

0.1.0
```

修正後
```
❯ pnpm run dev:cli --version

> reviewit@1.0.6 dev:cli /Users/noyan/ghq/github.com/yoshiko-pg/reviewit
> tsc --project tsconfig.cli.json && NODE_ENV=development node dist/cli/index.js --version

1.0.6
```