### PR TITLE
(patch) Fix port fallback behavior

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -211,13 +211,9 @@ async function startServerWithFallback(
             })
             .catch(reject);
         }
+        // Unexpected error
         default: {
-          // TODO: Use Error.isError() utility function to check if the error is an instance of Error after upgrading to Node.js to v24.0.0
-          reject(
-            new Error(
-              `Failed to launch a server: ${err instanceof Error ? err.message : String(err)}`
-            )
-          );
+          reject(new Error(`Failed to launch a server: ${err.message}`));
         }
       }
     });


### PR DESCRIPTION
## Summary
In v1.1.7, There are bugs when the prefered port is in-use.
* Printing `localhost:undefined` as the listening server address.
* Opening browser doesn't work

#### reproduce bug
1. launch a some server on port 3000
2. run `npx reviewit`
3. The server log prints `http://localhost:undefined` in stdout
```
Port 3000 is busy, trying 3001...

🚀 ReviewIt server started on http://localhost:undefined
📋 Reviewing: HEAD
🌐 Opening browser...
```


## What I changed
Express v5 passes an Error instance to the callback function for `listen` method. https://expressjs.com/en/guide/migrating-5.html#app.listen

By using this feature, we can do error handling more easier and simple than `server.on('error', ...`.

Now, the fallback port is printed correctly and opening browser works.
```
Port 3000 is busy, trying 3001...

🚀 ReviewIt server started on http://localhost:3001
📋 Reviewing: HEAD
🌐 Opening browser...

```
