### PR TITLE
fix: make --clean flag properly reset viewed files counter

### DIFF
--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -1,8 +1,13 @@
 #!/usr/bin/env node
 import { spawn } from 'child_process';
 
-const commitish = process.argv[2] || 'HEAD';
-const compareWith = process.argv[3];
+// Parse arguments: separate positional args from flags
+const args = process.argv.slice(2);
+const flags = args.filter((arg) => arg.startsWith('--') && arg !== '--');
+const positionalArgs = args.filter((arg) => !arg.startsWith('--') && arg !== '--');
+
+const commitish = positionalArgs[0] || 'HEAD';
+const compareWith = positionalArgs[1];
 const CLI_SERVER_READY_MESSAGE = 'difit server started';
 
 // Check if we should read from stdin
@@ -27,6 +32,8 @@ if (!shouldReadStdin) {
   cliArgs.push('-');
 }
 cliArgs.push('--no-open');
+// Add any flags passed to the dev script
+cliArgs.push(...flags);
 
 const cliProcess = spawn('pnpm', cliArgs, {
   // For stdin mode, pipe stdin; otherwise inherit

--- a/src/client/App.test.tsx
+++ b/src/client/App.test.tsx
@@ -22,13 +22,14 @@ vi.mock('./hooks/useDiffComments', () => ({
 }));
 
 // Mock the useViewedFiles hook
+const mockClearViewedFiles = vi.fn();
 vi.mock('./hooks/useViewedFiles', () => ({
   useViewedFiles: vi.fn(() => ({
     viewedFiles: new Set<string>(),
     toggleFileViewed: vi.fn(),
     isFileContentChanged: vi.fn(),
     getViewedFileRecord: vi.fn(),
-    clearViewedFiles: vi.fn(),
+    clearViewedFiles: mockClearViewedFiles,
   })),
 }));
 
@@ -186,6 +187,21 @@ describe('App Component - Clear Comments Functionality', () => {
       });
     });
 
+    it('should clear viewed files when clearComments flag is true in response', async () => {
+      const responseWithClearFlag: DiffResponse = {
+        ...mockDiffResponse,
+        clearComments: true,
+      };
+
+      mockFetch(responseWithClearFlag);
+
+      renderApp();
+
+      await waitFor(() => {
+        expect(mockClearViewedFiles).toHaveBeenCalled();
+      });
+    });
+
     it('should not clear comments when clearComments flag is false', async () => {
       const responseWithoutClearFlag: DiffResponse = {
         ...mockDiffResponse,
@@ -230,7 +246,7 @@ describe('App Component - Clear Comments Functionality', () => {
 
       await waitFor(() => {
         expect(consoleLogSpy).toHaveBeenCalledWith(
-          '✅ All existing comments cleared as requested via --clean flag'
+          '✅ All existing comments and viewed files cleared as requested via --clean flag'
         );
       });
 

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -57,7 +57,7 @@ function App() {
   );
 
   // Viewed files management
-  const { viewedFiles, toggleFileViewed } = useViewedFiles(
+  const { viewedFiles, toggleFileViewed, clearViewedFiles } = useViewedFiles(
     diffData?.baseCommitish,
     diffData?.targetCommitish,
     diffData?.commit,
@@ -184,15 +184,18 @@ function App() {
     void fetchDiffData();
   }, [fetchDiffData]);
 
-  // Clear comments on initial load if requested via CLI flag
+  // Clear comments and viewed files on initial load if requested via CLI flag
   const hasCleanedRef = useRef(false);
   useEffect(() => {
     if (diffData?.clearComments && !hasCleanedRef.current) {
       hasCleanedRef.current = true;
       clearAllComments();
-      console.log('✅ All existing comments cleared as requested via --clean flag');
+      clearViewedFiles();
+      console.log(
+        '✅ All existing comments and viewed files cleared as requested via --clean flag'
+      );
     }
-  }, [diffData?.clearComments, clearAllComments]);
+  }, [diffData?.clearComments, clearAllComments, clearViewedFiles]);
 
   // Trigger sparkle animation when all files are viewed
   useEffect(() => {


### PR DESCRIPTION
The --clean flag was only clearing comments but not resetting the viewed files counter. This fix addresses two issues:

1. App.tsx now calls clearViewedFiles() when --clean flag is detected
2. scripts/dev.js now properly passes through --clean flag to CLI

Fixes #91

🤖 Generated with [Claude Code](https://claude.ai/code)