### PR TITLE
 feat: Add --host option to configure server bind address

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -16,6 +16,7 @@ function isSpecialArg(arg: string): arg is SpecialArg {
 
 interface CliOptions {
   port?: number;
+  host?: string;
   open: boolean;
   mode: string;
   tui?: boolean;
@@ -38,6 +39,7 @@ program
     'Optional: Compare with this commit/branch (shows diff between commit-ish and compare-with)'
   )
   .option('--port <port>', 'preferred port (auto-assigned if occupied)', parseInt)
+  .option('--host <host>', 'host address to bind to (default: 127.0.0.1)', '127.0.0.1')
   .option('--no-open', 'do not automatically open browser')
   .option('--mode <mode>', 'diff mode (inline only for now)', 'inline')
   .option('--tui', 'use terminal UI instead of web interface')
@@ -113,6 +115,7 @@ program
         targetCommitish,
         baseCommitish,
         preferredPort: options.port,
+        host: options.host,
         openBrowser: options.open,
         mode: options.mode,
       });


### PR DESCRIPTION
## Summary

- Added `--host` option to configure server bind address
- Enables external access to ReviewIt diff viewer when needed
- Maintains secure localhost-only default for backward compatibility

## Features

- New `--host <host>` CLI option with default value `127.0.0.1`
- Support for binding to specific IP addresses or `0.0.0.0` for external access
- Smart URL generation (displays `localhost` when host is `0.0.0.0`)
- Preserves existing port fallback logic with specified host
- Updated documentation with usage examples

## Usage

```bash
# Default behavior (localhost only)
reviewit HEAD

# Allow external access
reviewit --host 0.0.0.0 HEAD

# Bind to specific IP address
reviewit --host 192.168.1.100 HEAD

# Combine with other options
reviewit --host 0.0.0.0 --port 8080 HEAD
```

## Implementation Details

- Extended CliOptions interface to include optional host property
- Updated ServerOptions interface in server module to accept host parameter
- Modified startServerWithFallback function to use configurable host instead of hardcoded 127.0.0.1
- Enhanced URL generation logic to handle 0.0.0.0 display as localhost for better UX
- Updated README.md with CLI options table and usage examples

## Test plan

- [x] CLI help displays --host option correctly
- [x] TypeScript compilation passes with new interfaces
- [x] All existing tests continue to pass
- [x] Linting and formatting checks pass
- [x] Default behavior unchanged when --host not specified
- [x] Backward compatibility maintained

🤖 Generated with https://claude.ai/code
