### PR TITLE
feat(client): 仮想行レンダリングを導入して差分描画を高速化

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   "dependencies": {
     "@floating-ui/react": "^0.27.16",
     "@parcel/watcher": "^2.5.1",
+    "@tanstack/react-virtual": "^3.13.19",
     "commander": "^14.0.0",
     "diff": "^8.0.2",
     "express": "^5.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@parcel/watcher':
         specifier: ^2.5.1
         version: 2.5.6
+      '@tanstack/react-virtual':
+        specifier: ^3.13.19
+        version: 3.13.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       commander:
         specifier: ^14.0.0
         version: 14.0.3
@@ -1333,6 +1336,15 @@ packages:
 
   '@tailwindcss/postcss@4.1.18':
     resolution: {integrity: sha512-Ce0GFnzAOuPyfV5SxjXGn0CubwGcuDB0zcdaPuCSzAa/2vII24JTkH+I6jcbXLb1ctjZMZZI6OjDaLPJQL1S0g==}
+
+  '@tanstack/react-virtual@3.13.19':
+    resolution: {integrity: sha512-KzwmU1IbE0IvCZSm6OXkS+kRdrgW2c2P3Ho3NC+zZXWK6oObv/L+lcV/2VuJ+snVESRlMJ+w/fg4WXI/JzoNGQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/virtual-core@3.13.19':
+    resolution: {integrity: sha512-/BMP7kNhzKOd7wnDeB8NrIRNLwkf5AhCYCvtfZV2GXWbBieFm/el0n6LOAXlTi6ZwHICSNnQcIxRCWHrLzDY+g==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -4786,6 +4798,14 @@ snapshots:
       '@tailwindcss/oxide': 4.1.18
       postcss: 8.5.6
       tailwindcss: 4.1.18
+
+  '@tanstack/react-virtual@3.13.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@tanstack/virtual-core': 3.13.19
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
+  '@tanstack/virtual-core@3.13.19': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:

--- a/src/client/components/DiffChunk.tsx
+++ b/src/client/components/DiffChunk.tsx
@@ -1,3 +1,4 @@
+import { useVirtualizer } from '@tanstack/react-virtual';
 import React, { useState, useEffect, useCallback, useMemo, memo } from 'react';
 
 import {
@@ -7,9 +8,12 @@ import {
   type Comment,
   type LineNumber,
   type DiffViewMode,
+  type VirtualDiffRow,
 } from '../../types/diff';
 import { DEFAULT_DIFF_VIEW_MODE } from '../../utils/diffMode';
+import { NAVIGATION_SELECTORS } from '../constants/navigation';
 import { type CursorPosition } from '../hooks/keyboardNavigation';
+import { registerVirtualRowScrollHandlers } from '../utils/virtualScrollRegistry';
 import {
   computeWordLevelDiff,
   shouldComputeWordDiff,
@@ -51,6 +55,46 @@ interface DiffChunkProps {
   onOpenInEditor?: (filePath: string, lineNumber: number) => void;
 }
 
+type UnifiedVirtualLineRow = {
+  type: 'line';
+  virtual: VirtualDiffRow;
+  line: DiffLine;
+  lineIndex: number;
+  lineId: string;
+  lineComments: Comment[];
+  commentLayout: 'left' | 'right' | 'full';
+  currentLineNumber: number;
+  currentLineSide: DiffSide;
+  isCurrentLine: boolean;
+};
+
+type UnifiedVirtualCommentRow = {
+  type: 'comment';
+  virtual: VirtualDiffRow;
+  line: DiffLine;
+  comment: Comment;
+  layout: 'left' | 'right' | 'full';
+};
+
+type UnifiedVirtualCommentFormRow = {
+  type: 'commentForm';
+  virtual: VirtualDiffRow;
+  line: DiffLine;
+  layout: 'left' | 'right' | 'full';
+};
+
+type UnifiedRenderableRow =
+  | UnifiedVirtualLineRow
+  | UnifiedVirtualCommentRow
+  | UnifiedVirtualCommentFormRow;
+
+const UNIFIED_VIRTUALIZATION_ROW_THRESHOLD = 180;
+const ESTIMATED_ROW_HEIGHTS = {
+  line: 24,
+  comment: 120,
+  commentForm: 230,
+} as const;
+
 export const DiffChunk = memo(function DiffChunk({
   chunk,
   chunkIndex,
@@ -86,7 +130,6 @@ export const DiffChunk = memo(function DiffChunk({
         const lineNumber = line.newLineNumber || line.oldLineNumber;
         const side: DiffSide = line.type === 'delete' ? 'old' : 'new';
         if (lineNumber) {
-          // oxlint-disable-next-line react-hooks-js/set-state-in-effect -- intentional: respond to external keyboard trigger
           setCommentingLine({ side, lineNumber });
           onCommentTriggerHandled?.();
         }
@@ -166,73 +209,84 @@ export const DiffChunk = memo(function DiffChunk({
     [commentingLine, onAddComment, getSelectedCodeContent],
   );
 
-  const getCommentsForLine = (lineNumber: number, side: DiffSide) => {
-    return comments.filter((c) => {
-      // Check if line number matches (single line or end of range)
-      const lineMatches = Array.isArray(c.line) ? c.line[1] === lineNumber : c.line === lineNumber;
+  const getCommentsForLine = useCallback(
+    (lineNumber: number, side: DiffSide) => {
+      return comments.filter((c) => {
+        // Check if line number matches (single line or end of range)
+        const lineMatches = Array.isArray(c.line)
+          ? c.line[1] === lineNumber
+          : c.line === lineNumber;
 
-      // Filter by side - if comment has no side (legacy), show on new side only
-      const sideMatches = !c.side || c.side === side;
+        // Filter by side - if comment has no side (legacy), show on new side only
+        const sideMatches = !c.side || c.side === side;
 
-      return lineMatches && sideMatches;
-    });
-  };
+        return lineMatches && sideMatches;
+      });
+    },
+    [comments],
+  );
 
-  const getCommentLayout = (line: DiffLine): 'left' | 'right' | 'full' => {
-    // In unified mode, always use full width for comments
-    if (mode === 'unified') {
-      return 'full';
-    }
-
-    switch (line.type) {
-      case 'delete':
-        return 'left';
-      case 'add':
-        return 'right';
-      default:
+  const getCommentLayout = useCallback(
+    (line: DiffLine): 'left' | 'right' | 'full' => {
+      // In unified mode, always use full width for comments
+      if (mode === 'unified') {
         return 'full';
-    }
-  };
+      }
 
-  const getSelectedLineStyle = (lineNumber: number | undefined, side: DiffSide): string => {
-    if (!lineNumber) {
+      switch (line.type) {
+        case 'delete':
+          return 'left';
+        case 'add':
+          return 'right';
+        default:
+          return 'full';
+      }
+    },
+    [mode],
+  );
+
+  const getSelectedLineStyle = useCallback(
+    (lineNumber: number | undefined, side: DiffSide): string => {
+      if (!lineNumber) {
+        return '';
+      }
+
+      // Show selection during drag
+      if (isDragging && startLine && endLine) {
+        const min = Math.min(startLine, endLine);
+        const max = Math.max(startLine, endLine);
+        if (lineNumber >= min && lineNumber <= max) {
+          let classes =
+            'after:bg-blue-100 after:absolute after:inset-0 after:opacity-30 after:border-l-4 after:border-blue-500 after:pointer-events-none';
+          // Add top border for first line
+          if (lineNumber === min) {
+            classes += ' after:border-t-2';
+          }
+          // Add bottom border for last line
+          if (lineNumber === max) {
+            classes += ' after:border-b-2';
+          }
+          return classes;
+        }
+      }
+
+      // Show selection for existing comment
+      if (commentingLine && commentingLine.side === side) {
+        const start = Array.isArray(commentingLine.lineNumber)
+          ? commentingLine.lineNumber[0]
+          : commentingLine.lineNumber;
+        const end = Array.isArray(commentingLine.lineNumber)
+          ? commentingLine.lineNumber[1]
+          : commentingLine.lineNumber;
+        if (lineNumber >= start && lineNumber <= end) {
+          return 'after:bg-diff-selected-bg after:absolute after:inset-0 after:border-l-5 after:border-l-diff-selected-border after:pointer-events-none';
+        }
+      }
+
       return '';
-    }
-
-    // Show selection during drag
-    if (isDragging && startLine && endLine) {
-      const min = Math.min(startLine, endLine);
-      const max = Math.max(startLine, endLine);
-      if (lineNumber >= min && lineNumber <= max) {
-        let classes =
-          'after:bg-blue-100 after:absolute after:inset-0 after:opacity-30 after:border-l-4 after:border-blue-500 after:pointer-events-none';
-        // Add top border for first line
-        if (lineNumber === min) {
-          classes += ' after:border-t-2';
-        }
-        // Add bottom border for last line
-        if (lineNumber === max) {
-          classes += ' after:border-b-2';
-        }
-        return classes;
-      }
-    }
-
-    // Show selection for existing comment
-    if (commentingLine && commentingLine.side === side) {
-      const start = Array.isArray(commentingLine.lineNumber)
-        ? commentingLine.lineNumber[0]
-        : commentingLine.lineNumber;
-      const end = Array.isArray(commentingLine.lineNumber)
-        ? commentingLine.lineNumber[1]
-        : commentingLine.lineNumber;
-      if (lineNumber >= start && lineNumber <= end) {
-        return 'after:bg-diff-selected-bg after:absolute after:inset-0 after:border-l-5 after:border-l-diff-selected-border after:pointer-events-none';
-      }
-    }
-
-    return '';
-  };
+    },
+    [commentingLine, endLine, isDragging, startLine],
+  );
 
   // Compute word-level diff for unified mode
   // Maps line index to diff segments for that line
@@ -294,6 +348,302 @@ export const DiffChunk = memo(function DiffChunk({
     return map;
   }, [chunk.lines]);
 
+  const unifiedRows = useMemo<UnifiedRenderableRow[]>(() => {
+    if (mode !== 'unified') {
+      return [];
+    }
+
+    const rows: UnifiedRenderableRow[] = [];
+    const formTargetLineNumber = commentingLine
+      ? Array.isArray(commentingLine.lineNumber)
+        ? commentingLine.lineNumber[1]
+        : commentingLine.lineNumber
+      : null;
+
+    chunk.lines.forEach((line, index) => {
+      const currentLineNumber = line.newLineNumber || line.oldLineNumber || 0;
+      const currentLineSide: DiffSide = line.type === 'delete' ? 'old' : 'new';
+      const commentLineNumber = line.type === 'delete' ? line.oldLineNumber : line.newLineNumber;
+      const commentSide: DiffSide = line.type === 'delete' ? 'old' : 'new';
+      const lineComments = commentLineNumber
+        ? getCommentsForLine(commentLineNumber, commentSide)
+        : [];
+      const lineId = `file-${fileIndex}-chunk-${chunkIndex}-line-${index}`;
+      const isCurrentLine = Boolean(
+        cursor && cursor.chunkIndex === chunkIndex && cursor.lineIndex === index,
+      );
+      const commentLayout = getCommentLayout(line);
+
+      rows.push({
+        type: 'line',
+        virtual: {
+          id: lineId,
+          kind: 'line',
+          filePath: filename || '',
+          chunkIndex,
+          lineIndex: index,
+          estimatedHeight: ESTIMATED_ROW_HEIGHTS.line,
+        },
+        line,
+        lineIndex: index,
+        lineId,
+        lineComments,
+        commentLayout,
+        currentLineNumber,
+        currentLineSide,
+        isCurrentLine,
+      });
+
+      lineComments.forEach((comment, commentIndex) => {
+        rows.push({
+          type: 'comment',
+          virtual: {
+            id: `${lineId}-comment-${comment.id}-${commentIndex}`,
+            kind: 'inlineComment',
+            filePath: filename || '',
+            chunkIndex,
+            lineIndex: index,
+            estimatedHeight: ESTIMATED_ROW_HEIGHTS.comment,
+          },
+          line,
+          comment,
+          layout: commentLayout,
+        });
+      });
+
+      if (
+        commentingLine &&
+        commentingLine.side === currentLineSide &&
+        formTargetLineNumber === currentLineNumber
+      ) {
+        rows.push({
+          type: 'commentForm',
+          virtual: {
+            id: `${lineId}-comment-form`,
+            kind: 'commentForm',
+            filePath: filename || '',
+            chunkIndex,
+            lineIndex: index,
+            estimatedHeight: ESTIMATED_ROW_HEIGHTS.commentForm,
+          },
+          line,
+          layout: commentLayout,
+        });
+      }
+    });
+
+    return rows;
+  }, [
+    chunk.lines,
+    mode,
+    commentingLine,
+    cursor,
+    chunkIndex,
+    fileIndex,
+    filename,
+    getCommentsForLine,
+    getCommentLayout,
+  ]);
+
+  const shouldVirtualizeUnified =
+    mode === 'unified' && unifiedRows.length >= UNIFIED_VIRTUALIZATION_ROW_THRESHOLD;
+
+  const unifiedRowVirtualizer = useVirtualizer({
+    count: unifiedRows.length,
+    enabled: shouldVirtualizeUnified,
+    getScrollElement: () =>
+      document.querySelector(NAVIGATION_SELECTORS.SCROLL_CONTAINER) as HTMLElement | null,
+    estimateSize: (index) =>
+      unifiedRows[index]?.virtual.estimatedHeight ?? ESTIMATED_ROW_HEIGHTS.line,
+    getItemKey: (index) => unifiedRows[index]?.virtual.id ?? index,
+    overscan: 24,
+  });
+
+  const lineRowIndexById = useMemo(() => {
+    const map = new Map<string, number>();
+    unifiedRows.forEach((row, rowIndex) => {
+      if (row.type === 'line') {
+        map.set(row.lineId, rowIndex);
+      }
+    });
+    return map;
+  }, [unifiedRows]);
+
+  useEffect(() => {
+    const handlers = new Map<string, () => void>();
+    lineRowIndexById.forEach((rowIndex, lineId) => {
+      handlers.set(lineId, () => {
+        unifiedRowVirtualizer.scrollToIndex(rowIndex, {
+          align: 'center',
+        });
+      });
+    });
+
+    return registerVirtualRowScrollHandlers(handlers);
+  }, [lineRowIndexById, unifiedRowVirtualizer]);
+
+  const renderUnifiedRow = useCallback(
+    (row: UnifiedRenderableRow, measureRef?: (node: HTMLTableRowElement | null) => void) => {
+      if (row.type === 'line') {
+        return (
+          <DiffLineRow
+            line={row.line}
+            index={row.lineIndex}
+            lineId={row.lineId}
+            isCurrentLine={row.isCurrentLine}
+            hoveredLineIndex={hoveredLine}
+            selectedLineStyle={getSelectedLineStyle(
+              row.line.newLineNumber || row.line.oldLineNumber,
+              row.line.type === 'delete' ? 'old' : 'new',
+            )}
+            onMouseEnter={() => {
+              setHoveredLine(row.lineIndex);
+            }}
+            onMouseLeave={() => setHoveredLine(null)}
+            onMouseMove={() => {
+              if (isDragging && startLine) {
+                const lineNumber = row.line.newLineNumber || row.line.oldLineNumber;
+                if (lineNumber) {
+                  setEndLine(lineNumber);
+                }
+              }
+            }}
+            onCommentButtonMouseDown={(e) => {
+              e.stopPropagation();
+              const lineNumber = row.line.newLineNumber || row.line.oldLineNumber;
+              if (lineNumber) {
+                setStartLine(lineNumber);
+                setEndLine(lineNumber);
+                setIsDragging(true);
+              }
+            }}
+            onCommentButtonMouseUp={(e) => {
+              e.stopPropagation();
+              const lineNumber = row.line.newLineNumber || row.line.oldLineNumber;
+              const side: DiffSide = row.line.type === 'delete' ? 'old' : 'new';
+              if (!lineNumber || !startLine) {
+                setIsDragging(false);
+                setStartLine(null);
+                setEndLine(null);
+                return;
+              }
+
+              const actualEndLine = endLine || lineNumber;
+              if (startLine === actualEndLine) {
+                handleAddComment(side, lineNumber);
+              } else {
+                const min = Math.min(startLine, actualEndLine);
+                const max = Math.max(startLine, actualEndLine);
+                handleAddComment(side, [min, max]);
+              }
+
+              setIsDragging(false);
+              setStartLine(null);
+              setEndLine(null);
+            }}
+            onOpenInEditor={
+              onOpenInEditor &&
+              filename &&
+              row.line.type !== 'delete' &&
+              (row.line.newLineNumber || row.line.oldLineNumber)
+                ? () => {
+                    const lineNumber = row.line.newLineNumber || row.line.oldLineNumber;
+                    if (!lineNumber) return;
+                    if (!filename) return;
+                    onOpenInEditor(filename, lineNumber);
+                  }
+                : undefined
+            }
+            syntaxTheme={syntaxTheme}
+            filename={filename}
+            diffSegments={wordLevelDiffMap.get(row.lineIndex)}
+            onClick={() => {
+              // Determine the side based on line type for unified mode
+              const side = row.line.type === 'delete' ? 'left' : 'right';
+              onLineClick?.(fileIndex, chunkIndex, row.lineIndex, side);
+            }}
+            measureRef={measureRef}
+          />
+        );
+      }
+
+      if (row.type === 'comment') {
+        return (
+          <tr ref={measureRef} className="bg-github-bg-secondary">
+            <td colSpan={3} className="p-0 border-t border-github-border">
+              <div
+                className={`flex ${
+                  row.layout === 'left'
+                    ? 'justify-start'
+                    : row.layout === 'right'
+                      ? 'justify-end'
+                      : 'justify-center'
+                }`}
+              >
+                <div className={`${row.layout === 'full' ? 'w-full' : 'w-1/2'} m-2 mx-4`}>
+                  <InlineComment
+                    comment={row.comment}
+                    onGeneratePrompt={onGeneratePrompt}
+                    onRemoveComment={onRemoveComment}
+                    onUpdateComment={onUpdateComment}
+                    syntaxTheme={syntaxTheme}
+                  />
+                </div>
+              </div>
+            </td>
+          </tr>
+        );
+      }
+
+      return (
+        <tr ref={measureRef} className="bg-[var(--bg-secondary)]">
+          <td colSpan={3} className="p-0">
+            <div
+              className={`flex ${
+                row.layout === 'left'
+                  ? 'justify-start'
+                  : row.layout === 'right'
+                    ? 'justify-end'
+                    : 'justify-center'
+              }`}
+            >
+              <div className={`${row.layout === 'full' ? 'w-full' : 'w-1/2'}`}>
+                <CommentForm
+                  onSubmit={handleSubmitComment}
+                  onCancel={handleCancelComment}
+                  selectedCode={getSelectedCodeContent()}
+                  syntaxTheme={syntaxTheme}
+                  filename={filename}
+                />
+              </div>
+            </div>
+          </td>
+        </tr>
+      );
+    },
+    [
+      chunkIndex,
+      endLine,
+      fileIndex,
+      filename,
+      getSelectedCodeContent,
+      getSelectedLineStyle,
+      handleAddComment,
+      handleCancelComment,
+      handleSubmitComment,
+      hoveredLine,
+      isDragging,
+      onGeneratePrompt,
+      onLineClick,
+      onOpenInEditor,
+      onRemoveComment,
+      onUpdateComment,
+      startLine,
+      syntaxTheme,
+      wordLevelDiffMap,
+    ],
+  );
+
   // Use side-by-side component for split mode
   if (mode === 'split') {
     return (
@@ -317,174 +667,46 @@ export const DiffChunk = memo(function DiffChunk({
     );
   }
 
+  const virtualItems = shouldVirtualizeUnified ? unifiedRowVirtualizer.getVirtualItems() : [];
+  const paddingTop =
+    shouldVirtualizeUnified && virtualItems.length > 0 ? (virtualItems[0]?.start ?? 0) : 0;
+  const paddingBottom =
+    shouldVirtualizeUnified && virtualItems.length > 0
+      ? unifiedRowVirtualizer.getTotalSize() - (virtualItems[virtualItems.length - 1]?.end ?? 0)
+      : 0;
+
   return (
     <div className="bg-github-bg-primary">
       <table className="w-full table-fixed border-collapse font-mono text-sm leading-5">
         <tbody>
-          {chunk.lines.map((line, index) => {
-            const currentLineNumber = line.newLineNumber || line.oldLineNumber || 0;
-            const currentLineSide: DiffSide = line.type === 'delete' ? 'old' : 'new';
-            const formTargetLineNumber = commentingLine
-              ? Array.isArray(commentingLine.lineNumber)
-                ? commentingLine.lineNumber[1]
-                : commentingLine.lineNumber
-              : null;
+          {shouldVirtualizeUnified && paddingTop > 0 && (
+            <tr aria-hidden="true">
+              <td colSpan={3} className="p-0 border-0" style={{ height: `${paddingTop}px` }} />
+            </tr>
+          )}
 
-            // Determine which line number and side to use for fetching comments
-            // Delete lines: use oldLineNumber and 'old' side
-            // Add/normal lines: use newLineNumber and 'new' side
-            const commentLineNumber =
-              line.type === 'delete' ? line.oldLineNumber : line.newLineNumber;
-            const commentSide: DiffSide = line.type === 'delete' ? 'old' : 'new';
-            const lineComments = commentLineNumber
-              ? getCommentsForLine(commentLineNumber, commentSide)
-              : [];
-            // Generate ID for all lines to match the format used in useKeyboardNavigation
-            const lineId = `file-${fileIndex}-chunk-${chunkIndex}-line-${index}`;
-            const isCurrentLine =
-              cursor && cursor.chunkIndex === chunkIndex && cursor.lineIndex === index;
+          {shouldVirtualizeUnified
+            ? virtualItems.map((virtualItem) => {
+                const row = unifiedRows[virtualItem.index];
+                if (!row) {
+                  return null;
+                }
 
-            return (
-              <React.Fragment key={index}>
-                <DiffLineRow
-                  line={line}
-                  index={index}
-                  lineId={lineId}
-                  isCurrentLine={isCurrentLine || false}
-                  hoveredLineIndex={hoveredLine}
-                  selectedLineStyle={getSelectedLineStyle(
-                    line.newLineNumber || line.oldLineNumber,
-                    line.type === 'delete' ? 'old' : 'new',
-                  )}
-                  onMouseEnter={() => {
-                    setHoveredLine(index);
-                  }}
-                  onMouseLeave={() => setHoveredLine(null)}
-                  onMouseMove={() => {
-                    if (isDragging && startLine) {
-                      const lineNumber = line.newLineNumber || line.oldLineNumber;
-                      if (lineNumber) {
-                        setEndLine(lineNumber);
-                      }
-                    }
-                  }}
-                  onCommentButtonMouseDown={(e) => {
-                    e.stopPropagation();
-                    const lineNumber = line.newLineNumber || line.oldLineNumber;
-                    if (lineNumber) {
-                      setStartLine(lineNumber);
-                      setEndLine(lineNumber);
-                      setIsDragging(true);
-                    }
-                  }}
-                  onCommentButtonMouseUp={(e) => {
-                    e.stopPropagation();
-                    const lineNumber = line.newLineNumber || line.oldLineNumber;
-                    const side: DiffSide = line.type === 'delete' ? 'old' : 'new';
-                    if (!lineNumber || !startLine) {
-                      setIsDragging(false);
-                      setStartLine(null);
-                      setEndLine(null);
-                      return;
-                    }
+                return (
+                  <React.Fragment key={row.virtual.id}>
+                    {renderUnifiedRow(row, unifiedRowVirtualizer.measureElement)}
+                  </React.Fragment>
+                );
+              })
+            : unifiedRows.map((row) => (
+                <React.Fragment key={row.virtual.id}>{renderUnifiedRow(row)}</React.Fragment>
+              ))}
 
-                    const actualEndLine = endLine || lineNumber;
-                    if (startLine === actualEndLine) {
-                      handleAddComment(side, lineNumber);
-                    } else {
-                      const min = Math.min(startLine, actualEndLine);
-                      const max = Math.max(startLine, actualEndLine);
-                      handleAddComment(side, [min, max]);
-                    }
-
-                    setIsDragging(false);
-                    setStartLine(null);
-                    setEndLine(null);
-                  }}
-                  onOpenInEditor={
-                    onOpenInEditor &&
-                    filename &&
-                    line.type !== 'delete' &&
-                    (line.newLineNumber || line.oldLineNumber)
-                      ? () => {
-                          const lineNumber = line.newLineNumber || line.oldLineNumber;
-                          if (!lineNumber) return;
-                          if (!filename) return;
-                          onOpenInEditor(filename, lineNumber);
-                        }
-                      : undefined
-                  }
-                  syntaxTheme={syntaxTheme}
-                  filename={filename}
-                  diffSegments={wordLevelDiffMap.get(index)}
-                  onClick={() => {
-                    // Determine the side based on line type for unified mode
-                    const side = line.type === 'delete' ? 'left' : 'right';
-                    onLineClick?.(fileIndex, chunkIndex, index, side);
-                  }}
-                />
-
-                {lineComments.map((comment) => {
-                  const layout = getCommentLayout(line);
-                  return (
-                    <tr key={comment.id} className="bg-github-bg-secondary">
-                      <td colSpan={3} className="p-0 border-t border-github-border">
-                        <div
-                          className={`flex ${
-                            layout === 'left'
-                              ? 'justify-start'
-                              : layout === 'right'
-                                ? 'justify-end'
-                                : 'justify-center'
-                          }`}
-                        >
-                          <div className={`${layout === 'full' ? 'w-full' : 'w-1/2'} m-2 mx-4`}>
-                            <InlineComment
-                              comment={comment}
-                              onGeneratePrompt={onGeneratePrompt}
-                              onRemoveComment={onRemoveComment}
-                              onUpdateComment={onUpdateComment}
-                              syntaxTheme={syntaxTheme}
-                            />
-                          </div>
-                        </div>
-                      </td>
-                    </tr>
-                  );
-                })}
-
-                {commentingLine &&
-                  commentingLine.side === currentLineSide &&
-                  formTargetLineNumber === currentLineNumber && (
-                    <tr className="bg-[var(--bg-secondary)]">
-                      <td colSpan={3} className="p-0">
-                        <div
-                          className={`flex ${
-                            getCommentLayout(line) === 'left'
-                              ? 'justify-start'
-                              : getCommentLayout(line) === 'right'
-                                ? 'justify-end'
-                                : 'justify-center'
-                          }`}
-                        >
-                          <div
-                            className={`${getCommentLayout(line) === 'full' ? 'w-full' : 'w-1/2'}`}
-                          >
-                            <CommentForm
-                              onSubmit={handleSubmitComment}
-                              onCancel={handleCancelComment}
-                              selectedCode={getSelectedCodeContent()}
-                              syntaxTheme={syntaxTheme}
-                              filename={filename}
-                            />
-                          </div>
-                        </div>
-                      </td>
-                    </tr>
-                  )}
-              </React.Fragment>
-            );
-          })}
+          {shouldVirtualizeUnified && paddingBottom > 0 && (
+            <tr aria-hidden="true">
+              <td colSpan={3} className="p-0 border-0" style={{ height: `${paddingBottom}px` }} />
+            </tr>
+          )}
         </tbody>
       </table>
     </div>

--- a/src/client/components/DiffLineRow.tsx
+++ b/src/client/components/DiffLineRow.tsx
@@ -25,6 +25,7 @@ interface DiffLineRowProps {
   onClick?: () => void;
   filename?: string;
   diffSegments?: DiffSegment[];
+  measureRef?: (node: HTMLTableRowElement | null) => void;
 }
 
 const getLineClass = (line: DiffLine | ExpandedLine) => {
@@ -60,6 +61,7 @@ export const DiffLineRow: React.FC<DiffLineRowProps> = React.memo(
     onClick,
     filename,
     diffSegments,
+    measureRef,
   }) => {
     const lineNumber = line.newLineNumber || line.oldLineNumber;
     const showLineActions = hoveredLineIndex === index && lineNumber;
@@ -68,6 +70,7 @@ export const DiffLineRow: React.FC<DiffLineRowProps> = React.memo(
 
     return (
       <tr
+        ref={measureRef}
         id={lineId}
         className={`group ${getLineClass(line)} relative ${selectedLineStyle} ${highlightClass} cursor-pointer`}
         onMouseEnter={onMouseEnter}

--- a/src/client/components/SideBySideDiffChunk.tsx
+++ b/src/client/components/SideBySideDiffChunk.tsx
@@ -1,3 +1,4 @@
+import { useVirtualizer } from '@tanstack/react-virtual';
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 
 import {
@@ -7,8 +8,11 @@ import {
   type Comment,
   type LineNumber,
   type LineSelection,
+  type VirtualDiffRow,
 } from '../../types/diff';
+import { NAVIGATION_SELECTORS } from '../constants/navigation';
 import { type CursorPosition } from '../hooks/keyboardNavigation';
+import { registerVirtualRowScrollHandlers } from '../utils/virtualScrollRegistry';
 import {
   computeWordLevelDiff,
   shouldComputeWordDiff,
@@ -60,6 +64,40 @@ interface SideBySideLine {
   newLineOriginalIndex?: number;
   wordLevelDiff?: WordLevelDiffResult;
 }
+
+type SplitLineRow = {
+  type: 'line';
+  virtual: VirtualDiffRow;
+  sideLine: SideBySideLine;
+  index: number;
+  allComments: Comment[];
+  oldLineOriginalIndex: number;
+  newLineOriginalIndex: number;
+  oldLineNavId?: string;
+  newLineNavId?: string;
+};
+
+type SplitCommentRow = {
+  type: 'comment';
+  virtual: VirtualDiffRow;
+  sideLine: SideBySideLine;
+  allComments: Comment[];
+};
+
+type SplitCommentFormRow = {
+  type: 'commentForm';
+  virtual: VirtualDiffRow;
+  sideLine: SideBySideLine;
+};
+
+type SplitRenderableRow = SplitLineRow | SplitCommentRow | SplitCommentFormRow;
+
+const SPLIT_VIRTUALIZATION_ROW_THRESHOLD = 120;
+const SPLIT_ESTIMATED_HEIGHTS = {
+  line: 24,
+  comment: 140,
+  commentForm: 230,
+} as const;
 
 // Type guard to check if a line is an expanded line (#6)
 const isExpandedLine = (line: DiffLine | undefined): boolean => {
@@ -116,7 +154,6 @@ export function SideBySideDiffChunk({
       if (line && line.type !== 'delete') {
         const lineNumber = line.newLineNumber;
         if (lineNumber) {
-          // oxlint-disable-next-line react-hooks-js/set-state-in-effect -- intentional: respond to external keyboard trigger
           setCommentingLine({ side: 'new', lineNumber });
           onCommentTriggerHandled?.();
         }
@@ -196,19 +233,24 @@ export function SideBySideDiffChunk({
     [commentingLine, onAddComment, getSelectedCodeContent],
   );
 
-  const getCommentsForLine = (lineNumber: number, side: DiffSide) => {
-    return comments.filter((c) => {
-      // Check if line number matches (single line or end of range)
-      const lineMatches = Array.isArray(c.line) ? c.line[1] === lineNumber : c.line === lineNumber;
+  const getCommentsForLine = useCallback(
+    (lineNumber: number, side: DiffSide) => {
+      return comments.filter((c) => {
+        // Check if line number matches (single line or end of range)
+        const lineMatches = Array.isArray(c.line)
+          ? c.line[1] === lineNumber
+          : c.line === lineNumber;
 
-      // Filter by side - if comment has no side (legacy), show on new side only
-      const sideMatches = !c.side || c.side === side;
+        // Filter by side - if comment has no side (legacy), show on new side only
+        const sideMatches = !c.side || c.side === side;
 
-      return lineMatches && sideMatches;
-    });
-  };
+        return lineMatches && sideMatches;
+      });
+    },
+    [comments],
+  );
 
-  const getCommentLayout = (sideLine: SideBySideLine): 'left' | 'right' | 'full' => {
+  const getCommentLayout = useCallback((sideLine: SideBySideLine): 'left' | 'right' | 'full' => {
     // サイドバイサイドでは、削除行側（左）にコメントがある場合は左半分、
     // 追加行側（右）にコメントがある場合は右半分、
     // 変更なし行の場合は全幅で表示
@@ -223,48 +265,51 @@ export function SideBySideDiffChunk({
       return 'right';
     }
     return 'full';
-  };
+  }, []);
 
-  const getSelectedLineStyle = (side: DiffSide, sideLine: SideBySideLine): string => {
-    const lineNumber = side === 'old' ? sideLine.oldLineNumber : sideLine.newLineNumber;
-    if (!lineNumber) {
+  const getSelectedLineStyle = useCallback(
+    (side: DiffSide, sideLine: SideBySideLine): string => {
+      const lineNumber = side === 'old' ? sideLine.oldLineNumber : sideLine.newLineNumber;
+      if (!lineNumber) {
+        return '';
+      }
+
+      // Show selection during drag
+      if (isDragging && startLine && endLine && startLine.side === side && endLine.side === side) {
+        const min = Math.min(startLine.lineNumber, endLine.lineNumber);
+        const max = Math.max(startLine.lineNumber, endLine.lineNumber);
+        if (lineNumber >= min && lineNumber <= max) {
+          let classes =
+            'after:bg-blue-100 after:absolute after:inset-0 after:opacity-30 after:border-l-4 after:border-blue-500 after:pointer-events-none';
+          // Add top border for first line
+          if (lineNumber === min) {
+            classes += ' after:border-t-2';
+          }
+          // Add bottom border for last line
+          if (lineNumber === max) {
+            classes += ' after:border-b-2';
+          }
+          return classes;
+        }
+      }
+
+      // Show selection for existing comment
+      if (commentingLine && commentingLine.side === side) {
+        const lineNumberRange = Array.isArray(commentingLine.lineNumber)
+          ? commentingLine.lineNumber
+          : [commentingLine.lineNumber, commentingLine.lineNumber];
+        const start = lineNumberRange[0];
+        const end = lineNumberRange[1];
+
+        if (start !== undefined && end !== undefined && lineNumber >= start && lineNumber <= end) {
+          return 'after:bg-diff-selected-bg after:absolute after:inset-0 after:border-l-5 after:border-l-diff-selected-border after:pointer-events-none';
+        }
+      }
+
       return '';
-    }
-
-    // Show selection during drag
-    if (isDragging && startLine && endLine && startLine.side === side && endLine.side === side) {
-      const min = Math.min(startLine.lineNumber, endLine.lineNumber);
-      const max = Math.max(startLine.lineNumber, endLine.lineNumber);
-      if (lineNumber >= min && lineNumber <= max) {
-        let classes =
-          'after:bg-blue-100 after:absolute after:inset-0 after:opacity-30 after:border-l-4 after:border-blue-500 after:pointer-events-none';
-        // Add top border for first line
-        if (lineNumber === min) {
-          classes += ' after:border-t-2';
-        }
-        // Add bottom border for last line
-        if (lineNumber === max) {
-          classes += ' after:border-b-2';
-        }
-        return classes;
-      }
-    }
-
-    // Show selection for existing comment
-    if (commentingLine && commentingLine.side === side) {
-      const lineNumberRange = Array.isArray(commentingLine.lineNumber)
-        ? commentingLine.lineNumber
-        : [commentingLine.lineNumber, commentingLine.lineNumber];
-      const start = lineNumberRange[0];
-      const end = lineNumberRange[1];
-
-      if (start !== undefined && end !== undefined && lineNumber >= start && lineNumber <= end) {
-        return 'after:bg-diff-selected-bg after:absolute after:inset-0 after:border-l-5 after:border-l-diff-selected-border after:pointer-events-none';
-      }
-    }
-
-    return '';
-  };
+    },
+    [commentingLine, endLine, isDragging, startLine],
+  );
 
   // Convert unified diff to split format
   const convertToSideBySide = useCallback(
@@ -363,378 +408,532 @@ export function SideBySideDiffChunk({
     [chunk.lines, convertToSideBySide],
   );
 
+  const splitRows = useMemo<SplitRenderableRow[]>(() => {
+    const rows: SplitRenderableRow[] = [];
+
+    sideBySideLines.forEach((sideLine, index) => {
+      const oldComments = sideLine.oldLineNumber
+        ? getCommentsForLine(sideLine.oldLineNumber, 'old')
+        : [];
+      const newComments = sideLine.newLineNumber
+        ? getCommentsForLine(sideLine.newLineNumber, 'new')
+        : [];
+      const allComments = [...oldComments, ...newComments];
+
+      const oldLineOriginalIndex = sideLine.oldLineOriginalIndex ?? -1;
+      const newLineOriginalIndex = sideLine.newLineOriginalIndex ?? -1;
+
+      const oldLineNavId =
+        oldLineOriginalIndex >= 0
+          ? `file-${fileIndex}-chunk-${chunkIndex}-line-${oldLineOriginalIndex}-left`
+          : undefined;
+      const newLineNavId =
+        newLineOriginalIndex >= 0
+          ? `file-${fileIndex}-chunk-${chunkIndex}-line-${newLineOriginalIndex}-right`
+          : undefined;
+
+      rows.push({
+        type: 'line',
+        virtual: {
+          id:
+            newLineNavId ||
+            oldLineNavId ||
+            `file-${fileIndex}-chunk-${chunkIndex}-split-line-${index}`,
+          kind: 'line',
+          filePath: filename || '',
+          chunkIndex,
+          lineIndex: newLineOriginalIndex >= 0 ? newLineOriginalIndex : oldLineOriginalIndex,
+          estimatedHeight: SPLIT_ESTIMATED_HEIGHTS.line,
+        },
+        sideLine,
+        index,
+        allComments,
+        oldLineOriginalIndex,
+        newLineOriginalIndex,
+        oldLineNavId,
+        newLineNavId,
+      });
+
+      if (allComments.length > 0) {
+        rows.push({
+          type: 'comment',
+          virtual: {
+            id: `${newLineNavId || oldLineNavId || `line-${index}`}-comments`,
+            kind: 'inlineComment',
+            filePath: filename || '',
+            chunkIndex,
+            lineIndex: newLineOriginalIndex >= 0 ? newLineOriginalIndex : oldLineOriginalIndex,
+            estimatedHeight: SPLIT_ESTIMATED_HEIGHTS.comment,
+          },
+          sideLine,
+          allComments,
+        });
+      }
+
+      if (
+        commentingLine &&
+        ((commentingLine.side === 'old' && commentingLine.lineNumber === sideLine.oldLineNumber) ||
+          (commentingLine.side === 'new' && commentingLine.lineNumber === sideLine.newLineNumber) ||
+          (Array.isArray(commentingLine.lineNumber) &&
+            ((commentingLine.side === 'new' &&
+              commentingLine.lineNumber[1] === sideLine.newLineNumber) ||
+              (commentingLine.side === 'old' &&
+                commentingLine.lineNumber[1] === sideLine.oldLineNumber))))
+      ) {
+        rows.push({
+          type: 'commentForm',
+          virtual: {
+            id: `${newLineNavId || oldLineNavId || `line-${index}`}-form`,
+            kind: 'commentForm',
+            filePath: filename || '',
+            chunkIndex,
+            lineIndex: newLineOriginalIndex >= 0 ? newLineOriginalIndex : oldLineOriginalIndex,
+            estimatedHeight: SPLIT_ESTIMATED_HEIGHTS.commentForm,
+          },
+          sideLine,
+        });
+      }
+    });
+
+    return rows;
+  }, [chunkIndex, commentingLine, fileIndex, filename, getCommentsForLine, sideBySideLines]);
+
+  const shouldVirtualizeSplit = splitRows.length >= SPLIT_VIRTUALIZATION_ROW_THRESHOLD;
+
+  const splitRowVirtualizer = useVirtualizer({
+    count: splitRows.length,
+    enabled: shouldVirtualizeSplit,
+    getScrollElement: () =>
+      document.querySelector(NAVIGATION_SELECTORS.SCROLL_CONTAINER) as HTMLElement | null,
+    estimateSize: (index) =>
+      splitRows[index]?.virtual.estimatedHeight ?? SPLIT_ESTIMATED_HEIGHTS.line,
+    getItemKey: (index) => splitRows[index]?.virtual.id ?? index,
+    overscan: 24,
+  });
+
+  const splitLineRowIndexById = useMemo(() => {
+    const map = new Map<string, number>();
+    splitRows.forEach((row, rowIndex) => {
+      if (row.type !== 'line') {
+        return;
+      }
+
+      if (row.oldLineNavId) {
+        map.set(row.oldLineNavId, rowIndex);
+      }
+      if (row.newLineNavId) {
+        map.set(row.newLineNavId, rowIndex);
+      }
+    });
+    return map;
+  }, [splitRows]);
+
+  useEffect(() => {
+    const handlers = new Map<string, () => void>();
+    splitLineRowIndexById.forEach((rowIndex, lineId) => {
+      handlers.set(lineId, () => {
+        splitRowVirtualizer.scrollToIndex(rowIndex, { align: 'center' });
+      });
+    });
+
+    return registerVirtualRowScrollHandlers(handlers);
+  }, [splitLineRowIndexById, splitRowVirtualizer]);
+
+  const renderSplitRow = useCallback(
+    (row: SplitRenderableRow, measureRef?: (node: HTMLTableRowElement | null) => void) => {
+      if (row.type === 'line') {
+        const { sideLine, oldLineOriginalIndex, newLineOriginalIndex } = row;
+
+        // Check if the current side's line matches the cursor position
+        const isHighlighted = (() => {
+          if (!cursor) return false;
+
+          // Only highlight the line on the current side
+          if (cursor.side === 'left' && oldLineOriginalIndex >= 0) {
+            return cursor.chunkIndex === chunkIndex && cursor.lineIndex === oldLineOriginalIndex;
+          }
+          if (cursor.side === 'right' && newLineOriginalIndex >= 0) {
+            return cursor.chunkIndex === chunkIndex && cursor.lineIndex === newLineOriginalIndex;
+          }
+
+          return false;
+        })();
+
+        // Determine which cell to highlight
+        const highlightOldCell = isHighlighted && cursor?.side === 'left';
+        const highlightNewCell = isHighlighted && cursor?.side === 'right';
+
+        const cellHighlightClass = 'keyboard-cursor';
+
+        return (
+          <tr
+            ref={measureRef}
+            className="group cursor-pointer"
+            onClick={(e) => {
+              if (!isDragging) {
+                const target = e.target;
+                if (!(target instanceof HTMLElement)) return;
+                const isInOldSide =
+                  target.closest('td:nth-child(1)') || target.closest('td:nth-child(2)');
+                const isInNewSide =
+                  target.closest('td:nth-child(3)') || target.closest('td:nth-child(4)');
+
+                if (isInOldSide && oldLineOriginalIndex >= 0) {
+                  onLineClick?.(fileIndex, chunkIndex, oldLineOriginalIndex, 'left');
+                } else if (isInNewSide && newLineOriginalIndex >= 0) {
+                  onLineClick?.(fileIndex, chunkIndex, newLineOriginalIndex, 'right');
+                }
+              }
+            }}
+            onMouseEnter={(e) => {
+              const target = e.target;
+              if (!(target instanceof HTMLElement)) return;
+              const isInOldSide =
+                target.closest('td:nth-child(1)') || target.closest('td:nth-child(2)');
+              const isInNewSide =
+                target.closest('td:nth-child(3)') || target.closest('td:nth-child(4)');
+
+              if (isInOldSide && sideLine.oldLineNumber) {
+                setHoveredLine({ side: 'old', lineNumber: sideLine.oldLineNumber });
+              } else if (isInNewSide && sideLine.newLineNumber) {
+                setHoveredLine({ side: 'new', lineNumber: sideLine.newLineNumber });
+              }
+            }}
+            onMouseMove={(e) => {
+              const target = e.target;
+              if (!(target instanceof HTMLElement)) return;
+              const isInOldSide =
+                target.closest('td:nth-child(1)') || target.closest('td:nth-child(2)');
+              const isInNewSide =
+                target.closest('td:nth-child(3)') || target.closest('td:nth-child(4)');
+
+              // Update hover state based on mouse position
+              if (isInOldSide && sideLine.oldLineNumber) {
+                if (
+                  hoveredLine?.side !== 'old' ||
+                  hoveredLine?.lineNumber !== sideLine.oldLineNumber
+                ) {
+                  setHoveredLine({ side: 'old', lineNumber: sideLine.oldLineNumber });
+                }
+              } else if (isInNewSide && sideLine.newLineNumber) {
+                if (
+                  hoveredLine?.side !== 'new' ||
+                  hoveredLine?.lineNumber !== sideLine.newLineNumber
+                ) {
+                  setHoveredLine({ side: 'new', lineNumber: sideLine.newLineNumber });
+                }
+              }
+
+              // Handle dragging
+              if (isDragging && startLine) {
+                if (startLine.side === 'old' && sideLine.oldLineNumber) {
+                  setEndLine({ side: 'old', lineNumber: sideLine.oldLineNumber });
+                } else if (startLine.side === 'new' && sideLine.newLineNumber) {
+                  setEndLine({ side: 'new', lineNumber: sideLine.newLineNumber });
+                }
+              }
+            }}
+            onMouseLeave={() => setHoveredLine(null)}
+          >
+            {/* Old side */}
+            <td
+              id={row.oldLineNavId}
+              className={`w-[var(--line-number-width)] min-w-[var(--line-number-width)] max-w-[var(--line-number-width)] px-2 text-right text-github-text-muted bg-github-bg-secondary border-r border-github-border select-none align-top relative overflow-visible ${highlightOldCell ? cellHighlightClass : ''}`}
+            >
+              <span>{sideLine.oldLineNumber || ''}</span>
+              {hoveredLine?.side === 'old' &&
+                hoveredLine?.lineNumber === sideLine.oldLineNumber && (
+                  <>
+                    {onOpenInEditor &&
+                      filename &&
+                      sideLine.oldLine?.type !== 'delete' &&
+                      sideLine.newLineNumber !== undefined && (
+                        <OpenInEditorButton
+                          onClick={() => {
+                            const lineNumber = sideLine.newLineNumber;
+                            if (!filename || lineNumber === undefined) return;
+                            onOpenInEditor(filename, lineNumber);
+                          }}
+                        />
+                      )}
+                    <CommentButton
+                      onMouseDown={(e) => {
+                        e.stopPropagation();
+                        if (sideLine.oldLineNumber) {
+                          setStartLine({ side: 'old', lineNumber: sideLine.oldLineNumber });
+                          setEndLine({ side: 'old', lineNumber: sideLine.oldLineNumber });
+                          setIsDragging(true);
+                        }
+                      }}
+                      onMouseUp={(e) => {
+                        e.stopPropagation();
+                        if (!sideLine.oldLineNumber || !startLine) {
+                          setIsDragging(false);
+                          setStartLine(null);
+                          setEndLine(null);
+                          return;
+                        }
+
+                        const actualEndLine =
+                          endLine && endLine.side === 'old'
+                            ? endLine.lineNumber
+                            : sideLine.oldLineNumber;
+                        if (startLine.side !== 'old' || startLine.lineNumber === actualEndLine) {
+                          handleAddComment('old', sideLine.oldLineNumber);
+                        } else {
+                          const min = Math.min(startLine.lineNumber, actualEndLine);
+                          const max = Math.max(startLine.lineNumber, actualEndLine);
+                          handleAddComment('old', [min, max]);
+                        }
+
+                        setIsDragging(false);
+                        setStartLine(null);
+                        setEndLine(null);
+                      }}
+                    />
+                  </>
+                )}
+            </td>
+            <td
+              className={`w-1/2 p-0 align-top border-r border-github-border relative ${getSideBySideLineClass(sideLine.oldLine, isExpandedLine(sideLine.oldLine))} ${getSelectedLineStyle('old', sideLine)} ${highlightOldCell ? cellHighlightClass : ''}`}
+            >
+              {sideLine.oldLine && (
+                <div className="flex items-center relative min-h-[20px] px-3">
+                  {sideLine.wordLevelDiff ? (
+                    <WordLevelDiffHighlighter
+                      segments={sideLine.wordLevelDiff.oldSegments}
+                      className="flex-1 text-github-text-primary whitespace-pre-wrap break-all overflow-wrap-break-word select-text"
+                    />
+                  ) : (
+                    <EnhancedPrismSyntaxHighlighter
+                      code={sideLine.oldLine.content}
+                      className="flex-1 text-github-text-primary whitespace-pre-wrap break-all overflow-wrap-break-word select-text [&_pre]:m-0 [&_pre]:p-0 [&_pre]:!bg-transparent [&_pre]:font-inherit [&_pre]:text-inherit [&_pre]:leading-inherit [&_code]:!bg-transparent [&_code]:font-inherit [&_code]:text-inherit [&_code]:leading-inherit"
+                      syntaxTheme={syntaxTheme}
+                      filename={filename}
+                    />
+                  )}
+                </div>
+              )}
+            </td>
+
+            {/* New side */}
+            <td
+              id={row.newLineNavId}
+              className={`w-[var(--line-number-width)] min-w-[var(--line-number-width)] max-w-[var(--line-number-width)] px-2 text-right text-github-text-muted bg-github-bg-secondary border-r border-github-border select-none align-top relative overflow-visible ${highlightNewCell ? cellHighlightClass : ''}`}
+            >
+              <span>{sideLine.newLineNumber || ''}</span>
+              {hoveredLine?.side === 'new' &&
+                hoveredLine?.lineNumber === sideLine.newLineNumber && (
+                  <>
+                    {onOpenInEditor && filename && sideLine.newLineNumber !== undefined && (
+                      <OpenInEditorButton
+                        onClick={() => {
+                          const lineNumber = sideLine.newLineNumber;
+                          if (!filename || lineNumber === undefined) return;
+                          onOpenInEditor(filename, lineNumber);
+                        }}
+                      />
+                    )}
+                    <CommentButton
+                      onMouseDown={(e) => {
+                        e.stopPropagation();
+                        if (sideLine.newLineNumber) {
+                          setStartLine({ side: 'new', lineNumber: sideLine.newLineNumber });
+                          setEndLine({ side: 'new', lineNumber: sideLine.newLineNumber });
+                          setIsDragging(true);
+                        }
+                      }}
+                      onMouseUp={(e) => {
+                        e.stopPropagation();
+                        if (!sideLine.newLineNumber || !startLine) {
+                          setIsDragging(false);
+                          setStartLine(null);
+                          setEndLine(null);
+                          return;
+                        }
+
+                        const actualEndLine =
+                          endLine && endLine.side === 'new'
+                            ? endLine.lineNumber
+                            : sideLine.newLineNumber;
+                        if (startLine.side !== 'new' || startLine.lineNumber === actualEndLine) {
+                          handleAddComment('new', sideLine.newLineNumber);
+                        } else {
+                          const min = Math.min(startLine.lineNumber, actualEndLine);
+                          const max = Math.max(startLine.lineNumber, actualEndLine);
+                          handleAddComment('new', [min, max]);
+                        }
+
+                        setIsDragging(false);
+                        setStartLine(null);
+                        setEndLine(null);
+                      }}
+                    />
+                  </>
+                )}
+            </td>
+            <td
+              className={`w-1/2 p-0 align-top relative ${getSideBySideLineClass(sideLine.newLine, isExpandedLine(sideLine.newLine))} ${getSelectedLineStyle('new', sideLine)} ${highlightNewCell ? cellHighlightClass : ''}`}
+            >
+              {sideLine.newLine && (
+                <div className="flex items-center relative min-h-[20px] px-3">
+                  {sideLine.wordLevelDiff ? (
+                    <WordLevelDiffHighlighter
+                      segments={sideLine.wordLevelDiff.newSegments}
+                      className="flex-1 text-github-text-primary whitespace-pre-wrap break-all overflow-wrap-break-word select-text"
+                    />
+                  ) : (
+                    <EnhancedPrismSyntaxHighlighter
+                      code={sideLine.newLine.content}
+                      className="flex-1 text-github-text-primary whitespace-pre-wrap break-all overflow-wrap-break-word select-text [&_pre]:m-0 [&_pre]:p-0 [&_pre]:!bg-transparent [&_pre]:font-inherit [&_pre]:text-inherit [&_pre]:leading-inherit [&_code]:!bg-transparent [&_code]:font-inherit [&_code]:text-inherit [&_code]:leading-inherit"
+                      syntaxTheme={syntaxTheme}
+                      filename={filename}
+                    />
+                  )}
+                </div>
+              )}
+            </td>
+          </tr>
+        );
+      }
+
+      if (row.type === 'comment') {
+        return (
+          <tr ref={measureRef} className="bg-github-bg-secondary">
+            <td colSpan={4} className="p-0 border-t border-github-border">
+              {row.allComments.map((comment) => {
+                // Determine layout based on comment's side
+                const commentSide = comment.side || 'new';
+                let layout: 'left' | 'right' | 'full';
+
+                if (commentSide === 'old' && row.sideLine.oldLineNumber) {
+                  layout = 'left';
+                } else if (commentSide === 'new' && row.sideLine.newLineNumber) {
+                  layout = 'right';
+                } else {
+                  layout = getCommentLayout(row.sideLine);
+                }
+
+                return (
+                  <div
+                    key={comment.id}
+                    className={`flex ${
+                      layout === 'left'
+                        ? 'justify-start'
+                        : layout === 'right'
+                          ? 'justify-end'
+                          : 'justify-center'
+                    }`}
+                  >
+                    <div className={`${layout === 'full' ? 'w-full' : 'w-1/2'}`}>
+                      <div className="m-2 mx-3">
+                        <InlineComment
+                          comment={comment}
+                          onGeneratePrompt={onGeneratePrompt}
+                          onRemoveComment={onRemoveComment}
+                          onUpdateComment={onUpdateComment}
+                          syntaxTheme={syntaxTheme}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </td>
+          </tr>
+        );
+      }
+
+      return (
+        <tr ref={measureRef} className="bg-github-bg-secondary">
+          <td colSpan={4} className="p-0">
+            <div
+              className={`flex ${
+                commentingLine?.side === 'old'
+                  ? 'justify-start'
+                  : commentingLine?.side === 'new'
+                    ? 'justify-end'
+                    : 'justify-center'
+              }`}
+            >
+              <div className="w-1/2">
+                <CommentForm
+                  onSubmit={handleSubmitComment}
+                  onCancel={handleCancelComment}
+                  selectedCode={getSelectedCodeContent()}
+                  syntaxTheme={syntaxTheme}
+                  filename={filename}
+                />
+              </div>
+            </div>
+          </td>
+        </tr>
+      );
+    },
+    [
+      chunkIndex,
+      commentingLine?.side,
+      cursor,
+      fileIndex,
+      filename,
+      getCommentLayout,
+      getSelectedCodeContent,
+      getSelectedLineStyle,
+      handleAddComment,
+      handleCancelComment,
+      handleSubmitComment,
+      hoveredLine,
+      isDragging,
+      onGeneratePrompt,
+      onLineClick,
+      onOpenInEditor,
+      onRemoveComment,
+      onUpdateComment,
+      startLine,
+      endLine,
+      syntaxTheme,
+    ],
+  );
+
+  const virtualItems = shouldVirtualizeSplit ? splitRowVirtualizer.getVirtualItems() : [];
+  const paddingTop =
+    shouldVirtualizeSplit && virtualItems.length > 0 ? (virtualItems[0]?.start ?? 0) : 0;
+  const paddingBottom =
+    shouldVirtualizeSplit && virtualItems.length > 0
+      ? splitRowVirtualizer.getTotalSize() - (virtualItems[virtualItems.length - 1]?.end ?? 0)
+      : 0;
+
   return (
     <div className="bg-github-bg-primary overflow-hidden">
       <table className="w-full table-fixed border-collapse font-mono text-sm leading-5">
         <tbody>
-          {sideBySideLines.map((sideLine, index) => {
-            // Fetch comments separately for each side to prevent duplication
-            const oldComments = sideLine.oldLineNumber
-              ? getCommentsForLine(sideLine.oldLineNumber, 'old')
-              : [];
-            const newComments = sideLine.newLineNumber
-              ? getCommentsForLine(sideLine.newLineNumber, 'new')
-              : [];
-            const allComments = [...oldComments, ...newComments];
+          {shouldVirtualizeSplit && paddingTop > 0 && (
+            <tr aria-hidden="true">
+              <td colSpan={4} className="p-0 border-0" style={{ height: `${paddingTop}px` }} />
+            </tr>
+          )}
 
-            // Use the stored original indices
-            const oldLineOriginalIndex = sideLine.oldLineOriginalIndex ?? -1;
-            const newLineOriginalIndex = sideLine.newLineOriginalIndex ?? -1;
-
-            // Check if the current side's line matches the cursor position
-            const isHighlighted = (() => {
-              if (!cursor) return false;
-
-              // Only highlight the line on the current side
-              if (cursor.side === 'left' && oldLineOriginalIndex >= 0) {
+          {shouldVirtualizeSplit
+            ? virtualItems.map((virtualItem) => {
+                const row = splitRows[virtualItem.index];
+                if (!row) {
+                  return null;
+                }
                 return (
-                  cursor.chunkIndex === chunkIndex && cursor.lineIndex === oldLineOriginalIndex
+                  <React.Fragment key={row.virtual.id}>
+                    {renderSplitRow(row, splitRowVirtualizer.measureElement)}
+                  </React.Fragment>
                 );
-              } else if (cursor.side === 'right' && newLineOriginalIndex >= 0) {
-                return (
-                  cursor.chunkIndex === chunkIndex && cursor.lineIndex === newLineOriginalIndex
-                );
-              }
+              })
+            : splitRows.map((row) => (
+                <React.Fragment key={row.virtual.id}>{renderSplitRow(row)}</React.Fragment>
+              ))}
 
-              return false;
-            })();
-
-            // Generate IDs for navigation with side suffix
-            const oldLineNavId =
-              oldLineOriginalIndex >= 0
-                ? `file-${fileIndex}-chunk-${chunkIndex}-line-${oldLineOriginalIndex}-left`
-                : undefined;
-            const newLineNavId =
-              newLineOriginalIndex >= 0
-                ? `file-${fileIndex}-chunk-${chunkIndex}-line-${newLineOriginalIndex}-right`
-                : undefined;
-
-            // Determine which cell to highlight
-            const highlightOldCell = isHighlighted && cursor?.side === 'left';
-            const highlightNewCell = isHighlighted && cursor?.side === 'right';
-
-            const cellHighlightClass = 'keyboard-cursor';
-
-            return (
-              <React.Fragment key={index}>
-                <tr
-                  className="group cursor-pointer"
-                  onClick={(e) => {
-                    if (!isDragging) {
-                      const target = e.target;
-                      if (!(target instanceof HTMLElement)) return;
-                      const isInOldSide =
-                        target.closest('td:nth-child(1)') || target.closest('td:nth-child(2)');
-                      const isInNewSide =
-                        target.closest('td:nth-child(3)') || target.closest('td:nth-child(4)');
-
-                      if (isInOldSide && oldLineOriginalIndex >= 0) {
-                        onLineClick?.(fileIndex, chunkIndex, oldLineOriginalIndex, 'left');
-                      } else if (isInNewSide && newLineOriginalIndex >= 0) {
-                        onLineClick?.(fileIndex, chunkIndex, newLineOriginalIndex, 'right');
-                      }
-                    }
-                  }}
-                  onMouseEnter={(e) => {
-                    const target = e.target;
-                    if (!(target instanceof HTMLElement)) return;
-                    const isInOldSide =
-                      target.closest('td:nth-child(1)') || target.closest('td:nth-child(2)');
-                    const isInNewSide =
-                      target.closest('td:nth-child(3)') || target.closest('td:nth-child(4)');
-
-                    if (isInOldSide && sideLine.oldLineNumber) {
-                      setHoveredLine({ side: 'old', lineNumber: sideLine.oldLineNumber });
-                    } else if (isInNewSide && sideLine.newLineNumber) {
-                      setHoveredLine({ side: 'new', lineNumber: sideLine.newLineNumber });
-                    }
-                  }}
-                  onMouseMove={(e) => {
-                    const target = e.target;
-                    if (!(target instanceof HTMLElement)) return;
-                    const isInOldSide =
-                      target.closest('td:nth-child(1)') || target.closest('td:nth-child(2)');
-                    const isInNewSide =
-                      target.closest('td:nth-child(3)') || target.closest('td:nth-child(4)');
-
-                    // Update hover state based on mouse position
-                    if (isInOldSide && sideLine.oldLineNumber) {
-                      if (
-                        hoveredLine?.side !== 'old' ||
-                        hoveredLine?.lineNumber !== sideLine.oldLineNumber
-                      ) {
-                        setHoveredLine({ side: 'old', lineNumber: sideLine.oldLineNumber });
-                      }
-                    } else if (isInNewSide && sideLine.newLineNumber) {
-                      if (
-                        hoveredLine?.side !== 'new' ||
-                        hoveredLine?.lineNumber !== sideLine.newLineNumber
-                      ) {
-                        setHoveredLine({ side: 'new', lineNumber: sideLine.newLineNumber });
-                      }
-                    }
-
-                    // Handle dragging
-                    if (isDragging && startLine) {
-                      if (startLine.side === 'old' && sideLine.oldLineNumber) {
-                        setEndLine({ side: 'old', lineNumber: sideLine.oldLineNumber });
-                      } else if (startLine.side === 'new' && sideLine.newLineNumber) {
-                        setEndLine({ side: 'new', lineNumber: sideLine.newLineNumber });
-                      }
-                    }
-                  }}
-                  onMouseLeave={() => setHoveredLine(null)}
-                >
-                  {/* Old side */}
-                  <td
-                    id={oldLineNavId}
-                    className={`w-[var(--line-number-width)] min-w-[var(--line-number-width)] max-w-[var(--line-number-width)] px-2 text-right text-github-text-muted bg-github-bg-secondary border-r border-github-border select-none align-top relative overflow-visible ${highlightOldCell ? cellHighlightClass : ''}`}
-                  >
-                    <span>{sideLine.oldLineNumber || ''}</span>
-                    {hoveredLine?.side === 'old' &&
-                      hoveredLine?.lineNumber === sideLine.oldLineNumber && (
-                        <>
-                          {onOpenInEditor &&
-                            filename &&
-                            sideLine.oldLine?.type !== 'delete' &&
-                            sideLine.newLineNumber !== undefined && (
-                              <OpenInEditorButton
-                                onClick={() => {
-                                  const lineNumber = sideLine.newLineNumber;
-                                  if (!filename || lineNumber === undefined) return;
-                                  onOpenInEditor(filename, lineNumber);
-                                }}
-                              />
-                            )}
-                          <CommentButton
-                            onMouseDown={(e) => {
-                              e.stopPropagation();
-                              if (sideLine.oldLineNumber) {
-                                setStartLine({ side: 'old', lineNumber: sideLine.oldLineNumber });
-                                setEndLine({ side: 'old', lineNumber: sideLine.oldLineNumber });
-                                setIsDragging(true);
-                              }
-                            }}
-                            onMouseUp={(e) => {
-                              e.stopPropagation();
-                              if (!sideLine.oldLineNumber || !startLine) {
-                                setIsDragging(false);
-                                setStartLine(null);
-                                setEndLine(null);
-                                return;
-                              }
-
-                              const actualEndLine =
-                                endLine && endLine.side === 'old'
-                                  ? endLine.lineNumber
-                                  : sideLine.oldLineNumber;
-                              if (
-                                startLine.side !== 'old' ||
-                                startLine.lineNumber === actualEndLine
-                              ) {
-                                handleAddComment('old', sideLine.oldLineNumber);
-                              } else {
-                                const min = Math.min(startLine.lineNumber, actualEndLine);
-                                const max = Math.max(startLine.lineNumber, actualEndLine);
-                                handleAddComment('old', [min, max]);
-                              }
-
-                              setIsDragging(false);
-                              setStartLine(null);
-                              setEndLine(null);
-                            }}
-                          />
-                        </>
-                      )}
-                  </td>
-                  <td
-                    className={`w-1/2 p-0 align-top border-r border-github-border relative ${getSideBySideLineClass(sideLine.oldLine, isExpandedLine(sideLine.oldLine))} ${getSelectedLineStyle('old', sideLine)} ${highlightOldCell ? cellHighlightClass : ''}`}
-                  >
-                    {sideLine.oldLine && (
-                      <div className="flex items-center relative min-h-[20px] px-3">
-                        {sideLine.wordLevelDiff ? (
-                          <WordLevelDiffHighlighter
-                            segments={sideLine.wordLevelDiff.oldSegments}
-                            className="flex-1 text-github-text-primary whitespace-pre-wrap break-all overflow-wrap-break-word select-text"
-                          />
-                        ) : (
-                          <EnhancedPrismSyntaxHighlighter
-                            code={sideLine.oldLine.content}
-                            className="flex-1 text-github-text-primary whitespace-pre-wrap break-all overflow-wrap-break-word select-text [&_pre]:m-0 [&_pre]:p-0 [&_pre]:!bg-transparent [&_pre]:font-inherit [&_pre]:text-inherit [&_pre]:leading-inherit [&_code]:!bg-transparent [&_code]:font-inherit [&_code]:text-inherit [&_code]:leading-inherit"
-                            syntaxTheme={syntaxTheme}
-                            filename={filename}
-                          />
-                        )}
-                      </div>
-                    )}
-                  </td>
-
-                  {/* New side */}
-                  <td
-                    id={newLineNavId}
-                    className={`w-[var(--line-number-width)] min-w-[var(--line-number-width)] max-w-[var(--line-number-width)] px-2 text-right text-github-text-muted bg-github-bg-secondary border-r border-github-border select-none align-top relative overflow-visible ${highlightNewCell ? cellHighlightClass : ''}`}
-                  >
-                    <span>{sideLine.newLineNumber || ''}</span>
-                    {hoveredLine?.side === 'new' &&
-                      hoveredLine?.lineNumber === sideLine.newLineNumber && (
-                        <>
-                          {onOpenInEditor && filename && sideLine.newLineNumber !== undefined && (
-                            <OpenInEditorButton
-                              onClick={() => {
-                                const lineNumber = sideLine.newLineNumber;
-                                if (!filename || lineNumber === undefined) return;
-                                onOpenInEditor(filename, lineNumber);
-                              }}
-                            />
-                          )}
-                          <CommentButton
-                            onMouseDown={(e) => {
-                              e.stopPropagation();
-                              if (sideLine.newLineNumber) {
-                                setStartLine({ side: 'new', lineNumber: sideLine.newLineNumber });
-                                setEndLine({ side: 'new', lineNumber: sideLine.newLineNumber });
-                                setIsDragging(true);
-                              }
-                            }}
-                            onMouseUp={(e) => {
-                              e.stopPropagation();
-                              if (!sideLine.newLineNumber || !startLine) {
-                                setIsDragging(false);
-                                setStartLine(null);
-                                setEndLine(null);
-                                return;
-                              }
-
-                              const actualEndLine =
-                                endLine && endLine.side === 'new'
-                                  ? endLine.lineNumber
-                                  : sideLine.newLineNumber;
-                              if (
-                                startLine.side !== 'new' ||
-                                startLine.lineNumber === actualEndLine
-                              ) {
-                                handleAddComment('new', sideLine.newLineNumber);
-                              } else {
-                                const min = Math.min(startLine.lineNumber, actualEndLine);
-                                const max = Math.max(startLine.lineNumber, actualEndLine);
-                                handleAddComment('new', [min, max]);
-                              }
-
-                              setIsDragging(false);
-                              setStartLine(null);
-                              setEndLine(null);
-                            }}
-                          />
-                        </>
-                      )}
-                  </td>
-                  <td
-                    className={`w-1/2 p-0 align-top relative ${getSideBySideLineClass(sideLine.newLine, isExpandedLine(sideLine.newLine))} ${getSelectedLineStyle('new', sideLine)} ${highlightNewCell ? cellHighlightClass : ''}`}
-                  >
-                    {sideLine.newLine && (
-                      <div className="flex items-center relative min-h-[20px] px-3">
-                        {sideLine.wordLevelDiff ? (
-                          <WordLevelDiffHighlighter
-                            segments={sideLine.wordLevelDiff.newSegments}
-                            className="flex-1 text-github-text-primary whitespace-pre-wrap break-all overflow-wrap-break-word select-text"
-                          />
-                        ) : (
-                          <EnhancedPrismSyntaxHighlighter
-                            code={sideLine.newLine.content}
-                            className="flex-1 text-github-text-primary whitespace-pre-wrap break-all overflow-wrap-break-word select-text [&_pre]:m-0 [&_pre]:p-0 [&_pre]:!bg-transparent [&_pre]:font-inherit [&_pre]:text-inherit [&_pre]:leading-inherit [&_code]:!bg-transparent [&_code]:font-inherit [&_code]:text-inherit [&_code]:leading-inherit"
-                            syntaxTheme={syntaxTheme}
-                            filename={filename}
-                          />
-                        )}
-                      </div>
-                    )}
-                  </td>
-                </tr>
-
-                {/* Comments row */}
-                {allComments.length > 0 && (
-                  <tr className="bg-github-bg-secondary">
-                    <td colSpan={4} className="p-0 border-t border-github-border">
-                      {allComments.map((comment) => {
-                        // Determine layout based on comment's side
-                        const commentSide = comment.side || 'new';
-                        let layout: 'left' | 'right' | 'full';
-
-                        if (commentSide === 'old' && sideLine.oldLineNumber) {
-                          layout = 'left';
-                        } else if (commentSide === 'new' && sideLine.newLineNumber) {
-                          layout = 'right';
-                        } else {
-                          layout = getCommentLayout(sideLine);
-                        }
-
-                        return (
-                          <div
-                            key={comment.id}
-                            className={`flex ${
-                              layout === 'left'
-                                ? 'justify-start'
-                                : layout === 'right'
-                                  ? 'justify-end'
-                                  : 'justify-center'
-                            }`}
-                          >
-                            <div className={`${layout === 'full' ? 'w-full' : 'w-1/2'}`}>
-                              <div className="m-2 mx-3">
-                                <InlineComment
-                                  comment={comment}
-                                  onGeneratePrompt={onGeneratePrompt}
-                                  onRemoveComment={onRemoveComment}
-                                  onUpdateComment={onUpdateComment}
-                                  syntaxTheme={syntaxTheme}
-                                />
-                              </div>
-                            </div>
-                          </div>
-                        );
-                      })}
-                    </td>
-                  </tr>
-                )}
-
-                {/* Comment form row */}
-                {commentingLine &&
-                  ((commentingLine.side === 'old' &&
-                    commentingLine.lineNumber === sideLine.oldLineNumber) ||
-                    (commentingLine.side === 'new' &&
-                      commentingLine.lineNumber === sideLine.newLineNumber) ||
-                    (Array.isArray(commentingLine.lineNumber) &&
-                      ((commentingLine.side === 'new' &&
-                        commentingLine.lineNumber[1] === sideLine.newLineNumber) ||
-                        (commentingLine.side === 'old' &&
-                          commentingLine.lineNumber[1] === sideLine.oldLineNumber)))) && (
-                    <tr className="bg-github-bg-secondary">
-                      <td colSpan={4} className="p-0">
-                        <div
-                          className={`flex ${
-                            commentingLine.side === 'old'
-                              ? 'justify-start'
-                              : commentingLine.side === 'new'
-                                ? 'justify-end'
-                                : 'justify-center'
-                          }`}
-                        >
-                          <div className={`w-1/2`}>
-                            <CommentForm
-                              onSubmit={handleSubmitComment}
-                              onCancel={handleCancelComment}
-                              selectedCode={getSelectedCodeContent()}
-                              syntaxTheme={syntaxTheme}
-                              filename={filename}
-                            />
-                          </div>
-                        </div>
-                      </td>
-                    </tr>
-                  )}
-              </React.Fragment>
-            );
-          })}
+          {shouldVirtualizeSplit && paddingBottom > 0 && (
+            <tr aria-hidden="true">
+              <td colSpan={4} className="p-0 border-0" style={{ height: `${paddingBottom}px` }} />
+            </tr>
+          )}
         </tbody>
       </table>
     </div>

--- a/src/client/hooks/keyboardNavigation/scrollUtils.ts
+++ b/src/client/hooks/keyboardNavigation/scrollUtils.ts
@@ -1,4 +1,5 @@
 import { NAVIGATION_SELECTORS } from '../../constants/navigation';
+import { scrollToVirtualRowById } from '../../utils/virtualScrollRegistry';
 
 import { SCROLL_CONSTANTS } from './types';
 
@@ -9,7 +10,10 @@ import { SCROLL_CONSTANTS } from './types';
 export function createScrollToElement() {
   return (elementId: string): void => {
     const element = document.getElementById(elementId);
-    if (!element) return;
+    if (!element) {
+      scrollToVirtualRowById(elementId);
+      return;
+    }
 
     // The main scrollable container is always the same in this app
     const scrollContainer = document.querySelector(

--- a/src/client/utils/virtualScrollRegistry.ts
+++ b/src/client/utils/virtualScrollRegistry.ts
@@ -1,0 +1,54 @@
+type ScrollHandler = () => void;
+
+declare global {
+  interface Window {
+    __difitVirtualRowScrollRegistry?: Map<string, ScrollHandler>;
+  }
+}
+
+function getRegistry(): Map<string, ScrollHandler> | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  if (!window.__difitVirtualRowScrollRegistry) {
+    window.__difitVirtualRowScrollRegistry = new Map<string, ScrollHandler>();
+  }
+
+  return window.__difitVirtualRowScrollRegistry;
+}
+
+export function registerVirtualRowScrollHandlers(handlers: Map<string, ScrollHandler>): () => void {
+  const registry = getRegistry();
+  if (!registry) {
+    return () => undefined;
+  }
+
+  handlers.forEach((handler, id) => {
+    registry.set(id, handler);
+  });
+
+  return () => {
+    handlers.forEach((handler, id) => {
+      const current = registry.get(id);
+      if (current === handler) {
+        registry.delete(id);
+      }
+    });
+  };
+}
+
+export function scrollToVirtualRowById(id: string): boolean {
+  const registry = getRegistry();
+  if (!registry) {
+    return false;
+  }
+
+  const handler = registry.get(id);
+  if (!handler) {
+    return false;
+  }
+
+  handler();
+  return true;
+}

--- a/src/types/diff.ts
+++ b/src/types/diff.ts
@@ -165,3 +165,14 @@ export interface ExpandedRange {
 export interface ExpandedLine extends DiffLine {
   isExpanded?: boolean;
 }
+
+export type VirtualDiffRowKind = 'line' | 'inlineComment' | 'commentForm' | 'expander';
+
+export interface VirtualDiffRow {
+  id: string;
+  kind: VirtualDiffRowKind;
+  filePath: string;
+  chunkIndex: number;
+  lineIndex: number;
+  estimatedHeight: number;
+}


### PR DESCRIPTION
## 概要
大きな差分での描画負荷を下げるため、差分行レンダリングに仮想化を導入しました。  
本PRは **仮想化本体のみ** を対象にしています。

## 変更内容
- `@tanstack/react-virtual` を追加
- `DiffChunk`（unified）に行仮想化を導入
- `SideBySideDiffChunk`（split）に行仮想化を導入
- 可変高さ行（コメント・フォーム）を含む仮想行モデルに対応
- DOM未マウント行へのスクロールフォールバックを追加
  - `scrollUtils` で仮想行レジストリにフォールバック
  - `virtualScrollRegistry` を新規追加
- `DiffLineRow` に `measureRef` を追加
- `VirtualDiffRow` 型を追加（内部型）

## 非対象（このPRでは未実施）
- ナビゲーション索引化
- サーバー側パーサー最適化
- API/CLI仕様変更

## 動作確認
- `pnpm check`
- `pnpm test`
- `pnpm build`
- `pnpm perf -- --size small --iterations 1 --memo virtualization-pr`
  - average operation time: `24.98ms`
- `pnpm perf -- --size large --iterations 1 --memo virtualization-pr`
  - average operation time: `42.00ms`

## 互換性
既存のUI仕様（コメント、展開、レビュー済み、open-in-editor、キーボード操作）を維持する前提で実装しています。
