### PR TITLE
fix: preserve leading whitespace in word-level diff

### DIFF
--- a/src/client/utils/wordLevelDiff.ts
+++ b/src/client/utils/wordLevelDiff.ts
@@ -1,4 +1,4 @@
-import { diffWords } from 'diff';
+import { diffWords, diffWordsWithSpace } from 'diff';
 
 export interface DiffSegment {
   value: string;
@@ -15,7 +15,7 @@ export interface WordLevelDiffResult {
  * Returns segments for both old and new lines, each marked as unchanged, added, or removed.
  */
 export function computeWordLevelDiff(oldContent: string, newContent: string): WordLevelDiffResult {
-  const changes = diffWords(oldContent, newContent);
+  const changes = diffWordsWithSpace(oldContent, newContent);
 
   const oldSegments: DiffSegment[] = [];
   const newSegments: DiffSegment[] = [];


### PR DESCRIPTION
## Summary

- Fix a bug where leading indentation on the old side was lost in Split/Unified diff view when a word was inserted at the beginning of a line
- Root cause: diffWords merges whitespace into adjacent word tokens, so a pure insertion at line start absorbs the leading  spaces into the added segment
- Fix: switch from diffWords to diffWordsWithSpace in computeWordLevelDiff so whitespace is treated as independent tokens

## Reproduce

Run `pnpm dev fb453e4` in the difit repository and see src/client/App.tsx.

before

<img width="1167" height="485" alt="image" src="https://github.com/user-attachments/assets/c8333cb0-3aeb-488a-97b1-c80ed9ab164d" />

after

<img width="1167" height="485" alt="image" src="https://github.com/user-attachments/assets/2a177f91-7259-45c5-a267-f88bcc80ef71" />
