### PR TITLE
feat: Add sticky directory headers in file tree

### DIFF
--- a/src/client/components/StickyDirectoryHeader.tsx
+++ b/src/client/components/StickyDirectoryHeader.tsx
@@ -1,0 +1,29 @@
+import { ChevronRight, FolderOpen } from 'lucide-react';
+
+import { type DirInfo } from '../hooks/useStickyDirectories';
+
+interface StickyDirectoryHeaderProps {
+  dirs: DirInfo[];
+  onNavigate: (path: string) => void;
+}
+
+export function StickyDirectoryHeader({ dirs, onNavigate }: StickyDirectoryHeaderProps) {
+  if (dirs.length === 0) return null;
+
+  return (
+    <div className="sticky top-0 z-20 bg-github-bg-secondary/95 backdrop-blur-sm border-b border-github-border">
+      {dirs.map((dir, idx) => (
+        <div
+          key={dir.path}
+          className="flex items-center gap-2 px-4 py-1.5 hover:bg-github-bg-tertiary cursor-pointer text-sm"
+          style={{ paddingLeft: `${idx * 16 + 16}px` }}
+          onClick={() => onNavigate(dir.path)}
+        >
+          <ChevronRight size={14} className="text-github-text-muted flex-shrink-0" />
+          <FolderOpen size={14} className="text-github-text-secondary flex-shrink-0" />
+          <span className="text-github-text-primary font-medium truncate">{dir.name}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/client/hooks/useStickyDirectories.ts
+++ b/src/client/hooks/useStickyDirectories.ts
@@ -1,0 +1,96 @@
+import { useRef, useCallback, useSyncExternalStore } from 'react';
+
+export interface DirInfo {
+  path: string;
+  depth: number;
+  name: string;
+}
+
+interface DirElement {
+  element: HTMLElement;
+  depth: number;
+  name: string;
+}
+
+interface UseStickyDirectoriesOptions {
+  containerRef: React.RefObject<HTMLElement | null>;
+  enabled?: boolean;
+}
+
+interface UseStickyDirectoriesReturn {
+  stickyDirs: DirInfo[];
+  registerDir: (path: string, element: HTMLElement | null, depth: number, name: string) => void;
+}
+
+export function useStickyDirectories({
+  containerRef,
+  enabled = true,
+}: UseStickyDirectoriesOptions): UseStickyDirectoriesReturn {
+  const stickyDirsRef = useRef<DirInfo[]>([]);
+  const dirElementsRef = useRef<Map<string, DirElement>>(new Map());
+  const onStoreChangeRef = useRef<(() => void) | null>(null);
+
+  // Register/unregister directory elements
+  const registerDir = useCallback(
+    (path: string, element: HTMLElement | null, depth: number, name: string) => {
+      if (element) {
+        dirElementsRef.current.set(path, { element, depth, name });
+      } else {
+        dirElementsRef.current.delete(path);
+      }
+    },
+    []
+  );
+
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      onStoreChangeRef.current = onStoreChange;
+      const container = containerRef.current;
+      if (!container || !enabled) return () => {};
+
+      const handleScroll = () => {
+        const containerRect = container.getBoundingClientRect();
+        const containerTop = containerRect.top;
+        const newStickyDirs: DirInfo[] = [];
+
+        dirElementsRef.current.forEach(({ element, depth, name }, path) => {
+          const rect = element.getBoundingClientRect();
+          const relativeTop = rect.top - containerTop;
+          const relativeBottom = rect.bottom - containerTop;
+
+          if (relativeTop < 0 && relativeBottom > 0) {
+            newStickyDirs.push({ path, depth, name });
+          }
+        });
+
+        newStickyDirs.sort((a, b) => a.depth - b.depth);
+
+        // Only trigger update if changed
+        const hasChanged =
+          newStickyDirs.length !== stickyDirsRef.current.length ||
+          newStickyDirs.some((d, i) => d.path !== stickyDirsRef.current[i]?.path);
+
+        if (hasChanged) {
+          stickyDirsRef.current = newStickyDirs;
+          onStoreChange();
+        }
+      };
+
+      container.addEventListener('scroll', handleScroll, { passive: true });
+      // Initial check
+      handleScroll();
+
+      return () => {
+        container.removeEventListener('scroll', handleScroll);
+        onStoreChangeRef.current = null;
+      };
+    },
+    [containerRef, enabled]
+  );
+
+  const getSnapshot = useCallback(() => stickyDirsRef.current, []);
+
+  const stickyDirs = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+
+  return { stickyDirs, registerDir };
+}


### PR DESCRIPTION
## Summary

Add sticky directory headers to the file list panel, similar to VSCode's "Sticky Scroll" feature. When scrolling through the file tree, parent directories remain visible at the top, making it easier to understand the current location in deep directory structures.

## Problem

When reviewing diffs with deeply nested file structures, it's easy to lose track of which directory you're currently viewing. Users have to scroll back up to see the parent directory context.

## Solution

- When scrolling down in the file list, directories that have scrolled out of view (but still have visible children) will be displayed as sticky headers at the top
- Clicking a sticky header scrolls back to that directory
- The feature is disabled when the filter is active (since filtered results are typically flat)

## Screenshots

https://github.com/user-attachments/assets/e679f70c-4b1f-4c27-b27e-c7f971a7f31d


## Implementation Details

- Uses `useSyncExternalStore` for efficient scroll state synchronization (React 18+ pattern)
- No external dependencies required
- Directory elements are tracked via refs to avoid `querySelectorAll` on every scroll
- Only re-renders when sticky directories actually change


---

resolved #184 