### PR TITLE
Support file folder auto-collapse when all files viewed

### DIFF
--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -20,8 +20,9 @@ vi.mock('./utils.js', async () => {
 
 const { simpleGit } = await import('simple-git');
 const { startServer } = await import('../server/server.js');
-const { promptUser, findUntrackedFiles, markFilesIntentToAdd, resolvePrCommits } =
-  await import('./utils.js');
+const { promptUser, findUntrackedFiles, markFilesIntentToAdd, resolvePrCommits } = await import(
+  './utils.js'
+);
 
 describe('CLI index.ts', () => {
   let mockGit: any;


### PR DESCRIPTION
# Auto-collapse directories when all files are reviewed
## Feature Overview
- Improves the file list UX by automatically collapsing a directory once all files under it are marked as reviewed.
- Reduces visual noise and helps reviewers focus on remaining files.
Implementation Details

## User Impact
- All directories start expanded by default.
- Directories auto-collapse when all contained files are reviewed.
- Existing search, icons, comment counts, and selection behavior remain unchanged.

## Change Summary

- Frontend: File list state and rendering logic updated to support auto-collapse
  - FileList.tsx
- Tests: Minor adjustments in CLI test file (no functional CLI changes)
  - index.test.ts

 
## ScreenShot
![20260105083139_rec_](https://github.com/user-attachments/assets/b50457e5-ff9b-4171-b5d6-26419bee9352)
