### PR TITLE
docs: remove unnecessary default value in help

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -30,7 +30,7 @@ program
   .version(pkg.version)
   .argument(
     '[commit-ish]',
-    'Git commit, tag, branch, HEAD~n reference, or "working"/"staged"/"." (default: HEAD)',
+    'Git commit, tag, branch, HEAD~n reference, or "working"/"staged"/"."',
     'HEAD'
   )
   .argument(


### PR DESCRIPTION
Since commander.js automatically displays the default value, it is not necessary to include it in the help text.

<img width="1209" alt="image" src="https://github.com/user-attachments/assets/1be95bb2-7847-47a7-b172-5645cf57d265" />

