### PR TITLE
fix(cli): remove --patch flag from gh pr diff to fix files changed count

### DIFF
--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -47,7 +47,10 @@ export function shouldReadStdin(options: ShouldReadStdinOptions): boolean {
 
 export function getGitRoot(): string {
   try {
-    const result = execSync('git rev-parse --show-toplevel', { encoding: 'utf8', stdio: 'pipe' });
+    const result = execSync('git rev-parse --show-toplevel', {
+      encoding: 'utf8',
+      stdio: 'pipe',
+    });
     return result.trim();
   } catch {
     throw new Error('Not a git repository (or any of the parent directories)');
@@ -158,13 +161,13 @@ export function parseGitHubPrUrl(url: string): PullRequestInfo | null {
 
 export function getPrPatch(prArg: string): string {
   try {
-    const patch = execFileSync('gh', ['pr', 'diff', prArg, '--patch'], {
+    const patch = execFileSync('gh', ['pr', 'diff', prArg], {
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'],
     });
 
     if (!patch.trim()) {
-      throw new Error('No patch content returned from gh pr diff --patch');
+      throw new Error('No diff content returned from gh pr diff');
     }
 
     return patch;
@@ -212,7 +215,10 @@ export function validateDiffArguments(
 
   // Cannot compare same values
   if (targetCommitish === baseCommitish) {
-    return { valid: false, error: `Cannot compare ${targetCommitish} with itself` };
+    return {
+      valid: false,
+      error: `Cannot compare ${targetCommitish} with itself`,
+    };
   }
 
   // "working" shows unstaged changes and can only be compared with staging area


### PR DESCRIPTION
## 概要

`--pr` オプションでPRを表示した際に「Files changed」の数がGitHubの表示と異なるバグを修正しました。

## 原因

`gh pr diff --patch` はコミットごとに個別のパッチを返すため、複数コミットで同一ファイルを変更している場合、`diff --git` ブロックが重複して生成されます。difitのパーサーは `diff --git` で分割してファイル数をカウントするため、実際より多いファイル数が表示されていました（例: 4ファイルが12ファイルと表示）。

## 変更点

- `gh pr diff --patch` から `gh pr diff` に変更し、PRのbase→headの統合diffを取得するように修正
- エラーメッセージの更新

## テスト

- 全499テストパス
- build / lint / knip 全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)