### PR TITLE
feat: apply color-scheme CSS property for native browser UI dark mode

### DIFF
--- a/src/client/styles/global.css
+++ b/src/client/styles/global.css
@@ -158,6 +158,15 @@ td.keyboard-cursor::before {
   border-radius: 2px;
 }
 
+/* Browser native UI color scheme (scrollbars, form elements, etc.) */
+[data-theme='dark'] {
+  color-scheme: dark;
+}
+
+[data-theme='light'] {
+  color-scheme: light;
+}
+
 /* Dark theme word highlight */
 [data-theme='dark'] {
   --word-highlight-color: rgba(255, 253, 84, 0.3);


### PR DESCRIPTION
Add color-scheme property to data-theme selectors to make browser native UI elements (scrollbars, form inputs, etc.) respect the app's theme setting.

before:
<img width="590" height="551" alt="image" src="https://github.com/user-attachments/assets/5e26b25b-3028-49f9-bd2e-1208cd551874" />


after:
<img width="590" height="551" alt="image" src="https://github.com/user-attachments/assets/d24faeed-06a5-49e6-9b59-6cc87521e43a" />

when light theme is selected:
<img width="590" height="551" alt="image" src="https://github.com/user-attachments/assets/90c38951-eec4-425b-8c3c-3ec95199f1c7" />
