### PR TITLE
feat: independent file collapse state with Alt+Click support

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -134,6 +134,18 @@ function App() {
     });
   };
 
+  const toggleAllFilesCollapsed = (shouldCollapse: boolean) => {
+    if (!diffData) return;
+
+    if (shouldCollapse) {
+      // Collapse all files
+      setCollapsedFiles(new Set(diffData.files.map((f) => f.path)));
+    } else {
+      // Expand all files
+      setCollapsedFiles(new Set());
+    }
+  };
+
   const handleDiffModeChange = useCallback((mode: DiffViewMode) => {
     hasUserSetDiffModeRef.current = true;
     setDiffMode(mode);
@@ -682,6 +694,7 @@ function App() {
                     onToggleReviewed={toggleFileReviewed}
                     collapsedFiles={collapsedFiles}
                     onToggleCollapsed={toggleFileCollapsed}
+                    onToggleAllCollapsed={toggleAllFilesCollapsed}
                     onAddComment={handleAddComment}
                     onGeneratePrompt={(comment) => generatePrompt(comment.id)}
                     onRemoveComment={removeComment}

--- a/src/client/components/DiffViewer.test.tsx
+++ b/src/client/components/DiffViewer.test.tsx
@@ -37,6 +37,7 @@ describe('DiffViewer', () => {
   const mockOnUpdateComment = vi.fn();
   const mockOnToggleReviewed = vi.fn();
   const mockOnToggleCollapsed = vi.fn();
+  const mockOnToggleAllCollapsed = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -76,6 +77,7 @@ describe('DiffViewer', () => {
     onUpdateComment: mockOnUpdateComment,
     onToggleReviewed: mockOnToggleReviewed,
     onToggleCollapsed: mockOnToggleCollapsed,
+    onToggleAllCollapsed: mockOnToggleAllCollapsed,
   };
 
   describe('File type handling', () => {

--- a/src/client/components/DiffViewer.tsx
+++ b/src/client/components/DiffViewer.tsx
@@ -33,6 +33,7 @@ interface DiffViewerProps {
   onToggleReviewed: (path: string) => void;
   collapsedFiles: Set<string>;
   onToggleCollapsed: (path: string) => void;
+  onToggleAllCollapsed: (shouldCollapse: boolean) => void;
   onAddComment: (
     file: string,
     line: LineNumber,
@@ -67,6 +68,7 @@ export function DiffViewer({
   onToggleReviewed,
   collapsedFiles,
   onToggleCollapsed,
+  onToggleAllCollapsed,
   onAddComment,
   onGeneratePrompt,
   onRemoveComment,
@@ -115,9 +117,20 @@ export function DiffViewer({
       <div className="bg-github-bg-secondary border-t-2 border-t-github-accent border-b border-github-border px-5 py-4 flex items-center justify-between flex-wrap gap-3 sticky top-0 z-10">
         <div className="flex items-center gap-2 flex-1 min-w-0">
           <button
-            onClick={() => onToggleCollapsed(file.path)}
+            onClick={(e) => {
+              if (e.altKey) {
+                // When Alt+clicking, collapse all if this file is expanded, expand all if collapsed
+                onToggleAllCollapsed(!isCollapsed);
+              } else {
+                onToggleCollapsed(file.path);
+              }
+            }}
             className="text-github-text-muted hover:text-github-text-primary transition-colors cursor-pointer"
-            title={isCollapsed ? 'Expand file' : 'Collapse file'}
+            title={
+              isCollapsed ?
+                'Expand file (Alt+Click to expand all)'
+              : 'Collapse file (Alt+Click to collapse all)'
+            }
           >
             {isCollapsed ?
               <ChevronRight size={16} />


### PR DESCRIPTION
## Summary
- Separate file collapse state from viewed state, allowing independent control
- Initialize collapsed files from viewed state on page load
- Add Alt+Click to collapse/expand all files at once
- Improve scroll behavior when marking files as viewed

## Changes
- Add independent `collapsedFiles` state management
- Viewed button still auto-collapses/expands files
- Chevron button only controls collapse state
- Alt+Click on chevron button collapses/expands all files based on clicked file's state
- Initialize collapsed state from viewed files on load (only once per diff)
- Change scroll behavior to smooth when marking as viewed

## Test plan
- [x] Click chevron button to collapse/expand individual files
- [x] Click Viewed button to mark as viewed (auto-collapses)
- [x] Click Viewed button again to unmark (auto-expands)
- [x] Alt+Click on expanded file's chevron → all files collapse
- [x] Alt+Click on collapsed file's chevron → all files expand
- [x] Reload page → viewed files are collapsed
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)