### PR TITLE
Fix diff display issue when non-default git diff tool is set

### DIFF
--- a/src/server/git-diff.ts
+++ b/src/server/git-diff.ts
@@ -52,6 +52,10 @@ export class GitDiffParser {
         diffArgs.push('-w');
       }
 
+      // Ignore external diff-tools to unify output.
+      // https://github.com/yoshiko-pg/reviewit/issues/19
+      diffArgs.push('--no-ext-diff', '--color=never');
+
       // Add --color=never to ensure plain text output without ANSI escape sequences
       const diffSummary = await this.git.diffSummary(diffArgs);
       const diffRaw = await this.git.diff(['--color=never', ...diffArgs]);


### PR DESCRIPTION
# Summary
https://github.com/yoshiko-pg/reviewit/issues/19
I have fixed an issue where reviewIt could not display diffs when an external diff tool was configured in Git. For more details, please refer to the issue above.

# what I changed

- To ensure consistent output results, I have adjusted the options to use our original Diff tool instead of relying on external Diff tools.

# Manual Test Result
![image](https://github.com/user-attachments/assets/56a2defa-72db-40d9-9307-4cc5150443fc)

```
$ git config --global --get diff.external
difft --background=light

$ git status
On branch fix/no-ext-diff
Changes not staged for commit:
        new file:   hoge
        modified:   src/server/git-diff.ts

$ pnpm run start .

> reviewit@1.1.9 start
> pnpm run build && node dist/cli/index.js .

> reviewit@1.1.9 build
> tsc -b && vite build

vite v7.0.0 building for production...
1678 modules transformed.
built in 1.51s

ReviewIt server started on http://localhost:3000
Reviewing: .
Opening browser...

Client disconnected, shutting down server...

```
