### PR TITLE
Fix git diff header parsing to handle paths without prefix

### DIFF
--- a/src/server/git-diff.ts
+++ b/src/server/git-diff.ts
@@ -97,7 +97,7 @@ export class GitDiffParser {
     const lines = block.split('\n');
     const headerLine = lines[0];
 
-    const pathMatch = headerLine.match(/^diff --git [a-z]\/(.+) [a-z]\/(.+)$/);
+    const pathMatch = headerLine.match(/^diff --git (?:[a-z]\/)?(.+) (?:[a-z]\/)?(.+)$/);
     if (!pathMatch) return null;
 
     const oldPath = pathMatch[1];


### PR DESCRIPTION
## Problem
Currently, the git diff header parsing fails when git is configured with `diff.noprefix=true`. This configuration removes the `a/` and `b/` prefixes from file paths in diff output, causing the regex to not match and breaking the diff parsing functionality.

## Example
**With default git config (works):**
```
diff --git a/src/file.js b/src/file.js
```

**With `diff.noprefix=true` (currently broken):**
```
diff --git src/file.js src/file.js
```

## Solution
Updated the regex pattern to make the `a/` and `b/` prefixes optional using non-capturing groups `(?:[a-z]\/)?`, allowing the parser to handle both formats correctly.

## Impact
- ✅ Maintains backward compatibility with default git configuration
- ✅ Adds support for `diff.noprefix=true` configuration
- ✅ Makes the tool more robust across different git setups
- ✅ No breaking changes to existing functionality

This change ensures the tool works consistently regardless of the user's git configuration.

🤖 Generated with Claude Code