### PR TITLE
feat: Auto-collapse deleted files in diff view

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -148,28 +148,30 @@ src/components/Button.tsx:L42-L48   # この行が自動的に追加されます
 - **IaC**：Terraform (HCL)
 - **その他**：Python, Protobuf, YAML, Solidity, Vim Script
 
-## 🔍 自動生成ファイルの検出
+## 🔍 自動折りたたみファイル
 
-difitは生成されたファイルを自動的に識別し、ビューをすっきりさせるために折りたたみます。これには以下が含まれます：
+difitは特定のファイルを自動的に識別し、ビューをすっきりさせるために折りたたみます：
 
-- ロックファイル (`package-lock.json`, `go.mod`, `Cargo.lock`, `Gemfile.lock` など)
-- 圧縮されたファイル (`*.min.js`, `*.min.css`)
-- ソースマップ (`*.map`)
-- 生成されたコード:
-  - Orval (`*.msw.ts`, `*.zod.ts`, `*.api.ts`)
-  - Dart (`*.g.dart`, `*.freezed.dart`)
-  - C# (`*.g.cs`, `*.designer.cs`)
-  - Protobuf (`*.pb.go`, `*.pb.cc`, `*.pb.h`)
-- フレームワーク:
-  - Ruby on Rails (`db/schema.rb`)
-  - Laravel (`_ide_helper.php`)
-  - Gradle (`gradle.lockfile`)
-  - Python (`uv.lock`, `pdm.lock`)
-- 一般的な生成ファイル (`*.generated.cs`, `*.generated.ts`, `*.generated.js`)
-- コンテンツベースの検出:
-  - `@generated` マーカーを含むファイル
-  - `DO NOT EDIT` ヘッダーを含むファイル
-  - 言語固有の自動生成ヘッダー (Go, Pythonなど)
+- **削除されたファイル**: 削除されたファイルは詳細なレビューが不要なため、自動的に折りたたまれます
+- **自動生成ファイル**: 自動生成されたコードはデフォルトで折りたたまれます。これには以下が含まれます：
+  - ロックファイル (`package-lock.json`, `go.mod`, `Cargo.lock`, `Gemfile.lock` など)
+  - 圧縮されたファイル (`*.min.js`, `*.min.css`)
+  - ソースマップ (`*.map`)
+  - 生成されたコード:
+    - Orval (`*.msw.ts`, `*.zod.ts`, `*.api.ts`)
+    - Dart (`*.g.dart`, `*.freezed.dart`)
+    - C# (`*.g.cs`, `*.designer.cs`)
+    - Protobuf (`*.pb.go`, `*.pb.cc`, `*.pb.h`)
+  - フレームワーク:
+    - Ruby on Rails (`db/schema.rb`)
+    - Laravel (`_ide_helper.php`)
+    - Gradle (`gradle.lockfile`)
+    - Python (`uv.lock`, `pdm.lock`)
+  - 一般的な生成ファイル (`*.generated.cs`, `*.generated.ts`, `*.generated.js`)
+  - コンテンツベースの検出:
+    - `@generated` マーカーを含むファイル
+    - `DO NOT EDIT` ヘッダーを含むファイル
+    - 言語固有の自動生成ヘッダー (Go, Pythonなど)
 
 ## 🛠️ 開発
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -148,28 +148,30 @@ src/components/Button.tsx:L42-L48   # 이 줄은 자동으로 추가됩니다
 - **인프라 코드**: Terraform (HCL)
 - **기타**: Python, Protobuf, YAML, Solidity, Vim 스크립트
 
-## 🔍 자동 생성 파일 감지
+## 🔍 자동 접힘 파일
 
-difit은 생성된 파일을 자동으로 식별하고 접어서 뷰를 깔끔하게 유지합니다. 여기에는 다음이 포함됩니다:
+difit은 특정 파일을 자동으로 식별하고 접어서 뷰를 깔끔하게 유지합니다:
 
-- 잠금 파일 (`package-lock.json`, `go.mod`, `Cargo.lock`, `Gemfile.lock` 등)
-- 축소된 파일 (`*.min.js`, `*.min.css`)
-- 소스 맵 (`*.map`)
-- 생성된 코드:
-  - Orval (`*.msw.ts`, `*.zod.ts`, `*.api.ts`)
-  - Dart (`*.g.dart`, `*.freezed.dart`)
-  - C# (`*.g.cs`, `*.designer.cs`)
-  - Protobuf (`*.pb.go`, `*.pb.cc`, `*.pb.h`)
-- 프레임워크:
-  - Ruby on Rails (`db/schema.rb`)
-  - Laravel (`_ide_helper.php`)
-  - Gradle (`gradle.lockfile`)
-  - Python (`uv.lock`, `pdm.lock`)
-- 일반적인 생성 파일 (`*.generated.cs`, `*.generated.ts`, `*.generated.js`)
-- 콘텐츠 기반 감지:
-  - `@generated` 마커가 포함된 파일
-  - `DO NOT EDIT` 헤더가 포함된 파일
-  - 언어별 생성 헤더 (Go, Python 등)
+- **삭제된 파일**: 삭제된 파일은 자세한 검토가 필요하지 않으므로 자동으로 접힙니다
+- **자동 생성 파일**: 자동 생성된 코드는 기본적으로 접힙니다. 여기에는 다음이 포함됩니다:
+  - 잠금 파일 (`package-lock.json`, `go.mod`, `Cargo.lock`, `Gemfile.lock` 등)
+  - 축소된 파일 (`*.min.js`, `*.min.css`)
+  - 소스 맵 (`*.map`)
+  - 생성된 코드:
+    - Orval (`*.msw.ts`, `*.zod.ts`, `*.api.ts`)
+    - Dart (`*.g.dart`, `*.freezed.dart`)
+    - C# (`*.g.cs`, `*.designer.cs`)
+    - Protobuf (`*.pb.go`, `*.pb.cc`, `*.pb.h`)
+  - 프레임워크:
+    - Ruby on Rails (`db/schema.rb`)
+    - Laravel (`_ide_helper.php`)
+    - Gradle (`gradle.lockfile`)
+    - Python (`uv.lock`, `pdm.lock`)
+  - 일반적인 생성 파일 (`*.generated.cs`, `*.generated.ts`, `*.generated.js`)
+  - 콘텐츠 기반 감지:
+    - `@generated` 마커가 포함된 파일
+    - `DO NOT EDIT` 헤더가 포함된 파일
+    - 언어별 생성 헤더 (Go, Python 등)
 
 ## 🛠️ 개발
 

--- a/README.md
+++ b/README.md
@@ -148,28 +148,30 @@ This section is unnecessary
 - **Infrastructure as Code**: Terraform (HCL)
 - **Others**: Python, Protobuf, YAML, Solidity, Vim script
 
-## 🔍 Detecting Auto-generated Files
+## 🔍 Auto-collapsed Files
 
-difit automatically identifies and collapses generated files to keep your view clean. This includes:
+difit automatically identifies and collapses certain files to keep your view clean:
 
-- Lock files (`package-lock.json`, `go.mod`, `Cargo.lock`, `Gemfile.lock`, etc.)
-- Minified files (`*.min.js`, `*.min.css`)
-- Source maps (`*.map`)
-- Generated code:
-  - Orval (`*.msw.ts`, `*.zod.ts`, `*.api.ts`)
-  - Dart (`*.g.dart`, `*.freezed.dart`)
-  - C# (`*.g.cs`, `*.designer.cs`)
-  - Protobuf (`*.pb.go`, `*.pb.cc`, `*.pb.h`)
-- Frameworks:
-  - Ruby on Rails (`db/schema.rb`)
-  - Laravel (`_ide_helper.php`)
-  - Gradle (`gradle.lockfile`)
-  - Python (`uv.lock`, `pdm.lock`)
-- Generic generated files (`*.generated.cs`, `*.generated.ts`, `*.generated.js`)
-- Content-based detection:
-  - Files containing `@generated` marker
-  - Files containing `DO NOT EDIT` header
-  - Language-specific generated headers (Go, Python, etc.)
+- **Deleted files**: Removed files are auto-collapsed since they don't require close review
+- **Generated files**: Auto-generated code is collapsed by default. This includes:
+  - Lock files (`package-lock.json`, `go.mod`, `Cargo.lock`, `Gemfile.lock`, etc.)
+  - Minified files (`*.min.js`, `*.min.css`)
+  - Source maps (`*.map`)
+  - Generated code:
+    - Orval (`*.msw.ts`, `*.zod.ts`, `*.api.ts`)
+    - Dart (`*.g.dart`, `*.freezed.dart`)
+    - C# (`*.g.cs`, `*.designer.cs`)
+    - Protobuf (`*.pb.go`, `*.pb.cc`, `*.pb.h`)
+  - Frameworks:
+    - Ruby on Rails (`db/schema.rb`)
+    - Laravel (`_ide_helper.php`)
+    - Gradle (`gradle.lockfile`)
+    - Python (`uv.lock`, `pdm.lock`)
+  - Generic generated files (`*.generated.cs`, `*.generated.ts`, `*.generated.js`)
+  - Content-based detection:
+    - Files containing `@generated` marker
+    - Files containing `DO NOT EDIT` header
+    - Language-specific generated headers (Go, Python, etc.)
 
 ## 🛠️ Development
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -148,28 +148,30 @@ src/components/Button.tsx:L42-L48   # 此行自动添加
 - **基础设施即代码**：Terraform (HCL)
 - **其他**：Python, Protobuf, YAML, Solidity, Vim Script
 
-## 🔍 检测自动生成文件
+## 🔍 自动折叠文件
 
-difit 自动识别并折叠生成的文件以保持视图整洁。这包括：
+difit 自动识别并折叠某些文件以保持视图整洁：
 
-- 锁定文件 (`package-lock.json`, `go.mod`, `Cargo.lock`, `Gemfile.lock` 等)
-- 压缩文件 (`*.min.js`, `*.min.css`)
-- 源映射 (`*.map`)
-- 生成的代码:
-  - Orval (`*.msw.ts`, `*.zod.ts`, `*.api.ts`)
-  - Dart (`*.g.dart`, `*.freezed.dart`)
-  - C# (`*.g.cs`, `*.designer.cs`)
-  - Protobuf (`*.pb.go`, `*.pb.cc`, `*.pb.h`)
-- 框架:
-  - Ruby on Rails (`db/schema.rb`)
-  - Laravel (`_ide_helper.php`)
-  - Gradle (`gradle.lockfile`)
-  - Python (`uv.lock`, `pdm.lock`)
-- 通用生成文件 (`*.generated.cs`, `*.generated.ts`, `*.generated.js`)
-- 基于内容的检测:
-  - 包含 `@generated` 标记的文件
-  - 包含 `DO NOT EDIT` 标头的文件
-  - 特定语言的生成标头 (Go, Python 等)
+- **已删除文件**：已删除的文件不需要详细审查，因此自动折叠
+- **自动生成文件**：自动生成的代码默认折叠。这包括：
+  - 锁定文件 (`package-lock.json`, `go.mod`, `Cargo.lock`, `Gemfile.lock` 等)
+  - 压缩文件 (`*.min.js`, `*.min.css`)
+  - 源映射 (`*.map`)
+  - 生成的代码:
+    - Orval (`*.msw.ts`, `*.zod.ts`, `*.api.ts`)
+    - Dart (`*.g.dart`, `*.freezed.dart`)
+    - C# (`*.g.cs`, `*.designer.cs`)
+    - Protobuf (`*.pb.go`, `*.pb.cc`, `*.pb.h`)
+  - 框架:
+    - Ruby on Rails (`db/schema.rb`)
+    - Laravel (`_ide_helper.php`)
+    - Gradle (`gradle.lockfile`)
+    - Python (`uv.lock`, `pdm.lock`)
+  - 通用生成文件 (`*.generated.cs`, `*.generated.ts`, `*.generated.js`)
+  - 基于内容的检测:
+    - 包含 `@generated` 标记的文件
+    - 包含 `DO NOT EDIT` 标头的文件
+    - 特定语言的生成标头 (Go, Python 等)
 
 ## 🛠️ 开发
 

--- a/src/client/hooks/useViewedFiles.test.ts
+++ b/src/client/hooks/useViewedFiles.test.ts
@@ -1,0 +1,321 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { type DiffFile, type ViewedFileRecord } from '../../types/diff';
+
+import { useViewedFiles } from './useViewedFiles';
+
+// Mock StorageService
+const mockGetViewedFiles = vi.fn((): ViewedFileRecord[] => []);
+const mockSaveViewedFiles = vi.fn();
+
+vi.mock('../services/StorageService', () => ({
+  storageService: {
+    getViewedFiles: () => mockGetViewedFiles(),
+    saveViewedFiles: (...args: unknown[]) => mockSaveViewedFiles(...args),
+  },
+}));
+
+// Mock diffUtils
+vi.mock('../utils/diffUtils', () => ({
+  generateDiffHash: vi.fn(async (content: string) => `hash-${content.slice(0, 10)}`),
+  getDiffContentForHashing: vi.fn((file: DiffFile) => `${file.path}-${file.status}`),
+}));
+
+// Helper to create a mock DiffFile
+function createMockDiffFile(
+  path: string,
+  status: 'modified' | 'added' | 'deleted' | 'renamed' = 'modified',
+  isGenerated = false
+): DiffFile {
+  return {
+    path,
+    status,
+    additions: 10,
+    deletions: 5,
+    chunks: [],
+    isGenerated,
+  };
+}
+
+describe('useViewedFiles', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetViewedFiles.mockReturnValue([]);
+  });
+
+  describe('initial state', () => {
+    it('should initialize with empty viewed files', () => {
+      const { result } = renderHook(() => useViewedFiles('main', 'feature-branch'));
+
+      expect(result.current.viewedFiles.size).toBe(0);
+    });
+
+    it('should not initialize without commitish values', () => {
+      const { result } = renderHook(() => useViewedFiles(undefined, undefined));
+
+      expect(mockGetViewedFiles).not.toHaveBeenCalled();
+      expect(result.current.viewedFiles.size).toBe(0);
+    });
+  });
+
+  describe('loading viewed files from storage', () => {
+    it('should load viewed files from storage on mount', async () => {
+      const storedRecords: ViewedFileRecord[] = [
+        { filePath: 'src/file1.ts', viewedAt: '2024-01-01T00:00:00Z', diffContentHash: 'hash1' },
+        { filePath: 'src/file2.ts', viewedAt: '2024-01-01T00:00:00Z', diffContentHash: 'hash2' },
+      ];
+      mockGetViewedFiles.mockReturnValue(storedRecords);
+
+      const { result } = renderHook(() => useViewedFiles('main', 'feature-branch'));
+
+      await waitFor(() => {
+        expect(result.current.viewedFiles.size).toBe(2);
+      });
+
+      expect(result.current.viewedFiles.has('src/file1.ts')).toBe(true);
+      expect(result.current.viewedFiles.has('src/file2.ts')).toBe(true);
+    });
+  });
+
+  describe('auto-collapsing files', () => {
+    it('should auto-mark generated files as viewed', async () => {
+      const initialFiles: DiffFile[] = [
+        createMockDiffFile('package-lock.json', 'modified', true),
+        createMockDiffFile('src/app.ts', 'modified', false),
+      ];
+
+      const { result } = renderHook(() =>
+        useViewedFiles('main', 'feature-branch', 'abc123', undefined, initialFiles)
+      );
+
+      await waitFor(() => {
+        expect(result.current.viewedFiles.has('package-lock.json')).toBe(true);
+      });
+
+      expect(result.current.viewedFiles.has('src/app.ts')).toBe(false);
+      expect(mockSaveViewedFiles).toHaveBeenCalled();
+    });
+
+    it('should auto-mark deleted files as viewed', async () => {
+      const initialFiles: DiffFile[] = [
+        createMockDiffFile('src/old-file.ts', 'deleted', false),
+        createMockDiffFile('src/app.ts', 'modified', false),
+      ];
+
+      const { result } = renderHook(() =>
+        useViewedFiles('main', 'feature-branch', 'abc123', undefined, initialFiles)
+      );
+
+      await waitFor(() => {
+        expect(result.current.viewedFiles.has('src/old-file.ts')).toBe(true);
+      });
+
+      expect(result.current.viewedFiles.has('src/app.ts')).toBe(false);
+      expect(mockSaveViewedFiles).toHaveBeenCalled();
+    });
+
+    it('should auto-mark both generated and deleted files as viewed', async () => {
+      const initialFiles: DiffFile[] = [
+        createMockDiffFile('package-lock.json', 'modified', true),
+        createMockDiffFile('src/deleted.ts', 'deleted', false),
+        createMockDiffFile('src/app.ts', 'modified', false),
+      ];
+
+      const { result } = renderHook(() =>
+        useViewedFiles('main', 'feature-branch', 'abc123', undefined, initialFiles)
+      );
+
+      await waitFor(() => {
+        expect(result.current.viewedFiles.size).toBe(2);
+      });
+
+      expect(result.current.viewedFiles.has('package-lock.json')).toBe(true);
+      expect(result.current.viewedFiles.has('src/deleted.ts')).toBe(true);
+      expect(result.current.viewedFiles.has('src/app.ts')).toBe(false);
+    });
+
+    it('should not re-add already viewed files', async () => {
+      const storedRecords: ViewedFileRecord[] = [
+        {
+          filePath: 'package-lock.json',
+          viewedAt: '2024-01-01T00:00:00Z',
+          diffContentHash: 'existing-hash',
+        },
+      ];
+      mockGetViewedFiles.mockReturnValue(storedRecords);
+
+      const initialFiles: DiffFile[] = [
+        createMockDiffFile('package-lock.json', 'modified', true),
+        createMockDiffFile('src/deleted.ts', 'deleted', false),
+      ];
+
+      const { result } = renderHook(() =>
+        useViewedFiles('main', 'feature-branch', 'abc123', undefined, initialFiles)
+      );
+
+      await waitFor(() => {
+        expect(result.current.viewedFiles.size).toBe(2);
+      });
+
+      // The saved records should include the existing one plus the new deleted file
+      const saveCall = mockSaveViewedFiles.mock.calls[0];
+      const savedRecords = saveCall?.[2] as ViewedFileRecord[];
+      expect(savedRecords).toHaveLength(2);
+
+      // The existing record should keep its original hash
+      const existingRecord = savedRecords?.find((r) => r.filePath === 'package-lock.json');
+      expect(existingRecord?.diffContentHash).toBe('existing-hash');
+    });
+  });
+
+  describe('toggleFileViewed', () => {
+    it('should add file to viewed when not viewed', async () => {
+      const { result } = renderHook(() => useViewedFiles('main', 'feature-branch'));
+
+      const diffFile = createMockDiffFile('src/app.ts', 'modified');
+
+      await act(async () => {
+        await result.current.toggleFileViewed('src/app.ts', diffFile);
+      });
+
+      expect(result.current.viewedFiles.has('src/app.ts')).toBe(true);
+      expect(mockSaveViewedFiles).toHaveBeenCalled();
+    });
+
+    it('should remove file from viewed when already viewed', async () => {
+      const storedRecords: ViewedFileRecord[] = [
+        { filePath: 'src/app.ts', viewedAt: '2024-01-01T00:00:00Z', diffContentHash: 'hash1' },
+      ];
+      mockGetViewedFiles.mockReturnValue(storedRecords);
+
+      const { result } = renderHook(() => useViewedFiles('main', 'feature-branch'));
+
+      await waitFor(() => {
+        expect(result.current.viewedFiles.has('src/app.ts')).toBe(true);
+      });
+
+      const diffFile = createMockDiffFile('src/app.ts', 'modified');
+
+      await act(async () => {
+        await result.current.toggleFileViewed('src/app.ts', diffFile);
+      });
+
+      expect(result.current.viewedFiles.has('src/app.ts')).toBe(false);
+    });
+  });
+
+  describe('getViewedFileRecord', () => {
+    it('should return record for viewed file', async () => {
+      const storedRecords: ViewedFileRecord[] = [
+        { filePath: 'src/app.ts', viewedAt: '2024-01-01T00:00:00Z', diffContentHash: 'hash1' },
+      ];
+      mockGetViewedFiles.mockReturnValue(storedRecords);
+
+      const { result } = renderHook(() => useViewedFiles('main', 'feature-branch'));
+
+      await waitFor(() => {
+        expect(result.current.viewedFiles.has('src/app.ts')).toBe(true);
+      });
+
+      const record = result.current.getViewedFileRecord('src/app.ts');
+      expect(record).toBeDefined();
+      expect(record?.filePath).toBe('src/app.ts');
+      expect(record?.diffContentHash).toBe('hash1');
+    });
+
+    it('should return undefined for non-viewed file', () => {
+      const { result } = renderHook(() => useViewedFiles('main', 'feature-branch'));
+
+      const record = result.current.getViewedFileRecord('src/not-viewed.ts');
+      expect(record).toBeUndefined();
+    });
+  });
+
+  describe('isFileContentChanged', () => {
+    it('should return false for non-viewed file', async () => {
+      const { result } = renderHook(() => useViewedFiles('main', 'feature-branch'));
+
+      const diffFile = createMockDiffFile('src/app.ts', 'modified');
+      const isChanged = await result.current.isFileContentChanged('src/app.ts', diffFile);
+
+      expect(isChanged).toBe(false);
+    });
+
+    it('should return false when hash matches', async () => {
+      // Mock generates hash as: hash- + first 10 chars of content
+      // getDiffContentForHashing returns: src/app.ts-modified
+      // So hash = hash-src/app.ts (first 10 chars)
+      const storedRecords: ViewedFileRecord[] = [
+        {
+          filePath: 'src/app.ts',
+          viewedAt: '2024-01-01T00:00:00Z',
+          diffContentHash: 'hash-src/app.ts',
+        },
+      ];
+      mockGetViewedFiles.mockReturnValue(storedRecords);
+
+      const { result } = renderHook(() => useViewedFiles('main', 'feature-branch'));
+
+      await waitFor(() => {
+        expect(result.current.viewedFiles.has('src/app.ts')).toBe(true);
+      });
+
+      const diffFile = createMockDiffFile('src/app.ts', 'modified');
+      const isChanged = await result.current.isFileContentChanged('src/app.ts', diffFile);
+
+      expect(isChanged).toBe(false);
+    });
+
+    it('should return true when hash differs', async () => {
+      const storedRecords: ViewedFileRecord[] = [
+        {
+          filePath: 'src/app.ts',
+          viewedAt: '2024-01-01T00:00:00Z',
+          diffContentHash: 'old-hash',
+        },
+      ];
+      mockGetViewedFiles.mockReturnValue(storedRecords);
+
+      const { result } = renderHook(() => useViewedFiles('main', 'feature-branch'));
+
+      await waitFor(() => {
+        expect(result.current.viewedFiles.has('src/app.ts')).toBe(true);
+      });
+
+      const diffFile = createMockDiffFile('src/app.ts', 'modified');
+      const isChanged = await result.current.isFileContentChanged('src/app.ts', diffFile);
+
+      expect(isChanged).toBe(true);
+    });
+  });
+
+  describe('clearViewedFiles', () => {
+    it('should clear all viewed files', async () => {
+      const storedRecords: ViewedFileRecord[] = [
+        { filePath: 'src/file1.ts', viewedAt: '2024-01-01T00:00:00Z', diffContentHash: 'hash1' },
+        { filePath: 'src/file2.ts', viewedAt: '2024-01-01T00:00:00Z', diffContentHash: 'hash2' },
+      ];
+      mockGetViewedFiles.mockReturnValue(storedRecords);
+
+      const { result } = renderHook(() => useViewedFiles('main', 'feature-branch'));
+
+      await waitFor(() => {
+        expect(result.current.viewedFiles.size).toBe(2);
+      });
+
+      act(() => {
+        result.current.clearViewedFiles();
+      });
+
+      expect(result.current.viewedFiles.size).toBe(0);
+      expect(mockSaveViewedFiles).toHaveBeenCalledWith(
+        'main',
+        'feature-branch',
+        [],
+        undefined,
+        undefined
+      );
+    });
+  });
+});


### PR DESCRIPTION
Hi @yoshiko-pg san!

I would like to submit another PR to introduce an improvement for automatically collapsing files.

## Summary

- Add auto-collapse functionality for deleted files, making it easier to focus on meaningful changes
- Deleted files are now automatically marked as "viewed" since they typically don't require close review
- Rename internal variables from `generatedFiles` to `autoCollapsedFiles` for better clarity

## Background

I introduced the auto-collapse feature for generated files in https://github.com/yoshiko-pg/difit/pull/136. 

When reviewing diffs, deleted files often don't need detailed inspection - we just need to know they were removed. 

This PR extends that functionality to also include deleted files, inspired by how GitHub automatically hides deleted file diffs in pull request reviews.

Thanks!