### PR TITLE
feat: Add Perl syntax highlighting support

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -143,7 +143,7 @@ src/components/Button.tsx:L42-L48   # この行が自動的に追加されます
 - **JavaScript/TypeScript**：`.js`, `.jsx`, `.ts`, `.tsx`
 - **Web技術**：HTML, CSS, JSON, XML, Markdown
 - **シェルスクリプト**：`.sh`, `.bash`, `.zsh`, `.fish`
-- **バックエンド言語**：PHP, SQL, Ruby, Java, Scala
+- **バックエンド言語**：PHP, SQL, Ruby, Java, Scala, Perl
 - **システム言語**：C, C++, C#, Rust, Go
 - **モバイル言語**：Swift, Kotlin, Dart
 - **IaC**：Terraform (HCL)

--- a/README.ko.md
+++ b/README.ko.md
@@ -143,7 +143,7 @@ src/components/Button.tsx:L42-L48   # 이 줄은 자동으로 추가됩니다
 - **JavaScript/TypeScript**: `.js`, `.jsx`, `.ts`, `.tsx`
 - **웹 기술**: HTML, CSS, JSON, XML, Markdown
 - **셸 스크립트**: `.sh`, `.bash`, `.zsh`, `.fish`
-- **백엔드 언어**: PHP, SQL, Ruby, Java, Scala
+- **백엔드 언어**: PHP, SQL, Ruby, Java, Scala, Perl
 - **시스템 언어**: C, C++, C#, Rust, Go
 - **모바일 언어**: Swift, Kotlin, Dart
 - **인프라 코드**: Terraform (HCL)

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ This section is unnecessary
 - **JavaScript/TypeScript**: `.js`, `.jsx`, `.ts`, `.tsx`
 - **Web Technologies**: HTML, CSS, JSON, XML, Markdown
 - **Shell Scripts**: `.sh`, `.bash`, `.zsh`, `.fish`
-- **Backend Languages**: PHP, SQL, Ruby, Java, Scala
+- **Backend Languages**: PHP, SQL, Ruby, Java, Scala, Perl
 - **Systems Languages**: C, C++, C#, Rust, Go
 - **Mobile Languages**: Swift, Kotlin, Dart
 - **Infrastructure as Code**: Terraform (HCL)

--- a/README.zh.md
+++ b/README.zh.md
@@ -143,7 +143,7 @@ src/components/Button.tsx:L42-L48   # 此行自动添加
 - **JavaScript/TypeScript**：`.js`, `.jsx`, `.ts`, `.tsx`
 - **Web 技术**：HTML, CSS, JSON, XML, Markdown
 - **Shell 脚本**：`.sh`, `.bash`, `.zsh`, `.fish`
-- **后端语言**：PHP, SQL, Ruby, Java, Scala
+- **后端语言**：PHP, SQL, Ruby, Java, Scala, Perl
 - **系统语言**：C, C++, C#, Rust, Go
 - **移动语言**：Swift, Kotlin, Dart
 - **基础设施即代码**：Terraform (HCL)

--- a/src/client/components/PrismSyntaxHighlighter.tsx
+++ b/src/client/components/PrismSyntaxHighlighter.tsx
@@ -77,6 +77,8 @@ function detectLanguage(filename: string): string {
     r: 'r',
     lua: 'lua',
     perl: 'perl',
+    pl: 'perl',
+    pm: 'perl',
     dockerfile: 'docker',
     makefile: 'makefile',
     gitignore: 'git',

--- a/src/client/utils/languageLoader.ts
+++ b/src/client/utils/languageLoader.ts
@@ -30,6 +30,7 @@ export function loadPrismLanguage(lang: string): Promise<void> {
       csharp: () => import('prismjs/components/prism-csharp.js'),
       protobuf: () => import('prismjs/components/prism-protobuf.js'),
       hcl: () => import('prismjs/components/prism-hcl.js'),
+      perl: () => import('prismjs/components/prism-perl.js'),
     };
 
     const importFn = languageImports[lang];


### PR DESCRIPTION
This PR adds syntax highlighting support for Perl files.

I noticed that the `detectLanguage` function already had a mapping for the `perl` extension, so I thought I would add it.

## Changes

### Perl Support

- Add Perl language loader in `languageLoader.ts`
- Add file extension mappings for `.pl`, `.pm`
- Update README docs in all 4 languages (EN, JA, KO, ZH)

## Supported Extensions

| Extension | Language               |
| --------- | ---------------------- |
| `.pl`     | Perl                   |
| `.pm`     | Perl (module)          |
| `.perl`   | Perl (already existed) |
