### PR TITLE
feat(cli): add --keep-alive flag to prevent auto-shutdown on disconnect

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -57,6 +57,7 @@ interface CliOptions {
   pr?: string;
   clean?: boolean;
   includeUntracked?: boolean;
+  keepAlive?: boolean;
 }
 
 const program = new Command();
@@ -87,6 +88,7 @@ program
   .option('--pr <url>', 'GitHub PR URL to review (e.g., https://github.com/owner/repo/pull/123)')
   .option('--clean', 'start with a clean slate by clearing all existing comments')
   .option('--include-untracked', 'automatically include untracked files in diff')
+  .option('--keep-alive', 'keep server running even after browser disconnects')
   .action(async (commitish: string, compareWith: string | undefined, options: CliOptions) => {
     try {
       // Check if we should read from stdin
@@ -113,10 +115,14 @@ program
           openBrowser: options.open,
           mode: options.mode,
           clearComments: options.clean,
+          keepAlive: options.keepAlive,
         });
 
         console.log(`\n🚀 difit server started on ${url}`);
         console.log(`📋 Reviewing: diff from stdin`);
+        if (options.keepAlive) {
+          console.log('🔒 Keep-alive mode: server will stay running after browser disconnects');
+        }
         console.log('\nPress Ctrl+C to stop the server');
         return;
       }
@@ -217,12 +223,17 @@ program
         openBrowser: options.open,
         mode: options.mode,
         clearComments: options.clean,
+        keepAlive: options.keepAlive,
         diffMode,
         repoPath,
       });
 
       console.log(`\n🚀 difit server started on ${url}`);
       console.log(`📋 Reviewing: ${targetCommitish}`);
+
+      if (options.keepAlive) {
+        console.log('🔒 Keep-alive mode: server will stay running after browser disconnects');
+      }
 
       if (options.clean) {
         console.log('🧹 Starting with a clean slate - all existing comments will be cleared');


### PR DESCRIPTION
## Summary

- Adds a `--keep-alive` CLI flag that prevents the server from auto-shutting down when the browser disconnects
- When accessing difit from a remote host (e.g. a phone on the same network, or a different machine), closing the browser or the device going to sleep disconnects the SSE heartbeat, which triggers `process.exit(0)`. With `--keep-alive`, the server stays running until manually stopped with Ctrl+C.
- On each client disconnect, reminds the user to press Ctrl+C to stop the server

## Changes

- `src/cli/index.ts`: Add `--keep-alive` option, pass it through to `startServer()`, log when active
- `src/server/server.ts`: Add `keepAlive` to `ServerOptions`, skip `process.exit` in heartbeat close handler when enabled
- `src/cli/index.test.ts`: CLI option parsing and console output tests
- `src/server/server.test.ts`: Functional tests verifying `process.exit` is/isn't called on disconnect

## Test plan

- [x] `pnpm run build` passes
- [x] `pnpm test` passes (499 tests, 0 failures)
- [x] Manual: `difit` without flag — server exits when browser tab is closed (existing behavior)
- [x] Manual: `difit --keep-alive` — server stays running after browser disconnects, prints Ctrl+C reminder