### PR TITLE
fix: decode literal UTF-8 characters correctly in git paths

### DIFF
--- a/src/server/git-diff.test.ts
+++ b/src/server/git-diff.test.ts
@@ -515,6 +515,21 @@ describe('GitDiffParser', () => {
       expect(result.isGenerated).toBe(false);
     });
 
+    it('parses file paths with literal unescaped Japanese characters', () => {
+      const diffLines = [
+        'diff --git a/テスト/file.txt b/テスト/file.txt',
+        'new file mode 100644',
+        'index 0000000..257cc56',
+        '--- /dev/null',
+        '+++ b/テスト/file.txt',
+        '@@ -0,0 +1 @@',
+        '+content',
+      ];
+      const result = (parser as any).parseFileBlock(diffLines.join('\n'), null);
+      expect(result).toBeDefined();
+      expect(result.path).toBe('テスト/file.txt');
+    });
+
     it('decodes unquoted octal escapes in diff headers', () => {
       const diffLines = [
         'diff --git a/some\\040folder/file\\040name.ts b/some\\040folder/file\\040name.ts',

--- a/src/server/git-diff.ts
+++ b/src/server/git-diff.ts
@@ -177,14 +177,14 @@ export class GitDiffParser {
             bytes.push(0x20);
             break;
           default:
-            bytes.push(next.charCodeAt(0));
+            bytes.push(...Buffer.from(next, 'utf8'));
             break;
         }
         i++; // Skip the escaped character
         continue;
       }
 
-      bytes.push(char.charCodeAt(0));
+      bytes.push(...Buffer.from(char, 'utf8'));
     }
 
     return Buffer.from(bytes).toString('utf8');


### PR DESCRIPTION
# Summary
- Fix mojibake for Japanese directory/file names in the file-tree panel when core.quotePath=false
- Use proper UTF-8 byte encoding in decodeGitPath() for non-ASCII characters
- Add test case for literal (unquoted) Japanese paths

# ScreenShots

For example, if there is a `ほげ/a.txt`, then 

## Before
<img width="600" height="253" alt="スクリーンショット 2026-03-12 22 24 36" src="https://github.com/user-attachments/assets/639597c6-0339-41ce-8739-10cb4e232a84" />

## After
<img width="584" height="248" alt="スクリーンショット 2026-03-12 22 24 23" src="https://github.com/user-attachments/assets/2ca74053-556e-43d2-9c92-164ef62bf31f" />

# Cause
`decodeGitPath()` used `charCodeAt(0)` to convert each character to a byte. This works for ASCII, but for Japanese characters , `charCodeAt(0)` returns the UTF-16 code unit 0x3042, which Buffer.from(bytes) truncates to 8 bits (0x3042 & 0xFF = 0x42 = 'B'), producing mojibake.

# Fix
Replace `charCodeAt(0)` with `Buffer.from(char, 'utf8')` to properly encode multi-byte characters as UTF-8 byte sequences.

# Test
- All 515 existing tests pass with no regressions
- New test case for literal Japanese path added