### PR TITLE
feat: add Elixir language support

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -168,7 +168,7 @@ npx skills add yoshiko-pg/difit
 - **JavaScript/TypeScript**：`.js`, `.jsx`, `.ts`, `.tsx`
 - **Web技術**：HTML, CSS, JSON, XML, Markdown
 - **シェルスクリプト**：`.sh`, `.bash`, `.zsh`, `.fish`
-- **バックエンド言語**：PHP, SQL, Ruby, Java, Scala, Perl
+- **バックエンド言語**：PHP, SQL, Ruby, Java, Scala, Perl, Elixir
 - **システム言語**：C, C++, C#, Rust, Go
 - **モバイル言語**：Swift, Kotlin, Dart
 - **IaC**：Terraform (HCL)

--- a/README.ko.md
+++ b/README.ko.md
@@ -168,7 +168,7 @@ npx skills add yoshiko-pg/difit
 - **JavaScript/TypeScript**: `.js`, `.jsx`, `.ts`, `.tsx`
 - **웹 기술**: HTML, CSS, JSON, XML, Markdown
 - **셸 스크립트**: `.sh`, `.bash`, `.zsh`, `.fish`
-- **백엔드 언어**: PHP, SQL, Ruby, Java, Scala, Perl
+- **백엔드 언어**: PHP, SQL, Ruby, Java, Scala, Perl, Elixir
 - **시스템 언어**: C, C++, C#, Rust, Go
 - **모바일 언어**: Swift, Kotlin, Dart
 - **인프라 코드**: Terraform (HCL)

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ After an agent edits code, it will start the difit server.
 - **JavaScript/TypeScript**: `.js`, `.jsx`, `.ts`, `.tsx`
 - **Web Technologies**: HTML, CSS, JSON, XML, Markdown
 - **Shell Scripts**: `.sh`, `.bash`, `.zsh`, `.fish`
-- **Backend Languages**: PHP, SQL, Ruby, Java, Scala, Perl
+- **Backend Languages**: PHP, SQL, Ruby, Java, Scala, Perl, Elixir
 - **Systems Languages**: C, C++, C#, Rust, Go
 - **Mobile Languages**: Swift, Kotlin, Dart
 - **Infrastructure as Code**: Terraform (HCL)

--- a/README.zh.md
+++ b/README.zh.md
@@ -168,7 +168,7 @@ npx skills add yoshiko-pg/difit
 - **JavaScript/TypeScript**：`.js`, `.jsx`, `.ts`, `.tsx`
 - **Web 技术**：HTML, CSS, JSON, XML, Markdown
 - **Shell 脚本**：`.sh`, `.bash`, `.zsh`, `.fish`
-- **后端语言**：PHP, SQL, Ruby, Java, Scala, Perl
+- **后端语言**：PHP, SQL, Ruby, Java, Scala, Perl, Elixir
 - **系统语言**：C, C++, C#, Rust, Go
 - **移动语言**：Swift, Kotlin, Dart
 - **基础设施即代码**：Terraform (HCL)

--- a/src/client/utils/languageDetection.ts
+++ b/src/client/utils/languageDetection.ts
@@ -41,6 +41,9 @@ const DIFF_EXTENSION_LANGUAGE_MAP: Record<string, string> = {
   markdown: 'markdown',
   tex: 'latex',
   vim: 'vim',
+  ex: 'elixir',
+  exs: 'elixir',
+  heex: 'elixir',
 };
 
 // Prism syntax highlighting: use Prism language IDs (e.g. tsx -> tsx, scss -> css).
@@ -98,6 +101,9 @@ const PRISM_EXTENSION_LANGUAGE_MAP: Record<string, string> = {
   tf: 'hcl',
   tfvars: 'hcl',
   hcl: 'hcl',
+  ex: 'elixir',
+  exs: 'elixir',
+  heex: 'elixir',
 };
 
 const PRISM_FILENAME_LANGUAGE_MAP: Record<string, string> = {

--- a/src/client/utils/languageLoader.ts
+++ b/src/client/utils/languageLoader.ts
@@ -31,6 +31,7 @@ export function loadPrismLanguage(lang: string): Promise<void> {
       protobuf: () => import('prismjs/components/prism-protobuf.js'),
       hcl: () => import('prismjs/components/prism-hcl.js'),
       perl: () => import('prismjs/components/prism-perl.js'),
+      elixir: () => import('prismjs/components/prism-elixir.js'),
     };
 
     const importFn = languageImports[lang];


### PR DESCRIPTION
## Summary
- Add syntax highlighting support for Elixir files (`.ex`, `.exs`, `.heex`)
- Add extension mappings in `languageDetection.ts` for both diff metadata and Prism highlighting
- Add dynamic Prism.js loader for `prism-elixir` component
- Update all README locales (EN, JA, ZH, KO)