### PR TITLE
feat(pr): import reviewer comments for --pr

### DIFF
--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -17,12 +17,13 @@ vi.mock('./utils.js', async () => {
     findUntrackedFiles: vi.fn(),
     markFilesIntentToAdd: vi.fn(),
     getPrPatch: vi.fn(),
+    getPrReviewComments: vi.fn(),
   };
 });
 
 const { simpleGit } = await import('simple-git');
 const { startServer } = await import('../server/server.js');
-const { promptUser, findUntrackedFiles, markFilesIntentToAdd, getPrPatch } =
+const { promptUser, findUntrackedFiles, markFilesIntentToAdd, getPrPatch, getPrReviewComments } =
   await import('./utils.js');
 
 describe('CLI index.ts', () => {
@@ -32,6 +33,7 @@ describe('CLI index.ts', () => {
   let mockFindUntrackedFiles: any;
   let mockMarkFilesIntentToAdd: any;
   let mockGetPrPatch: any;
+  let mockGetPrReviewComments: any;
 
   // Store original console methods
   let originalConsoleLog: any;
@@ -57,6 +59,7 @@ describe('CLI index.ts', () => {
     mockFindUntrackedFiles = vi.mocked(findUntrackedFiles);
     mockMarkFilesIntentToAdd = vi.mocked(markFilesIntentToAdd);
     mockGetPrPatch = vi.mocked(getPrPatch);
+    mockGetPrReviewComments = vi.mocked(getPrReviewComments);
 
     // Mock console and process.exit
     originalConsoleLog = console.log;
@@ -467,7 +470,21 @@ describe('CLI index.ts', () => {
     it('loads PR patch with gh and starts server with stdin diff', async () => {
       const prUrl = 'https://github.com/owner/repo/pull/123';
       const prPatch = 'diff --git a/file.ts b/file.ts\nindex 1111111..2222222 100644\n';
+      const prComments = [
+        {
+          id: 'github-pr-review:1',
+          file: 'file.ts',
+          line: 12,
+          body: 'Imported review comment',
+          timestamp: '2024-01-01T00:00:00Z',
+          side: 'new',
+          source: 'github-pr-review',
+          author: 'reviewer',
+          readOnly: true,
+        },
+      ];
       mockGetPrPatch.mockReturnValue(prPatch);
+      mockGetPrReviewComments.mockReturnValue(prComments);
 
       const program = new Command();
 
@@ -490,6 +507,7 @@ describe('CLI index.ts', () => {
 
           await startServer({
             stdinDiff: getPrPatch(options.pr),
+            prComments: getPrReviewComments(options.pr),
             preferredPort: options.port,
             host: options.host,
             openBrowser: options.open,
@@ -500,8 +518,10 @@ describe('CLI index.ts', () => {
       await program.parseAsync(['--pr', prUrl], { from: 'user' });
 
       expect(mockGetPrPatch).toHaveBeenCalledWith(prUrl);
+      expect(mockGetPrReviewComments).toHaveBeenCalledWith(prUrl);
       expect(mockStartServer).toHaveBeenCalledWith({
         stdinDiff: prPatch,
+        prComments,
         preferredPort: undefined,
         host: '',
         openBrowser: true,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6,7 +6,7 @@ import { simpleGit, type SimpleGit } from 'simple-git';
 
 import pkg from '../../package.json' with { type: 'json' };
 import { startServer } from '../server/server.js';
-import { type DiffViewMode } from '../types/diff.js';
+import { type Comment, type DiffViewMode } from '../types/diff.js';
 import { DiffMode } from '../types/watch.js';
 import { DEFAULT_DIFF_VIEW_MODE, normalizeDiffViewMode } from '../utils/diffMode.js';
 
@@ -17,6 +17,7 @@ import {
   promptUser,
   validateDiffArguments,
   getPrPatch,
+  getPrReviewComments,
   getGitRoot,
 } from './utils.js';
 
@@ -93,6 +94,7 @@ program
     try {
       let stdinDiff: string | undefined;
       let stdinReviewLabel = 'diff from stdin';
+      let prComments: Comment[] = [];
 
       if (options.pr) {
         if (commitish !== 'HEAD' || compareWith) {
@@ -107,6 +109,7 @@ program
 
         try {
           stdinDiff = getPrPatch(options.pr);
+          prComments = getPrReviewComments(options.pr);
           stdinReviewLabel = options.pr;
         } catch (error) {
           console.error(
@@ -137,6 +140,7 @@ program
         // Start server with stdin diff (including --pr patch)
         const { url } = await startServer({
           stdinDiff,
+          prComments,
           preferredPort: options.port,
           host: options.host,
           openBrowser: options.open,

--- a/src/cli/utils.test.ts
+++ b/src/cli/utils.test.ts
@@ -1,7 +1,22 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { execFileSyncMock, execSyncMock } = vi.hoisted(() => ({
+  execFileSyncMock: vi.fn(),
+  execSyncMock: vi.fn(),
+}));
+
+vi.mock('child_process', () => ({
+  execFileSync: execFileSyncMock,
+  execSync: execSyncMock,
+  default: {
+    execFileSync: execFileSyncMock,
+    execSync: execSyncMock,
+  },
+}));
 
 import {
   detectStdinSource,
+  getPrReviewComments,
   parseGitHubPrUrl,
   shortHash,
   shouldReadStdin,
@@ -9,7 +24,15 @@ import {
   validateDiffArguments,
 } from './utils';
 
+const { execFileSync } = await import('child_process');
+
+const mockExecFileSync = vi.mocked(execFileSync);
+
 describe('CLI Utils', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   describe('stdin detection', () => {
     it('detects pipe from stdin stat', () => {
       expect(
@@ -469,6 +492,121 @@ describe('CLI Utils', () => {
       expect(parseGitHubPrUrl('https://github.com')).toBe(null);
       expect(parseGitHubPrUrl('https://github.com/owner')).toBe(null);
       expect(parseGitHubPrUrl('https://github.com/owner/repo/pull')).toBe(null);
+    });
+  });
+
+  describe('getPrReviewComments', () => {
+    it('fetches and normalizes non-author review comments', () => {
+      mockExecFileSync
+        .mockReturnValueOnce(JSON.stringify({ user: { login: 'author' } }) as never)
+        .mockReturnValueOnce(
+          JSON.stringify([
+            [
+              {
+                id: 10,
+                path: 'src/file.ts',
+                body: 'Looks good overall',
+                created_at: '2024-01-01T00:00:00Z',
+                html_url: 'https://github.com/owner/repo/pull/123#discussion_r10',
+                line: 42,
+                side: 'RIGHT',
+                user: { login: 'reviewer-a' },
+              },
+              {
+                id: 11,
+                path: 'src/file.ts',
+                body: 'Author self-review',
+                created_at: '2024-01-01T00:01:00Z',
+                line: 45,
+                side: 'RIGHT',
+                user: { login: 'author' },
+              },
+            ],
+            [
+              {
+                id: 12,
+                path: 'src/file.ts',
+                body: 'Range comment',
+                created_at: '2024-01-01T00:02:00Z',
+                start_line: 10,
+                line: 12,
+                start_side: 'LEFT',
+                side: 'LEFT',
+                user: { login: 'reviewer-b' },
+              },
+            ],
+          ]) as never,
+        );
+
+      const result = getPrReviewComments('https://github.com/owner/repo/pull/123');
+
+      expect(result).toEqual([
+        {
+          id: 'github-pr-review:10',
+          file: 'src/file.ts',
+          line: 42,
+          body: 'Looks good overall',
+          timestamp: '2024-01-01T00:00:00Z',
+          side: 'new',
+          source: 'github-pr-review',
+          author: 'reviewer-a',
+          readOnly: true,
+          url: 'https://github.com/owner/repo/pull/123#discussion_r10',
+        },
+        {
+          id: 'github-pr-review:12',
+          file: 'src/file.ts',
+          line: [10, 12],
+          body: 'Range comment',
+          timestamp: '2024-01-01T00:02:00Z',
+          side: 'old',
+          source: 'github-pr-review',
+          author: 'reviewer-b',
+          readOnly: true,
+          url: undefined,
+        },
+      ]);
+
+      expect(mockExecFileSync).toHaveBeenNthCalledWith(
+        1,
+        'gh',
+        ['api', 'repos/owner/repo/pulls/123'],
+        expect.objectContaining({ encoding: 'utf8' }),
+      );
+      expect(mockExecFileSync).toHaveBeenNthCalledWith(
+        2,
+        'gh',
+        ['api', '--paginate', '--slurp', 'repos/owner/repo/pulls/123/comments'],
+        expect.objectContaining({ encoding: 'utf8' }),
+      );
+    });
+
+    it('uses --hostname for GitHub Enterprise URLs', () => {
+      mockExecFileSync
+        .mockReturnValueOnce(JSON.stringify({ user: { login: 'author' } }) as never)
+        .mockReturnValueOnce(JSON.stringify([[]]) as never);
+
+      getPrReviewComments('https://git.company.io/team/project/pull/456');
+
+      expect(mockExecFileSync).toHaveBeenNthCalledWith(
+        1,
+        'gh',
+        ['api', '--hostname', 'git.company.io', 'repos/team/project/pulls/456'],
+        expect.objectContaining({ encoding: 'utf8' }),
+      );
+      expect(mockExecFileSync).toHaveBeenNthCalledWith(
+        2,
+        'gh',
+        [
+          'api',
+          '--hostname',
+          'git.company.io',
+          '--paginate',
+          '--slurp',
+          'repos/team/project/pulls/456/comments',
+        ],
+        expect.objectContaining({ encoding: 'utf8' }),
+      );
     });
   });
 });

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -3,6 +3,7 @@ import { fstatSync, type Stats } from 'node:fs';
 import { createInterface } from 'readline/promises';
 
 import type { SimpleGit } from 'simple-git';
+import { type Comment, type DiffSide } from '../types/diff.js';
 
 type StdinStat = Pick<Stats, 'isFIFO' | 'isFile' | 'isSocket'>;
 
@@ -133,6 +134,106 @@ interface PullRequestInfo {
   hostname: string;
 }
 
+interface GitHubPullRequestResponse {
+  user?: {
+    login?: string;
+  };
+}
+
+interface GitHubReviewCommentResponse {
+  id: number;
+  path?: string;
+  body?: string;
+  created_at?: string;
+  updated_at?: string;
+  html_url?: string;
+  line?: number | null;
+  start_line?: number | null;
+  original_line?: number | null;
+  original_start_line?: number | null;
+  side?: 'LEFT' | 'RIGHT' | null;
+  start_side?: 'LEFT' | 'RIGHT' | null;
+  subject_type?: 'line' | 'file';
+  user?: {
+    login?: string;
+  };
+}
+
+function buildGhArgs(hostname: string, args: string[]): string[] {
+  if (hostname === 'github.com' || args[0] !== 'api') {
+    return args;
+  }
+
+  return [args[0], '--hostname', hostname, ...args.slice(1)];
+}
+
+function runGhJsonCommand<T>(hostname: string, args: string[]): T {
+  const response = execFileSync('gh', buildGhArgs(hostname, args), {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  return JSON.parse(response) as T;
+}
+
+function mapGitHubCommentSide(
+  side: GitHubReviewCommentResponse['side'] | GitHubReviewCommentResponse['start_side'],
+): DiffSide {
+  return side === 'LEFT' ? 'old' : 'new';
+}
+
+function normalizeGitHubReviewCommentLine(
+  comment: GitHubReviewCommentResponse,
+): number | [number, number] | null {
+  const endLine = comment.line ?? comment.original_line;
+  if (!endLine || endLine <= 0) {
+    return null;
+  }
+
+  const startLine = comment.start_line ?? comment.original_start_line ?? endLine;
+  if (startLine <= 0) {
+    return endLine;
+  }
+
+  if (startLine === endLine) {
+    return endLine;
+  }
+
+  return [Math.min(startLine, endLine), Math.max(startLine, endLine)];
+}
+
+function normalizeGitHubReviewComment(
+  comment: GitHubReviewCommentResponse,
+  prAuthorLogin: string,
+): Comment | null {
+  if (!comment.path || !comment.body || comment.subject_type === 'file') {
+    return null;
+  }
+
+  const author = comment.user?.login;
+  if (!author || author === prAuthorLogin) {
+    return null;
+  }
+
+  const line = normalizeGitHubReviewCommentLine(comment);
+  if (!line) {
+    return null;
+  }
+
+  return {
+    id: `github-pr-review:${comment.id}`,
+    file: comment.path,
+    line,
+    body: comment.body,
+    timestamp: comment.created_at ?? new Date(0).toISOString(),
+    side: mapGitHubCommentSide(comment.side ?? comment.start_side ?? 'RIGHT'),
+    source: 'github-pr-review',
+    author,
+    readOnly: true,
+    url: comment.html_url,
+  };
+}
+
 export function parseGitHubPrUrl(url: string): PullRequestInfo | null {
   try {
     const urlObj = new URL(url);
@@ -183,6 +284,36 @@ export function getPrPatch(prArg: string): string {
       stderrText || (error instanceof Error ? error.message : 'Unknown error while running gh');
     throw new Error(`${message}\nTry: gh auth login`);
   }
+}
+
+export function getPrReviewComments(prArg: string): Comment[] {
+  const prInfo = parseGitHubPrUrl(prArg);
+  if (!prInfo) {
+    throw new Error('Invalid GitHub PR URL');
+  }
+
+  const pullRequest = runGhJsonCommand<GitHubPullRequestResponse>(prInfo.hostname, [
+    'api',
+    `repos/${prInfo.owner}/${prInfo.repo}/pulls/${prInfo.pullNumber}`,
+  ]);
+  const prAuthorLogin = pullRequest.user?.login;
+
+  if (!prAuthorLogin) {
+    throw new Error('Unable to determine PR author');
+  }
+
+  const comments = runGhJsonCommand<GitHubReviewCommentResponse[][]>(prInfo.hostname, [
+    'api',
+    '--paginate',
+    '--slurp',
+    `repos/${prInfo.owner}/${prInfo.repo}/pulls/${prInfo.pullNumber}/comments`,
+  ]);
+
+  return comments
+    .flat()
+    .map((comment) => normalizeGitHubReviewComment(comment, prAuthorLogin))
+    .filter((comment): comment is Comment => comment !== null)
+    .sort((a, b) => a.timestamp.localeCompare(b.timestamp));
 }
 
 export function validateDiffArguments(

--- a/src/client/App.test.tsx
+++ b/src/client/App.test.tsx
@@ -21,6 +21,7 @@ vi.mock('./hooks/useViewport', () => ({
 vi.mock('./hooks/useDiffComments', () => ({
   useDiffComments: vi.fn(() => ({
     comments: mockComments,
+    localComments: mockComments.filter((comment) => comment.readOnly !== true),
     addComment: vi.fn(),
     removeComment: vi.fn(),
     updateComment: vi.fn(),
@@ -98,6 +99,25 @@ Object.defineProperty(window, 'EventSource', {
   value: MockEventSource,
 });
 
+const localStorageStore = new Map<string, string>();
+const localStorageMock = {
+  getItem: vi.fn((key: string) => localStorageStore.get(key) ?? null),
+  setItem: vi.fn((key: string, value: string) => {
+    localStorageStore.set(key, value);
+  }),
+  removeItem: vi.fn((key: string) => {
+    localStorageStore.delete(key);
+  }),
+  clear: vi.fn(() => {
+    localStorageStore.clear();
+  }),
+};
+
+Object.defineProperty(window, 'localStorage', {
+  writable: true,
+  value: localStorageMock,
+});
+
 let mockComments: any[] = [];
 const mockClearAllComments = vi.fn();
 
@@ -111,6 +131,7 @@ const renderApp = () => {
 };
 
 beforeEach(() => {
+  localStorageStore.clear();
   window.localStorage.clear();
 });
 

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -107,9 +107,39 @@ function App() {
   const { settings, updateSettings } = useAppearanceSettings();
   const { isMobile, isDesktop } = useViewport();
 
+  const importedComments = useMemo(
+    () =>
+      (diffData?.comments ?? []).map((comment) => ({
+        id: comment.id,
+        filePath: comment.file,
+        body: comment.body,
+        createdAt: comment.timestamp,
+        updatedAt: comment.timestamp,
+        position: {
+          side: comment.side ?? 'new',
+          line:
+            typeof comment.line === 'number'
+              ? comment.line
+              : { start: comment.line[0], end: comment.line[1] },
+        },
+        codeSnapshot: comment.codeContent
+          ? {
+              content: comment.codeContent,
+              language: undefined,
+            }
+          : undefined,
+        source: comment.source ?? 'github-pr-review',
+        author: comment.author,
+        readOnly: comment.readOnly ?? true,
+        url: comment.url,
+      })),
+    [diffData?.comments],
+  );
+
   // New diff-aware comment system
   const {
     comments,
+    localComments,
     addComment,
     removeComment,
     updateComment,
@@ -122,6 +152,7 @@ function App() {
     diffData?.commit, // Using commit as currentCommitHash
     undefined, // branchToHash map - could be populated from server data
     diffData?.repositoryId, // Repository identifier for storage isolation
+    importedComments,
   );
 
   const normalizedComments = useMemo<Comment[]>(
@@ -137,6 +168,10 @@ function App() {
         timestamp: comment.createdAt,
         codeContent: comment.codeSnapshot?.content,
         side: comment.position.side,
+        source: comment.source,
+        author: comment.author,
+        readOnly: comment.readOnly,
+        url: comment.url,
       })),
     [comments],
   );
@@ -152,6 +187,10 @@ function App() {
         body: comment.body,
         timestamp: comment.createdAt,
         side: comment.position.side,
+        source: comment.source,
+        author: comment.author,
+        readOnly: comment.readOnly,
+        url: comment.url,
       })),
     [comments],
   );
@@ -168,7 +207,7 @@ function App() {
     });
     return map;
   }, [normalizedComments]);
-  const showMobileCommentsBar = isMobile && comments.length > 0;
+  const showMobileCommentsBar = isMobile && normalizedComments.length > 0;
 
   // Viewed files management
   const { viewedFiles, toggleFileViewed, clearViewedFiles } = useViewedFiles(
@@ -388,7 +427,7 @@ function App() {
       }
     },
     onDeleteAllComments: () => {
-      if (comments.length > 0 && confirm('Delete all comments?')) {
+      if (localComments.length > 0 && confirm('Delete all comments?')) {
         clearAllComments();
       }
     },
@@ -865,7 +904,8 @@ function App() {
             >
               {!isMobile && comments.length > 0 && (
                 <CommentsDropdown
-                  commentsCount={comments.length}
+                  commentsCount={normalizedComments.length}
+                  deletableCommentsCount={localComments.length}
                   isCopiedAll={isCopiedAll}
                   onCopyAll={handleCopyAllComments}
                   onDeleteAll={clearAllComments}
@@ -1117,7 +1157,8 @@ function App() {
         {showMobileCommentsBar && (
           <div className="fixed bottom-0 left-0 right-0 z-20 bg-github-bg-secondary border-t border-github-border px-4 py-2 flex justify-end">
             <CommentsDropdown
-              commentsCount={comments.length}
+              commentsCount={normalizedComments.length}
+              deletableCommentsCount={localComments.length}
               isCopiedAll={isCopiedAll}
               onCopyAll={handleCopyAllComments}
               onDeleteAll={clearAllComments}

--- a/src/client/components/CommentsDropdown.tsx
+++ b/src/client/components/CommentsDropdown.tsx
@@ -3,6 +3,7 @@ import { useState, useRef, useEffect } from 'react';
 
 interface CommentsDropdownProps {
   commentsCount: number;
+  deletableCommentsCount?: number;
   isCopiedAll: boolean;
   onCopyAll: () => void;
   onDeleteAll: () => void;
@@ -13,6 +14,7 @@ interface CommentsDropdownProps {
 
 export function CommentsDropdown({
   commentsCount,
+  deletableCommentsCount = commentsCount,
   isCopiedAll,
   onCopyAll,
   onDeleteAll,
@@ -24,6 +26,7 @@ export function CommentsDropdown({
   const dropdownRef = useRef<HTMLDivElement>(null);
   const isCompact = compact;
   const isUp = direction === 'up';
+  const canDelete = deletableCommentsCount > 0;
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -136,7 +139,8 @@ export function CommentsDropdown({
           )}
           <button
             onClick={handleDeleteAll}
-            className="w-full text-left px-3 py-2 text-xs flex items-center gap-2 text-github-text-primary hover:bg-github-bg-tertiary transition-colors"
+            className="w-full text-left px-3 py-2 text-xs flex items-center gap-2 text-github-text-primary hover:bg-github-bg-tertiary transition-colors disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent"
+            disabled={!canDelete}
           >
             <Eraser size={12} />
             Cleanup All Prompt

--- a/src/client/components/CommentsListModal.test.tsx
+++ b/src/client/components/CommentsListModal.test.tsx
@@ -181,6 +181,37 @@ describe('CommentsListModal', () => {
     expect(mockRemoveComment).toHaveBeenCalledWith('1');
   });
 
+  it('does not show resolve controls for read-only imported comments', () => {
+    const onClose = vi.fn();
+    const onNavigate = vi.fn();
+
+    render(
+      <CommentsListModal
+        isOpen={true}
+        onClose={onClose}
+        onNavigate={onNavigate}
+        comments={[
+          {
+            id: 'github-pr-review:1',
+            file: 'src/file1.ts',
+            line: 99,
+            body: 'Imported',
+            timestamp: '2024-01-01T00:00:00Z',
+            readOnly: true,
+            source: 'github-pr-review',
+            author: 'reviewer',
+          },
+        ]}
+        onRemoveComment={mockRemoveComment}
+        onGeneratePrompt={mockGeneratePrompt}
+        onUpdateComment={mockUpdateComment}
+      />,
+      { wrapper },
+    );
+
+    expect(screen.queryByTitle('Resolve')).not.toBeInTheDocument();
+  });
+
   it('should show empty state when no comments', () => {
     const onClose = vi.fn();
     const onNavigate = vi.fn();

--- a/src/client/components/CommentsListModal.tsx
+++ b/src/client/components/CommentsListModal.tsx
@@ -54,6 +54,9 @@ export function CommentsListModal({
 
   const handleDeleteComment = useCallback(
     (comment: Comment) => {
+      if (comment.readOnly) {
+        return;
+      }
       if (confirm(`Delete this comment?\n\n"${comment.body}"`)) {
         onRemoveComment(comment.id);
         // Adjust selected index if needed

--- a/src/client/components/InlineComment.tsx
+++ b/src/client/components/InlineComment.tsx
@@ -27,6 +27,7 @@ export function InlineComment({
   onClick,
   syntaxTheme,
 }: InlineCommentProps) {
+  const isReadOnly = comment.readOnly === true;
   const [isCopied, setIsCopied] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
   const [editedBody, setEditedBody] = useState(comment.body);
@@ -50,6 +51,9 @@ export function InlineComment({
 
   const handleStartEdit = (e: React.MouseEvent) => {
     e.stopPropagation();
+    if (isReadOnly) {
+      return;
+    }
     setIsEditing(true);
     setEditMode('edit');
     setEditedBody(comment.body);
@@ -72,6 +76,9 @@ export function InlineComment({
 
   const handleRemove = (e: React.MouseEvent) => {
     e.stopPropagation();
+    if (isReadOnly) {
+      return;
+    }
     onRemoveComment(comment.id);
   };
 
@@ -118,6 +125,16 @@ export function InlineComment({
     >
       <div className="flex items-center justify-between mb-2 gap-3">
         <div className="flex items-center gap-2 text-xs text-github-text-secondary flex-1 min-w-0">
+          {comment.author && (
+            <span className="font-medium text-github-text-primary whitespace-nowrap">
+              @{comment.author}
+            </span>
+          )}
+          {comment.source === 'github-pr-review' && (
+            <span className="px-1 py-0.5 rounded bg-github-bg-secondary border border-github-border whitespace-nowrap">
+              GitHub Review
+            </span>
+          )}
           <span
             className="font-mono px-1 py-0.5 rounded overflow-hidden text-ellipsis whitespace-nowrap"
             style={{
@@ -192,20 +209,24 @@ export function InlineComment({
               >
                 {isCopied ? 'Copied!' : 'Copy Prompt'}
               </button>
-              <button
-                onClick={handleStartEdit}
-                className="text-xs p-1.5 bg-github-bg-tertiary text-github-text-secondary border border-github-border rounded hover:text-github-text-primary hover:bg-github-bg-primary transition-all"
-                title="Edit"
-              >
-                <Edit2 size={12} />
-              </button>
-              <button
-                onClick={handleRemove}
-                className="text-xs p-1.5 bg-github-bg-tertiary text-green-600 border border-github-border rounded hover:bg-green-500/10 hover:border-green-600 transition-all"
-                title="Resolve"
-              >
-                <Check size={12} />
-              </button>
+              {!isReadOnly && (
+                <>
+                  <button
+                    onClick={handleStartEdit}
+                    className="text-xs p-1.5 bg-github-bg-tertiary text-github-text-secondary border border-github-border rounded hover:text-github-text-primary hover:bg-github-bg-primary transition-all"
+                    title="Edit"
+                  >
+                    <Edit2 size={12} />
+                  </button>
+                  <button
+                    onClick={handleRemove}
+                    className="text-xs p-1.5 bg-github-bg-tertiary text-green-600 border border-github-border rounded hover:bg-green-500/10 hover:border-green-600 transition-all"
+                    title="Resolve"
+                  >
+                    <Check size={12} />
+                  </button>
+                </>
+              )}
             </>
           )}
         </div>

--- a/src/client/hooks/useDiffComments.test.ts
+++ b/src/client/hooks/useDiffComments.test.ts
@@ -289,5 +289,52 @@ const next = true;
 
       expect(result.current.comments).toHaveLength(0);
     });
+
+    it('combines imported comments with local comments and keeps imported comments read-only', () => {
+      const importedComment = {
+        id: 'github-pr-review:1',
+        filePath: 'src/imported.ts',
+        body: 'Imported review comment',
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+        position: {
+          side: 'new' as const,
+          line: 11,
+        },
+        source: 'github-pr-review' as const,
+        author: 'reviewer',
+        readOnly: true,
+      };
+
+      const { result } = renderHook(() =>
+        useDiffComments('main', 'feature-branch', 'abc123', undefined, undefined, [
+          importedComment,
+        ]),
+      );
+
+      act(() => {
+        result.current.addComment({
+          filePath: 'src/local.ts',
+          body: 'Local comment',
+          side: 'new',
+          line: 15,
+        });
+      });
+
+      expect(result.current.comments).toHaveLength(2);
+      expect(result.current.localComments).toHaveLength(1);
+      expect(result.current.comments[0]?.id).toBe('github-pr-review:1');
+      expect(result.current.comments[0]?.readOnly).toBe(true);
+
+      act(() => {
+        result.current.removeComment('github-pr-review:1');
+      });
+
+      expect(result.current.comments).toHaveLength(2);
+
+      const prompt = result.current.generatePrompt('github-pr-review:1');
+      expect(prompt).toContain('[GitHub review by @reviewer]');
+      expect(prompt).toContain('Imported review comment');
+    });
   });
 });

--- a/src/client/hooks/useDiffComments.ts
+++ b/src/client/hooks/useDiffComments.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 
 import { type DiffComment, type DiffSide } from '../../types/diff';
 import { formatCommentPrompt, formatAllCommentsPrompt } from '../../utils/commentFormatting';
@@ -15,6 +15,7 @@ interface AddCommentParams {
 
 interface UseDiffCommentsReturn {
   comments: DiffComment[];
+  localComments: DiffComment[];
   addComment: (params: AddCommentParams) => DiffComment;
   removeComment: (commentId: string) => void;
   updateComment: (commentId: string, newBody: string) => void;
@@ -29,8 +30,9 @@ export function useDiffComments(
   currentCommitHash?: string,
   branchToHash?: Map<string, string>,
   repositoryId?: string,
+  importedComments: DiffComment[] = [],
 ): UseDiffCommentsReturn {
-  const [comments, setComments] = useState<DiffComment[]>([]);
+  const [localComments, setLocalComments] = useState<DiffComment[]>([]);
 
   // Load comments from storage when commitish changes
   useEffect(() => {
@@ -44,7 +46,7 @@ export function useDiffComments(
       repositoryId,
     );
     // oxlint-disable-next-line react-hooks-js/set-state-in-effect -- intentional: sync state from external storage on prop change
-    setComments(loadedComments);
+    setLocalComments(loadedComments);
   }, [baseCommitish, targetCommitish, currentCommitHash, branchToHash, repositoryId]);
 
   // Save comments to storage
@@ -60,9 +62,24 @@ export function useDiffComments(
         branchToHash,
         repositoryId,
       );
-      setComments(newComments);
+      setLocalComments(newComments);
     },
     [baseCommitish, targetCommitish, currentCommitHash, branchToHash, repositoryId],
+  );
+
+  const normalizedImportedComments = useMemo(
+    () =>
+      importedComments.map((comment) => ({
+        ...comment,
+        source: comment.source ?? 'github-pr-review',
+        readOnly: comment.readOnly ?? true,
+      })),
+    [importedComments],
+  );
+
+  const comments = useMemo(
+    () => [...normalizedImportedComments, ...localComments],
+    [normalizedImportedComments, localComments],
   );
 
   const addComment = useCallback(
@@ -81,31 +98,33 @@ export function useDiffComments(
           content: '',
           language: getLanguageFromPath(params.filePath),
         },
+        source: 'local',
+        readOnly: false,
       };
 
-      const newComments = [...comments, newComment];
+      const newComments = [...localComments, newComment];
       saveComments(newComments);
       return newComment;
     },
-    [comments, saveComments],
+    [localComments, saveComments],
   );
 
   const removeComment = useCallback(
     (commentId: string) => {
-      const newComments = comments.filter((c) => c.id !== commentId);
+      const newComments = localComments.filter((c) => c.id !== commentId);
       saveComments(newComments);
     },
-    [comments, saveComments],
+    [localComments, saveComments],
   );
 
   const updateComment = useCallback(
     (commentId: string, newBody: string) => {
-      const newComments = comments.map((c) =>
+      const newComments = localComments.map((c) =>
         c.id === commentId ? { ...c, body: newBody, updatedAt: new Date().toISOString() } : c,
       );
       saveComments(newComments);
     },
-    [comments, saveComments],
+    [localComments, saveComments],
   );
 
   const clearAllComments = useCallback(() => {
@@ -127,6 +146,10 @@ export function useDiffComments(
         line,
         comment.body,
         comment.codeSnapshot?.content,
+        {
+          source: comment.source,
+          author: comment.author,
+        },
       );
     },
     [comments],
@@ -143,6 +166,10 @@ export function useDiffComments(
       body: comment.body,
       timestamp: comment.createdAt,
       codeContent: comment.codeSnapshot?.content,
+      source: comment.source,
+      author: comment.author,
+      readOnly: comment.readOnly,
+      url: comment.url,
     }));
 
     return formatAllCommentsPrompt(transformedComments);
@@ -150,6 +177,7 @@ export function useDiffComments(
 
   return {
     comments,
+    localComments,
     addComment,
     removeComment,
     updateComment,

--- a/src/server/server.test.ts
+++ b/src/server/server.test.ts
@@ -442,6 +442,41 @@ describe('Server Integration Tests', () => {
       expect(data).toHaveProperty('openInEditorAvailable', false);
     });
 
+    it('GET /api/diff includes imported PR comments for stdin diff', async () => {
+      const stdinServer = await startServer({
+        stdinDiff: 'diff --git a/stdin-test.js b/stdin-test.js',
+        prComments: [
+          {
+            id: 'github-pr-review:1',
+            file: 'stdin-test.js',
+            line: 7,
+            body: 'Imported PR comment',
+            timestamp: '2024-01-01T00:00:00Z',
+            side: 'new',
+            source: 'github-pr-review',
+            author: 'reviewer',
+            readOnly: true,
+          },
+        ],
+        preferredPort: 9037,
+      });
+      servers.push(stdinServer.server);
+
+      const response = await fetch(`http://localhost:${stdinServer.port}/api/diff`);
+      const data = (await response.json()) as any;
+
+      expect(response.ok).toBe(true);
+      expect(data.comments).toEqual([
+        expect.objectContaining({
+          id: 'github-pr-review:1',
+          file: 'stdin-test.js',
+          body: 'Imported PR comment',
+          author: 'reviewer',
+          readOnly: true,
+        }),
+      ]);
+    });
+
     it('GET /api/generated-status/* returns 400 for stdin diff', async () => {
       const stdinServer = await startServer({
         stdinDiff: 'diff --git a/stdin-test.js b/stdin-test.js',

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -29,6 +29,7 @@ interface ServerOptions {
   targetCommitish?: string;
   baseCommitish?: string;
   stdinDiff?: string;
+  prComments?: Comment[];
   preferredPort?: number;
   host?: string;
   openBrowser?: boolean;
@@ -152,6 +153,7 @@ export async function startServer(
 
     res.json({
       ...diffDataCache,
+      comments: options.prComments ?? [],
       ignoreWhitespace,
       mode: diffMode,
       openInEditorAvailable: !options.stdinDiff,

--- a/src/types/diff.ts
+++ b/src/types/diff.ts
@@ -39,10 +39,12 @@ export interface ParsedDiff {
 export type DiffViewMode = 'split' | 'unified';
 export type LegacyDiffViewMode = 'side-by-side' | 'inline';
 export type DiffSide = 'old' | 'new';
+export type CommentSource = 'local' | 'github-pr-review';
 
 export interface DiffResponse {
   commit: string;
   files: DiffFile[];
+  comments?: Comment[];
   ignoreWhitespace?: boolean;
   isEmpty?: boolean;
   mode?: DiffViewMode | LegacyDiffViewMode;
@@ -72,6 +74,10 @@ export interface Comment {
   timestamp: string;
   codeContent?: string; // The actual code content for this line
   side?: DiffSide; // Which side the comment is on
+  source?: CommentSource;
+  author?: string;
+  readOnly?: boolean;
+  url?: string;
 }
 
 export interface LineSelection {
@@ -87,6 +93,10 @@ export interface DiffComment {
   body: string;
   createdAt: string; // ISO 8601 format
   updatedAt: string; // ISO 8601 format
+  source?: CommentSource;
+  author?: string;
+  readOnly?: boolean;
+  url?: string;
 
   // Comment position
   position: {

--- a/src/utils/commentFormatting.test.ts
+++ b/src/utils/commentFormatting.test.ts
@@ -87,6 +87,15 @@ const newCode = 42;
       expect(result).toContain('SUGGESTED:');
       expect(result).toContain('const newCode = 42;');
     });
+
+    it('should include GitHub review attribution when formatting imported comments', () => {
+      const result = formatCommentPrompt('src/file.ts', 10, 'Please rename this', undefined, {
+        source: 'github-pr-review',
+        author: 'reviewer',
+      });
+
+      expect(result).toBe('src/file.ts:L10\n[GitHub review by @reviewer]\nPlease rename this');
+    });
   });
 
   describe('formatAllCommentsPrompt', () => {

--- a/src/utils/commentFormatting.ts
+++ b/src/utils/commentFormatting.ts
@@ -1,24 +1,42 @@
-import type { Comment } from '../types/diff';
+import type { Comment, CommentSource } from '../types/diff';
 
 import { hasSuggestionBlock, parseSuggestionBlocks } from './suggestionUtils.js';
+
+interface CommentPromptOptions {
+  source?: CommentSource;
+  author?: string;
+}
+
+function getCommentMetadataLine(options?: CommentPromptOptions): string | null {
+  if (options?.source !== 'github-pr-review') {
+    return null;
+  }
+
+  return options.author ? `[GitHub review by @${options.author}]` : '[GitHub review]';
+}
 
 export function formatCommentPrompt(
   file: string,
   line: number | number[],
   body: string,
   codeContent?: string,
+  options?: CommentPromptOptions,
 ): string {
   const lineInfo =
     typeof line === 'number' ? `L${line}` : Array.isArray(line) ? `L${line[0]}-L${line[1]}` : '';
 
   // Handle undefined or null file paths
   const filePath = file || '<unknown file>';
+  const metadataLine = getCommentMetadataLine(options);
 
   // Check if body contains suggestion blocks
   if (hasSuggestionBlock(body)) {
     const suggestions = parseSuggestionBlocks(body);
     if (suggestions.length > 0) {
       let result = `${filePath}:${lineInfo}`;
+      if (metadataLine) {
+        result += `\n${metadataLine}`;
+      }
 
       // Walk through body preserving text between suggestion blocks
       let lastIndex = 0;
@@ -49,14 +67,22 @@ export function formatCommentPrompt(
   }
 
   // Regular comment without suggestion
-  return `${filePath}:${lineInfo}\n${body}`;
+  const parts = [`${filePath}:${lineInfo}`];
+  if (metadataLine) {
+    parts.push(metadataLine);
+  }
+  parts.push(body);
+  return parts.join('\n');
 }
 
 export function formatAllCommentsPrompt(comments: Comment[]): string {
   if (comments.length === 0) return '';
 
   const prompts = comments.map((comment) =>
-    formatCommentPrompt(comment.file, comment.line, comment.body, comment.codeContent),
+    formatCommentPrompt(comment.file, comment.line, comment.body, comment.codeContent, {
+      source: comment.source,
+      author: comment.author,
+    }),
   );
 
   return prompts.join('\n=====\n');


### PR DESCRIPTION
Hi! 

I really like this project. For the `--pr` function, I also wanted to fetch GitHub review comments to (a) show inline and (b) copy for LLM context.

The comments are shown inline with the only difference being that they have a `GitHub` tag, are not editable (there is no sync) and not resolvable in difit (one has to resolve them on the PR)

--
This PR was entirely generated by GPT 5.4 High with Codex.
If you think the idea is worthwhile, I'd invest time in reviewing the code and creating a ready PR :)