### PR TITLE
Add a "Discard changes" button to the file list sidebar

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -391,6 +391,27 @@ function App() {
     void fetchDiffData();
   }, [fetchDiffData]);
 
+  // Handle discard changes for a file
+  const handleDiscardChanges = useCallback(
+    async (filePath: string): Promise<void> => {
+      const response = await fetch(`/api/discard/${encodeURIComponent(filePath)}`, {
+        method: 'POST',
+      });
+
+      if (!response.ok) {
+        const data = (await response.json()) as { error?: string };
+        throw new Error(data.error || 'Failed to discard changes');
+      }
+
+      // Refresh diff data after successful discard
+      await fetchDiffData();
+    },
+    [fetchDiffData],
+  );
+
+  // Check if we're in stdin mode (discard not available)
+  const isStdinMode = diffData?.commit === 'stdin diff';
+
   // Fetch revision options on mount
   useEffect(() => {
     fetch('/api/revisions')
@@ -867,6 +888,8 @@ function App() {
                   reviewedFiles={viewedFiles}
                   onToggleReviewed={toggleFileReviewed}
                   selectedFileIndex={cursor?.fileIndex ?? null}
+                  onDiscardChanges={handleDiscardChanges}
+                  canDiscard={!isStdinMode}
                 />
               </div>
               <div className="p-4 border-t border-github-border flex justify-between items-center">

--- a/src/client/components/DiffViewerHeader.test.tsx
+++ b/src/client/components/DiffViewerHeader.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import type { DiffFile } from '../../types/diff';
+
+import { DiffViewerHeader } from './DiffViewerHeader';
+
+const createMockFile = (overrides: Partial<DiffFile> = {}): DiffFile => ({
+  path: 'src/test.ts',
+  status: 'modified',
+  additions: 10,
+  deletions: 5,
+  chunks: [],
+  ...overrides,
+});
+
+describe('DiffViewerHeader', () => {
+  const defaultProps = {
+    file: createMockFile(),
+    isCollapsed: false,
+    isReviewed: false,
+    onToggleCollapsed: vi.fn(),
+    onToggleAllCollapsed: vi.fn(),
+    onToggleReviewed: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders file path', () => {
+    render(<DiffViewerHeader {...defaultProps} />);
+    expect(screen.getByText('src/test.ts')).toBeInTheDocument();
+  });
+
+  it('renders additions and deletions count', () => {
+    render(<DiffViewerHeader {...defaultProps} />);
+    expect(screen.getByText('+10')).toBeInTheDocument();
+    expect(screen.getByText('-5')).toBeInTheDocument();
+  });
+
+  it('renders Viewed button', () => {
+    render(<DiffViewerHeader {...defaultProps} />);
+    expect(screen.getByText('Viewed')).toBeInTheDocument();
+  });
+
+  it('calls onToggleReviewed when Viewed button is clicked', () => {
+    render(<DiffViewerHeader {...defaultProps} />);
+    fireEvent.click(screen.getByText('Viewed'));
+    expect(defaultProps.onToggleReviewed).toHaveBeenCalledWith('src/test.ts');
+  });
+
+  it('calls onToggleCollapsed when collapse button is clicked', () => {
+    render(<DiffViewerHeader {...defaultProps} />);
+    const collapseButton = screen.getByTitle('Collapse file (Alt+Click to collapse all)');
+    fireEvent.click(collapseButton);
+    expect(defaultProps.onToggleCollapsed).toHaveBeenCalledWith('src/test.ts');
+  });
+});

--- a/src/client/components/FileList.test.tsx
+++ b/src/client/components/FileList.test.tsx
@@ -1,0 +1,136 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import type { DiffFile } from '../../types/diff';
+
+import { FileList } from './FileList';
+
+const createMockFile = (overrides: Partial<DiffFile> = {}): DiffFile => ({
+  path: 'src/test.ts',
+  status: 'modified',
+  additions: 10,
+  deletions: 5,
+  chunks: [],
+  ...overrides,
+});
+
+describe('FileList', () => {
+  const defaultProps = {
+    files: [createMockFile()],
+    onScrollToFile: vi.fn(),
+    comments: [],
+    reviewedFiles: new Set<string>(),
+    onToggleReviewed: vi.fn(),
+    selectedFileIndex: null,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('Discard button', () => {
+    it('shows Discard button on hover when canDiscard is true and onDiscardChanges is provided', () => {
+      const onDiscardChanges = vi.fn();
+      render(<FileList {...defaultProps} onDiscardChanges={onDiscardChanges} canDiscard={true} />);
+
+      // Button exists but may be hidden until hover
+      const discardButton = screen.getByTitle('Discard changes');
+      expect(discardButton).toBeInTheDocument();
+    });
+
+    it('hides Discard button when canDiscard is false', () => {
+      const onDiscardChanges = vi.fn();
+      render(<FileList {...defaultProps} onDiscardChanges={onDiscardChanges} canDiscard={false} />);
+
+      expect(screen.queryByTitle('Discard changes')).not.toBeInTheDocument();
+    });
+
+    it('hides Discard button when onDiscardChanges is not provided', () => {
+      render(<FileList {...defaultProps} canDiscard={true} />);
+
+      expect(screen.queryByTitle('Discard changes')).not.toBeInTheDocument();
+    });
+
+    it('shows confirmation dialog when Discard button is clicked', async () => {
+      const onDiscardChanges = vi.fn().mockResolvedValue(undefined);
+      const confirmMock = vi.fn().mockReturnValue(false);
+      vi.stubGlobal('confirm', confirmMock);
+
+      render(<FileList {...defaultProps} onDiscardChanges={onDiscardChanges} canDiscard={true} />);
+
+      fireEvent.click(screen.getByTitle('Discard changes'));
+
+      expect(confirmMock).toHaveBeenCalledWith(
+        expect.stringContaining('Are you sure you want to discard all changes'),
+      );
+      expect(onDiscardChanges).not.toHaveBeenCalled();
+    });
+
+    it('calls onDiscardChanges when user confirms discard', async () => {
+      const onDiscardChanges = vi.fn().mockResolvedValue(undefined);
+      const confirmMock = vi.fn().mockReturnValue(true);
+      vi.stubGlobal('confirm', confirmMock);
+
+      render(<FileList {...defaultProps} onDiscardChanges={onDiscardChanges} canDiscard={true} />);
+
+      fireEvent.click(screen.getByTitle('Discard changes'));
+
+      await waitFor(() => {
+        expect(onDiscardChanges).toHaveBeenCalledWith('src/test.ts');
+      });
+    });
+
+    it('does not call onDiscardChanges when user cancels discard', () => {
+      const onDiscardChanges = vi.fn();
+      const confirmMock = vi.fn().mockReturnValue(false);
+      vi.stubGlobal('confirm', confirmMock);
+
+      render(<FileList {...defaultProps} onDiscardChanges={onDiscardChanges} canDiscard={true} />);
+
+      fireEvent.click(screen.getByTitle('Discard changes'));
+
+      expect(onDiscardChanges).not.toHaveBeenCalled();
+    });
+
+    it('shows error alert when discard fails', async () => {
+      const onDiscardChanges = vi.fn().mockRejectedValue(new Error('Test error'));
+      const confirmMock = vi.fn().mockReturnValue(true);
+      const alertMock = vi.fn();
+      vi.stubGlobal('confirm', confirmMock);
+      vi.stubGlobal('alert', alertMock);
+
+      render(<FileList {...defaultProps} onDiscardChanges={onDiscardChanges} canDiscard={true} />);
+
+      fireEvent.click(screen.getByTitle('Discard changes'));
+
+      await waitFor(() => {
+        expect(alertMock).toHaveBeenCalledWith(expect.stringContaining('Test error'));
+      });
+    });
+
+    it('does not trigger file selection when clicking discard button', async () => {
+      const onDiscardChanges = vi.fn().mockResolvedValue(undefined);
+      const onScrollToFile = vi.fn();
+      const confirmMock = vi.fn().mockReturnValue(true);
+      vi.stubGlobal('confirm', confirmMock);
+
+      render(
+        <FileList
+          {...defaultProps}
+          onScrollToFile={onScrollToFile}
+          onDiscardChanges={onDiscardChanges}
+          canDiscard={true}
+        />,
+      );
+
+      fireEvent.click(screen.getByTitle('Discard changes'));
+
+      // onScrollToFile should not be called when clicking discard button
+      expect(onScrollToFile).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/server/git-diff.ts
+++ b/src/server/git-diff.ts
@@ -1,14 +1,14 @@
 import {
   simpleGit,
-  type SimpleGit,
   type DiffResult,
-  type DiffResultTextFile,
   type DiffResultBinaryFile,
   type DiffResultNameStatusFile,
+  type DiffResultTextFile,
+  type SimpleGit,
 } from 'simple-git';
 
-import { validateDiffArguments, shortHash, createCommitRangeString } from '../cli/utils.js';
-import { type DiffFile, type DiffChunk, type DiffLine, type DiffResponse } from '../types/diff.js';
+import { createCommitRangeString, shortHash, validateDiffArguments } from '../cli/utils.js';
+import { type DiffChunk, type DiffFile, type DiffLine, type DiffResponse } from '../types/diff.js';
 
 import { isGeneratedFile } from './generated-file-check.js';
 
@@ -626,5 +626,12 @@ export class GitDiffParser {
     }
 
     return { branches, commits, resolvedBase, resolvedTarget };
+  }
+
+  /**
+   * @param filepath - The path to the file to discard changes for
+   */
+  async discardChanges(filepath: string): Promise<void> {
+    await this.git.checkout(['--', filepath]);
   }
 }


### PR DESCRIPTION
## Summary

Add a "Discard changes" button to the file list sidebar, allowing users to revert file changes directly from the difit UI without switching to the terminal.

- Add discard button (undo icon) to each file row in the sidebar, visible on hover
- Implement `POST /api/discard/:filepath` endpoint with path traversal protection
- Show confirmation dialog before discarding to prevent accidental data loss
- Auto-refresh diff view after successful discard
- Hide discard button in stdin mode (not applicable)

## Motivation

When reviewing code changes, users often want to quickly revert unwanted modifications. Currently, this requires switching to a terminal and running git commands manually. This feature brings the familiar "Discard Changes" functionality (similar to VS Code or GitHub Desktop) directly into difit.

## Changes

### Backend
- `src/server/server.ts`: Add `POST /api/discard/*` endpoint
- `src/server/git-diff.ts`: Add `discardChanges()` method using `git checkout`

### Frontend
- `src/client/components/FileList.tsx`: Add discard button with hover visibility
- `src/client/App.tsx`: Add `handleDiscardChanges` handler and stdin mode detection

### Tests
- `src/client/components/FileList.test.tsx`: New test file for discard functionality
- `src/server/server.test.ts`: Add discard API test cases

## Verify
### build
```
npm run build
```

### change files
```
echo "test change" >> README.md
```

### show uncommitted changes
```
node dist/cli/index.js .
```
<img width="796" height="343" alt="image" src="https://github.com/user-attachments/assets/80589fe7-47dc-4f7a-b142-a8ffd49d98e8" />

### undo
<img width="439" height="210" alt="image" src="https://github.com/user-attachments/assets/a698dd50-a4ed-48c4-b32b-c853e33b014a" />

### the diff disappears 
<img width="1714" height="263" alt="image" src="https://github.com/user-attachments/assets/9fd44de0-126e-4384-89eb-7446eec4b199" />


### there are no changes
```
❯ cat README.md | tail -1                                          [10:19:18]
MIT
```
