### PR TITLE
fix: improve build scripts in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,17 +21,17 @@
   "scripts": {
     "dev": "node scripts/dev.js",
     "dev:cli": "tsc --project tsconfig.cli.json && NODE_ENV=development node dist/cli/index.js",
-    "build": "pnpm run build:cli && tsc && vite build",
+    "build": "tsc -b && vite build",
     "build:cli": "tsc --project tsconfig.cli.json",
-    "start": "pnpm run build && pnpm run build:cli && node dist/cli/index.js",
+    "start": "pnpm run build && node dist/cli/index.js",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc -b",
     "test": "vitest run",
     "test:watch": "vitest",
     "prepare": "lefthook install",
-    "prepublishOnly": "NODE_ENV=production pnpm run build && pnpm run build:cli"
+    "prepublishOnly": "NODE_ENV=production pnpm run build"
   },
   "dependencies": {
     "commander": "^11.1.0",


### PR DESCRIPTION
個別の`tsc`コマンドを`tsc -b`に置き換え、プロジェクトリファレンスを正しくビルド出来るように修正しました。それに伴って、冗長になったビルドコマンドの削除も行いました。

- build: `pnpm run build:cli && tsc` -> `tsc -b`
 `tsconfig.json`で参照された`tsconfig.cli.json`がビルドされるようになります
- start: 不要になった`build:cli`呼び出しを削除
- typecheck: `tsc --noEmit` -> `tsc -b`
以前までcliのビルドを行っていなかったところを行うように修正しました。`tsconfig.json`には元々`noEmit: true`が設定されているため、この変更で`pnpm run build:cli && tsc --noEmit`と同じような効果が得られるはずです
- prepublishOnly: 不要になった`build:cli`呼び出しを削除