### PR TITLE
improve markdown preview for code snippet

### DIFF
--- a/src/client/components/PrismSyntaxHighlighter.tsx
+++ b/src/client/components/PrismSyntaxHighlighter.tsx
@@ -123,13 +123,16 @@ export const PrismSyntaxHighlighter = React.memo(function PrismSyntaxHighlighter
         onMouseOut={onMouseOut}
       >
         {tokens.map((line, i) => (
-          <span key={i} {...getLineProps({ line })}>
-            {line.map((token, key) =>
-              renderToken ?
-                renderToken(token, key, getTokenProps)
-              : <span key={key} {...getTokenProps({ token })} />,
-            )}
-          </span>
+          <React.Fragment key={i}>
+            <span {...getLineProps({ line })}>
+              {line.map((token, key) =>
+                renderToken ?
+                  renderToken(token, key, getTokenProps)
+                : <span key={key} {...getTokenProps({ token })} />,
+              )}
+            </span>
+            {i < tokens.length - 1 && '\n'}
+          </React.Fragment>
         ))}
       </span>
     ),


### PR DESCRIPTION
This is a improvement for Markdown Preview of 'Code Snippet'
For example 
<img width="2366" height="996" alt="image" src="https://github.com/user-attachments/assets/ec60caa7-10f1-4cb0-a1e7-dec8febf2067" />

Previous the code snippet is rendering within one line
<img width="2328" height="540" alt="image" src="https://github.com/user-attachments/assets/c460afb9-c24e-41a8-9b5c-de66fa206e16" />


This fix help render the code snippet in original format
<img width="2338" height="740" alt="image" src="https://github.com/user-attachments/assets/6bc0395d-9f29-4218-bbd9-8fc88cfc2ca2" />

