### PR TITLE
Ensure diff code respects appearance font size

### DIFF
--- a/src/client/components/DiffChunk.tsx
+++ b/src/client/components/DiffChunk.tsx
@@ -242,7 +242,10 @@ export function DiffChunk({
 
   return (
     <div className="bg-github-bg-primary">
-      <table className="w-full border-collapse font-mono text-xs leading-5">
+      <table
+        className="w-full border-collapse font-mono"
+        style={{ fontSize: 'var(--app-code-font-size)' }}
+      >
         <tbody>
           {chunk.lines.map((line, index) => {
             const lineComments = getCommentsForLine(line.newLineNumber || line.oldLineNumber || 0);

--- a/src/client/components/DiffViewer.tsx
+++ b/src/client/components/DiffViewer.tsx
@@ -191,7 +191,10 @@ export function DiffViewer({
                   className="border-b border-github-border"
                 >
                   <div className="bg-github-bg-tertiary px-3 py-2 border-b border-github-border">
-                    <code className="text-github-text-secondary text-xs font-mono">
+                    <code
+                      className="text-github-text-secondary font-mono"
+                      style={{ fontSize: 'var(--app-code-font-size)' }}
+                    >
                       {chunk.header}
                     </code>
                   </div>

--- a/src/client/components/SideBySideDiffChunk.tsx
+++ b/src/client/components/SideBySideDiffChunk.tsx
@@ -281,7 +281,10 @@ export function SideBySideDiffChunk({
 
   return (
     <div className="bg-github-bg-primary border border-github-border rounded-md overflow-hidden">
-      <table className="w-full border-collapse font-mono text-xs leading-5">
+      <table
+        className="w-full border-collapse font-mono"
+        style={{ fontSize: 'var(--app-code-font-size)' }}
+      >
         <tbody>
           {sideBySideLines.map((sideLine, index) => {
             // For side-by-side view, only show comments on the right side (new line numbers)

--- a/src/client/hooks/useAppearanceSettings.test.ts
+++ b/src/client/hooks/useAppearanceSettings.test.ts
@@ -1,0 +1,50 @@
+import { renderHook, act } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { useAppearanceSettings } from './useAppearanceSettings';
+
+const STORAGE_KEY = 'reviewit-appearance-settings';
+
+describe('useAppearanceSettings', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.style.cssText = '';
+    document.body.style.cssText = '';
+  });
+
+  it('applies font size settings to root variables', () => {
+    const { result } = renderHook(() => useAppearanceSettings());
+
+    expect(document.documentElement.style.getPropertyValue('--app-font-size')).toBe('14px');
+    expect(document.documentElement.style.getPropertyValue('--app-code-font-size')).toBe('14px');
+
+    act(() => {
+      result.current.updateSettings({
+        ...result.current.settings,
+        fontSize: 18,
+      });
+    });
+
+    expect(document.documentElement.style.getPropertyValue('--app-font-size')).toBe('18px');
+    expect(document.documentElement.style.getPropertyValue('--app-code-font-size')).toBe('18px');
+  });
+
+  it('restores persisted font size to both text and code', () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        fontSize: 16,
+        fontFamily: 'Menlo, Monaco, "Courier New", monospace',
+        theme: 'dark',
+        syntaxTheme: 'vsDark',
+      })
+    );
+
+    const { unmount } = renderHook(() => useAppearanceSettings());
+
+    expect(document.documentElement.style.getPropertyValue('--app-font-size')).toBe('16px');
+    expect(document.documentElement.style.getPropertyValue('--app-code-font-size')).toBe('16px');
+
+    unmount();
+  });
+});

--- a/src/client/hooks/useAppearanceSettings.ts
+++ b/src/client/hooks/useAppearanceSettings.ts
@@ -34,6 +34,7 @@ export function useAppearanceSettings() {
 
     // Apply font size
     root.style.setProperty('--app-font-size', `${settings.fontSize}px`);
+    root.style.setProperty('--app-code-font-size', `${settings.fontSize}px`);
 
     // Apply font family
     root.style.setProperty('--app-font-family', settings.fontFamily);

--- a/src/client/styles/global.css
+++ b/src/client/styles/global.css
@@ -28,6 +28,7 @@
 /* CSS Custom Properties for dynamic theming */
 :root {
   --app-font-size: 14px;
+  --app-code-font-size: 14px;
   --app-font-family:
     -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif;
 }


### PR DESCRIPTION
## Purpose
Make user-adjusted font sizes apply consistently to code diffs so they remain readable when the appearance slider increases text size.

Before

<img width="1899" height="972" alt="スクリーンショット 2025-10-03 003240" src="https://github.com/user-attachments/assets/e2ff4a46-1628-4d26-89a9-51f98aabdc29" />

After

<img width="1887" height="973" alt="スクリーンショット 2025-10-03 003152" src="https://github.com/user-attachments/assets/a7910358-bc80-47ed-b322-dc5195605e25" />

## Summary
- add the `--app-code-font-size` CSS variable so diff tables inherit the selected text size
- update inline and side-by-side diff components (and chunk headers) to use the shared code font variable instead of fixed `text-xs`
- cover the new behavior with a hook test that verifies both UI and code font settings stay in sync, including persisted values

## Notes
- It’s still unclear whether the team prefers to accept this change; some reviewers might consider the smaller code font more desirable for higher information density.
