### PR TITLE
Fix flaky keyboard navigation benchmark comparisons in CI

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,10 +1,11 @@
-name: Performance Test
+name: Keyboard Navigation Benchmark
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
       - 'src/**'
+      - 'scripts/**'
       - '.github/workflows/performance.yml'
 
 jobs:
@@ -12,6 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      PERF_SIZE: medium
+      PERF_ITERATIONS: '2'
+      PERF_WARMUP_ITERATIONS: '1'
+      PERF_DIFF_SEED: performance-ci-medium-v1
 
     steps:
       - name: Setup Node.js
@@ -67,44 +73,79 @@ jobs:
           pnpm install --frozen-lockfile
           pnpm build
 
-      - name: Run performance test on head branch
-        id: head-perf
+      - name: Generate deterministic benchmark input
         working-directory: head
         run: |
-          pnpm perf --size medium --iterations 3
-          # Get the latest result file
-          RESULT_FILE=$(ls -t performance-results/perf-medium-*.json | head -1)
-          echo "result_file=$RESULT_FILE" >> $GITHUB_OUTPUT
+          mkdir -p ../performance-inputs
+          node scripts/generate-large-diff.js --size "$PERF_SIZE" --seed "$PERF_DIFF_SEED" > ../performance-inputs/perf-"$PERF_SIZE".diff
 
-      - name: Run performance test on base branch
-        id: base-perf
+      - name: Run base benchmark round 1
         working-directory: base
         run: |
-          # Install playwright in base directory if needed
-          # This ensures the test can run even if base branch doesn't have playwright
-          if ! pnpm list playwright >/dev/null 2>&1; then
-            echo "Installing playwright for base branch testing..."
-            pnpm add -D playwright
-            pnpm exec playwright install chromium
-          fi
+          node ../head/scripts/measure-performance.js \
+            --size "$PERF_SIZE" \
+            --iterations "$PERF_ITERATIONS" \
+            --warmup-iterations "$PERF_WARMUP_ITERATIONS" \
+            --diff-file ../performance-inputs/perf-"$PERF_SIZE".diff \
+            --output performance-results/base-round-1.json \
+            --memo "ci round 1 (base first)" \
+            --difit-path ../base/dist/cli/index.js
 
-          # Run performance test using head's script but base's build
-          # The script will create results in the head directory's performance-results
-          node ../head/scripts/measure-performance.js --size medium --iterations 3 --difit-path ../base/dist/cli/index.js
+      - name: Run head benchmark round 1
+        working-directory: head
+        run: |
+          node scripts/measure-performance.js \
+            --size "$PERF_SIZE" \
+            --iterations "$PERF_ITERATIONS" \
+            --warmup-iterations "$PERF_WARMUP_ITERATIONS" \
+            --diff-file ../performance-inputs/perf-"$PERF_SIZE".diff \
+            --output performance-results/head-round-1.json \
+            --memo "ci round 1 (head second)"
 
-          # Get the latest result file from head directory
-          RESULT_FILE=$(ls -t ../head/performance-results/perf-medium-*.json | head -1)
-          echo "result_file=$RESULT_FILE" >> $GITHUB_OUTPUT
+      - name: Run head benchmark round 2
+        working-directory: head
+        run: |
+          node scripts/measure-performance.js \
+            --size "$PERF_SIZE" \
+            --iterations "$PERF_ITERATIONS" \
+            --warmup-iterations "$PERF_WARMUP_ITERATIONS" \
+            --diff-file ../performance-inputs/perf-"$PERF_SIZE".diff \
+            --output performance-results/head-round-2.json \
+            --memo "ci round 2 (head first)"
+
+      - name: Run base benchmark round 2
+        working-directory: base
+        run: |
+          node ../head/scripts/measure-performance.js \
+            --size "$PERF_SIZE" \
+            --iterations "$PERF_ITERATIONS" \
+            --warmup-iterations "$PERF_WARMUP_ITERATIONS" \
+            --diff-file ../performance-inputs/perf-"$PERF_SIZE".diff \
+            --output performance-results/base-round-2.json \
+            --memo "ci round 2 (base second)" \
+            --difit-path ../base/dist/cli/index.js
+
+      - name: Merge benchmark results
+        working-directory: head
+        run: |
+          node scripts/merge-performance-results.js \
+            --output performance-results/base-merged.json \
+            ../base/performance-results/base-round-1.json \
+            ../base/performance-results/base-round-2.json
+          node scripts/merge-performance-results.js \
+            --output performance-results/head-merged.json \
+            performance-results/head-round-1.json \
+            performance-results/head-round-2.json
 
       - name: Compare performance
         id: compare
         working-directory: head
         run: |
           # Run comparison script and output markdown directly to GitHub Step Summary
-          node scripts/compare-performance.js ${{ steps.base-perf.outputs.result_file }} ${{ steps.head-perf.outputs.result_file }} >> $GITHUB_STEP_SUMMARY
+          node scripts/compare-performance.js performance-results/base-merged.json performance-results/head-merged.json >> $GITHUB_STEP_SUMMARY
 
           # Also get JSON output for status check
-          COMPARISON_JSON=$(node scripts/compare-performance.js ${{ steps.base-perf.outputs.result_file }} ${{ steps.head-perf.outputs.result_file }} --json)
+          COMPARISON_JSON=$(node scripts/compare-performance.js performance-results/base-merged.json performance-results/head-merged.json --json)
 
           # Extract change percentage for status check
           CHANGE_PERCENT=$(echo "$COMPARISON_JSON" | jq -r '.changePercent')

--- a/scripts/compare-performance.js
+++ b/scripts/compare-performance.js
@@ -42,7 +42,7 @@ function formatMilliseconds(ms) {
 function generateMarkdownTable(comparison) {
   const lines = [];
 
-  lines.push('# Performance Comparison Report\n');
+  lines.push('# Keyboard Navigation Benchmark Report\n');
 
   const baseline = comparison.baseline;
   const current = comparison.current;
@@ -75,9 +75,15 @@ function generateMarkdownTable(comparison) {
   // Test details
   lines.push('### Test Configuration');
   lines.push(
+    '- **Scope**: Synthetic diff keyboard navigation only (comment/thread rendering is not measured)',
+  );
+  lines.push(
     `- **Size**: ${baseline.size} (${baseline.totalFiles} files, ${baseline.totalLines} lines)`,
   );
-  lines.push(`- **Iterations**: ${baseline.iterations} → ${current.iterations}\n`);
+  lines.push(`- **Measured iterations**: ${baseline.iterations} → ${current.iterations}`);
+  lines.push(
+    `- **Discarded warm-up iterations**: ${baseline.warmupIterations} → ${current.warmupIterations}\n`,
+  );
 
   // Commit information in a more compact format
   lines.push('### Commits Compared');
@@ -118,6 +124,7 @@ function generateComparison(baselineResults, comparedResults) {
       totalFiles: baselineResults.stats.files,
       totalLines: baselineResults.stats.totalLines,
       iterations: baselineResults.config.iterations,
+      warmupIterations: baselineResults.config.warmupIterations ?? 0,
       averageOperationTime: baselineAvg,
     },
     current: {
@@ -132,6 +139,7 @@ function generateComparison(baselineResults, comparedResults) {
       totalFiles: comparedResults.stats.files,
       totalLines: comparedResults.stats.totalLines,
       iterations: comparedResults.config.iterations,
+      warmupIterations: comparedResults.config.warmupIterations ?? 0,
       averageOperationTime: comparedAvg,
     },
     difference,
@@ -231,8 +239,8 @@ async function main() {
   const outputFormat = args.includes('--json') ? 'json' : 'markdown';
 
   if (outputFormat !== 'json') {
-    log('Performance Comparison Tool');
-    log('===========================\n');
+    log('Keyboard Navigation Benchmark Tool');
+    log('==================================\n');
     log('Loading performance results...');
   }
 

--- a/scripts/generate-large-diff.js
+++ b/scripts/generate-large-diff.js
@@ -10,6 +10,67 @@ const config = {
   },
 };
 
+const defaultSeed = 'difit-performance-default-v1';
+
+function parseArgs(argv) {
+  let size = 'medium';
+  let seed = defaultSeed;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+
+    if (arg === '--size' && argv[i + 1]) {
+      size = argv[++i];
+      continue;
+    }
+
+    if (arg === '--seed' && argv[i + 1]) {
+      seed = argv[++i];
+      continue;
+    }
+
+    if (!arg.startsWith('--') && size === 'medium') {
+      size = arg;
+    }
+  }
+
+  return { size, seed };
+}
+
+function hashString(value) {
+  let hash = 2166136261;
+
+  for (const char of value) {
+    hash ^= char.charCodeAt(0);
+    hash = Math.imul(hash, 16777619);
+  }
+
+  return hash >>> 0;
+}
+
+function createRandom(seed) {
+  let state = hashString(seed) || 1;
+
+  return () => {
+    state += 0x6d2b79f5;
+    let next = state;
+    next = Math.imul(next ^ (next >>> 15), next | 1);
+    next ^= next + Math.imul(next ^ (next >>> 7), next | 61);
+    return ((next ^ (next >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function createTimestampFactory(seed) {
+  const baseTime = Date.UTC(2026, 0, 1, 0, 0, 0) + hashString(seed) * 1000;
+  let index = 0;
+
+  return () => {
+    const timestamp = new Date(baseTime + index * 1000).toISOString();
+    index++;
+    return timestamp;
+  };
+}
+
 function generateFileContent(fileIndex, lines) {
   const chunks = [];
 
@@ -76,7 +137,7 @@ export function Component${fileIndex}({ id, data, onUpdate }: Component${fileInd
   return chunks.join('');
 }
 
-function generateModifiedFileContent(fileIndex, lines) {
+function generateModifiedFileContent(fileIndex, lines, random, nextTimestamp) {
   const content = generateFileContent(fileIndex, lines);
   const lines_array = content.split('\n');
 
@@ -85,19 +146,18 @@ function generateModifiedFileContent(fileIndex, lines) {
   const modifiedLines = new Set();
 
   for (let i = 0; i < modifications; i++) {
-    const lineIndex = Math.floor(Math.random() * lines_array.length);
+    const lineIndex = Math.floor(random() * lines_array.length);
     if (!modifiedLines.has(lineIndex) && lines_array[lineIndex].trim()) {
       modifiedLines.add(lineIndex);
 
       // Different types of modifications
-      const modType = Math.random();
+      const modType = random();
       if (modType < 0.3) {
         // Change variable names
         lines_array[lineIndex] = lines_array[lineIndex].replace(/item/g, 'element');
       } else if (modType < 0.6) {
         // Add comments
-        lines_array[lineIndex] =
-          `  // Modified: ${new Date().toISOString()}\n${lines_array[lineIndex]}`;
+        lines_array[lineIndex] = `  // Modified: ${nextTimestamp()}\n${lines_array[lineIndex]}`;
       } else {
         // Change string literals
         lines_array[lineIndex] = lines_array[lineIndex].replace(/'([^']+)'/g, "'modified-$1'");
@@ -108,8 +168,8 @@ function generateModifiedFileContent(fileIndex, lines) {
   // Add some new lines
   const additions = Math.floor(lines * 0.1); // Add 10% new lines
   for (let i = 0; i < additions; i++) {
-    const insertIndex = Math.floor(Math.random() * lines_array.length);
-    lines_array.splice(insertIndex, 0, `  // New line added at ${new Date().toISOString()}`);
+    const insertIndex = Math.floor(random() * lines_array.length);
+    lines_array.splice(insertIndex, 0, `  // New line added at ${nextTimestamp()}`);
   }
 
   return lines_array.join('\n');
@@ -162,14 +222,16 @@ function generateUnifiedDiff(filename, oldContent, newContent) {
   return diff.join('\n');
 }
 
-function generateDiff(size) {
+function generateDiff(size, seed) {
   const { files, linesPerFile } = config.sizes[size];
   const diffs = [];
+  const random = createRandom(`${seed}:${size}`);
+  const nextTimestamp = createTimestampFactory(`${seed}:${size}`);
 
   for (let i = 0; i < files; i++) {
     const filename = `src/components/Component${i}.tsx`;
     const oldContent = generateFileContent(i, linesPerFile);
-    const newContent = generateModifiedFileContent(i, linesPerFile);
+    const newContent = generateModifiedFileContent(i, linesPerFile, random, nextTimestamp);
 
     diffs.push(generateUnifiedDiff(filename, oldContent, newContent));
   }
@@ -179,8 +241,7 @@ function generateDiff(size) {
 
 // Main function
 function main() {
-  const args = process.argv.slice(2);
-  const size = args[0] || 'medium';
+  const { size, seed } = parseArgs(process.argv.slice(2));
 
   if (!config.sizes[size]) {
     console.error(`Invalid size: ${size}`);
@@ -188,7 +249,7 @@ function main() {
     process.exit(1);
   }
 
-  const diff = generateDiff(size);
+  const diff = generateDiff(size, seed);
   console.log(diff);
 }
 

--- a/scripts/measure-performance.js
+++ b/scripts/measure-performance.js
@@ -5,7 +5,7 @@ import { exec, spawn } from 'child_process';
 import { promisify } from 'util';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { promises as fs } from 'fs';
+import { createReadStream, promises as fs } from 'fs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const execAsync = promisify(exec);
@@ -63,16 +63,16 @@ async function getGitInfo() {
   }
 }
 
-async function startDifitServer(size, difitPath) {
+async function startDifitServer(size, options = {}) {
   log('Starting difit server...', colors.blue);
 
   let actualPort = config.port;
+  let diffInput;
 
   // Use provided difit path or default
-  const difitBinaryPath = difitPath || path.join(__dirname, '..', 'dist', 'cli', 'index.js');
+  const difitBinaryPath =
+    options.difitPath || path.join(__dirname, '..', 'dist', 'cli', 'index.js');
 
-  // Generate diff and pipe to difit
-  const generateDiff = spawn('node', [path.join(__dirname, 'generate-large-diff.js'), size]);
   const difitProcess = spawn(
     'node',
     [difitBinaryPath, '--port', config.port.toString(), '--no-open'],
@@ -81,8 +81,25 @@ async function startDifitServer(size, difitPath) {
     },
   );
 
-  // Pipe diff to difit
-  generateDiff.stdout.pipe(difitProcess.stdin);
+  if (options.diffFile) {
+    diffInput = createReadStream(path.resolve(options.diffFile));
+    diffInput.on('error', (error) => {
+      log(`  Diff input error: ${error.message}`, colors.red);
+    });
+    diffInput.pipe(difitProcess.stdin);
+  } else {
+    const generateArgs = [path.join(__dirname, 'generate-large-diff.js'), '--size', size];
+
+    if (options.diffSeed) {
+      generateArgs.push('--seed', options.diffSeed);
+    }
+
+    diffInput = spawn('node', generateArgs);
+    diffInput.stdout.pipe(difitProcess.stdin);
+    diffInput.stderr.on('data', (data) => {
+      log(`  Diff generator error: ${data.toString().trim()}`, colors.red);
+    });
+  }
 
   // Promise to wait for server start
   const serverStarted = new Promise((resolve) => {
@@ -101,10 +118,6 @@ async function startDifitServer(size, difitPath) {
     difitProcess.stderr.on('data', (data) => {
       log(`  Server error: ${data.toString().trim()}`, colors.red);
     });
-
-    generateDiff.stderr.on('data', (data) => {
-      log(`  Diff generator error: ${data.toString().trim()}`, colors.red);
-    });
   });
 
   // Wait for server to start and get actual port
@@ -113,7 +126,7 @@ async function startDifitServer(size, difitPath) {
     new Promise((resolve) => setTimeout(() => resolve(actualPort), 5000)),
   ]);
 
-  return { process: difitProcess, port };
+  return { process: difitProcess, port, diffInput };
 }
 
 async function measureKeyboardNavigation(page) {
@@ -210,6 +223,7 @@ async function measurePerformance(size, options = {}) {
   const { files, linesPerFile } = config.sizes[size];
   const totalLines = files * linesPerFile;
   const results = [];
+  const warmupResults = [];
 
   log(`\nRunning performance test (${size})...`, colors.yellow);
   log(
@@ -223,16 +237,25 @@ async function measurePerformance(size, options = {}) {
   });
 
   const iterations = options.iterations || config.defaultIterations;
+  const warmupIterations = options.warmupIterations || 0;
+  const totalIterations = warmupIterations + iterations;
 
-  for (let i = 0; i < iterations; i++) {
-    log(`\nIteration ${i + 1}/${iterations}`, colors.blue);
+  if (warmupIterations > 0) {
+    log(`Warm-up iterations discarded: ${warmupIterations}`, colors.yellow);
+  }
 
-    const { process: difitProcess, port: actualPort } = await startDifitServer(
-      size,
-      options.difitPath,
-    );
+  for (let i = 0; i < totalIterations; i++) {
+    const isWarmup = i < warmupIterations;
+    log(`\nIteration ${i + 1}/${totalIterations}${isWarmup ? ' (warm-up)' : ''}`, colors.blue);
+
+    const {
+      process: difitProcess,
+      port: actualPort,
+      diffInput,
+    } = await startDifitServer(size, options);
     const iterationMetrics = {
-      iteration: i + 1,
+      iteration: isWarmup ? i + 1 : i + 1 - warmupIterations,
+      phase: isWarmup ? 'warmup' : 'measured',
       timestamp: new Date().toISOString(),
     };
 
@@ -286,14 +309,27 @@ async function measurePerformance(size, options = {}) {
       iterationMetrics.performanceData = perfData;
 
       await context.close();
-      results.push(iterationMetrics);
+      if (isWarmup) {
+        warmupResults.push(iterationMetrics);
+      } else {
+        results.push(iterationMetrics);
+      }
     } catch (error) {
       log(`  Error: ${error.message}`, colors.red);
       iterationMetrics.error = error.message;
-      results.push(iterationMetrics);
+      if (isWarmup) {
+        warmupResults.push(iterationMetrics);
+      } else {
+        results.push(iterationMetrics);
+      }
     } finally {
       // Kill the process
       difitProcess.kill('SIGTERM');
+      if (diffInput?.kill) {
+        diffInput.kill('SIGTERM');
+      } else if (diffInput?.destroy) {
+        diffInput.destroy();
+      }
       await new Promise((resolve) => setTimeout(resolve, 1000));
     }
   }
@@ -305,8 +341,10 @@ async function measurePerformance(size, options = {}) {
     stats: { files, linesPerFile, totalLines },
     config: {
       iterations: iterations,
+      warmupIterations,
     },
     results,
+    warmupResults,
     summary: calculateSummary(results),
   };
 }
@@ -372,7 +410,19 @@ async function main() {
   const positionalArgs = args.filter((arg, index) => {
     if (arg.startsWith('--')) return false;
     // Skip flag values
-    if (index > 0 && ['--size', '--memo', '--iterations', '--difit-path'].includes(args[index - 1]))
+    if (
+      index > 0 &&
+      [
+        '--size',
+        '--memo',
+        '--iterations',
+        '--warmup-iterations',
+        '--difit-path',
+        '--diff-file',
+        '--seed',
+        '--output',
+      ].includes(args[index - 1])
+    )
       return false;
     return true;
   });
@@ -389,6 +439,15 @@ async function main() {
   const difitPathIndex = args.indexOf('--difit-path');
   const difitPath =
     difitPathIndex !== -1 && args[difitPathIndex + 1] ? args[difitPathIndex + 1] : undefined;
+  const diffFileIndex = args.indexOf('--diff-file');
+  const diffFile =
+    diffFileIndex !== -1 && args[diffFileIndex + 1] ? args[diffFileIndex + 1] : undefined;
+  const diffSeedIndex = args.indexOf('--seed');
+  const diffSeed =
+    diffSeedIndex !== -1 && args[diffSeedIndex + 1] ? args[diffSeedIndex + 1] : undefined;
+  const outputIndex = args.indexOf('--output');
+  const outputPath =
+    outputIndex !== -1 && args[outputIndex + 1] ? args[outputIndex + 1] : undefined;
 
   const options = {
     headless: !args.includes('--headed'),
@@ -396,7 +455,12 @@ async function main() {
     iterations: args.includes('--iterations')
       ? parseInt(args[args.indexOf('--iterations') + 1])
       : undefined,
+    warmupIterations: args.includes('--warmup-iterations')
+      ? parseInt(args[args.indexOf('--warmup-iterations') + 1])
+      : undefined,
     difitPath,
+    diffFile,
+    diffSeed,
   };
 
   if (!config.sizes[size]) {
@@ -407,9 +471,13 @@ async function main() {
     log(`  --size <size>        Size of diff to test (default: medium)`);
     log(`  --headed             Run tests in headed mode (show browser)`);
     log(`  --iterations <n>     Number of iterations (default: ${config.defaultIterations})`);
+    log(`  --warmup-iterations <n>  Warm-up iterations to discard (default: 0)`);
     log(`  --memo <text>        Add a memo to the results`);
     log(`  --devtools           Open browser devtools`);
     log(`  --difit-path <path>  Path to difit CLI (default: dist/cli/index.js)`);
+    log(`  --diff-file <path>   Use an existing diff file instead of generating one`);
+    log(`  --seed <value>       Seed for deterministic diff generation`);
+    log(`  --output <path>      Write results to a specific file`);
     process.exit(1);
   }
 
@@ -429,6 +497,11 @@ async function main() {
     duration: totalTime,
     gitInfo,
     memo,
+    benchmark: {
+      name: 'keyboard-navigation',
+      diffFile,
+      diffSeed: diffSeed || null,
+    },
     environment: {
       node: process.version,
       platform: process.platform,
@@ -444,9 +517,12 @@ async function main() {
   log(
     `Valid iterations: ${results.results.filter((r) => !r.error).length}/${results.config.iterations}`,
   );
+  if (results.config.warmupIterations > 0) {
+    log(`Discarded warm-up iterations: ${results.config.warmupIterations}`);
+  }
 
   if (results.summary.keyboardNavigation.averageOperationTime > 0) {
-    log(`\nKeyboard Navigation Performance:`);
+    log(`\nKeyboard Navigation Benchmark:`);
     log(
       `  Average operation time: ${results.summary.keyboardNavigation.averageOperationTime.toFixed(2)}ms`,
     );
@@ -461,12 +537,12 @@ async function main() {
   }
 
   // Save results
-  const resultsDir = path.join(__dirname, '..', 'performance-results');
-  await fs.mkdir(resultsDir, { recursive: true });
-
   const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-  const resultsFile = path.join(resultsDir, `perf-${size}-${timestamp}.json`);
+  const resultsFile = outputPath
+    ? path.resolve(outputPath)
+    : path.join(__dirname, '..', 'performance-results', `perf-${size}-${timestamp}.json`);
 
+  await fs.mkdir(path.dirname(resultsFile), { recursive: true });
   await fs.writeFile(resultsFile, JSON.stringify(results, null, 2));
   log(`\nResults saved to: ${resultsFile}`, colors.green);
 

--- a/scripts/merge-performance-results.js
+++ b/scripts/merge-performance-results.js
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+
+import { promises as fs } from 'fs';
+import path from 'path';
+
+async function loadPerformanceResults(filePath) {
+  try {
+    const content = await fs.readFile(filePath, 'utf-8');
+    return JSON.parse(content);
+  } catch (error) {
+    throw new Error(`Failed to load ${filePath}: ${error.message}`);
+  }
+}
+
+function calculateSummary(results) {
+  const summary = {
+    keyboardNavigation: {
+      averageOperationTime: 0,
+      operationBreakdown: {},
+    },
+  };
+
+  const validResults = results.filter((result) => !result.error);
+
+  if (validResults.length === 0) {
+    return summary;
+  }
+
+  const allOperationTimes = validResults.map(
+    (result) => result.keyboardNavigation.averageOperationTime,
+  );
+  summary.keyboardNavigation.averageOperationTime =
+    allOperationTimes.reduce((total, value) => total + value, 0) / allOperationTimes.length;
+
+  const operationTypes = {};
+  validResults.forEach((result) => {
+    result.keyboardNavigation.operations.forEach((operation) => {
+      if (!operationTypes[operation.type]) {
+        operationTypes[operation.type] = {
+          count: 0,
+          totalAverage: 0,
+          totalMax: 0,
+        };
+      }
+
+      operationTypes[operation.type].count++;
+      operationTypes[operation.type].totalAverage += operation.average;
+      operationTypes[operation.type].totalMax += operation.max;
+    });
+  });
+
+  Object.entries(operationTypes).forEach(([type, data]) => {
+    summary.keyboardNavigation.operationBreakdown[type] = {
+      averageTime: data.totalAverage / data.count,
+      averageMaxTime: data.totalMax / data.count,
+    };
+  });
+
+  return summary;
+}
+
+function validateCompatibleResults(results, filePaths) {
+  const [first, ...rest] = results;
+
+  for (let index = 0; index < rest.length; index++) {
+    const current = rest[index];
+    const filePath = filePaths[index + 1];
+
+    if (current.size !== first.size) {
+      throw new Error(
+        `Cannot merge different sizes: ${filePaths[0]} (${first.size}) vs ${filePath} (${current.size})`,
+      );
+    }
+
+    if (current.metadata?.gitInfo?.commitHash !== first.metadata?.gitInfo?.commitHash) {
+      throw new Error(`Cannot merge different commits: ${filePaths[0]} vs ${filePath}`);
+    }
+  }
+}
+
+function mergeResults(results, sourceFiles) {
+  const [first] = results;
+  const measuredResults = [];
+  const warmupResults = [];
+  const memos = new Set();
+
+  results.forEach((result, resultIndex) => {
+    const sourceFile = path.basename(sourceFiles[resultIndex]);
+
+    if (result.metadata?.memo) {
+      memos.add(result.metadata.memo);
+    }
+
+    result.results.forEach((entry, entryIndex) => {
+      measuredResults.push({
+        ...entry,
+        iteration: measuredResults.length + 1,
+        sourceFile,
+        sourceIteration: entry.iteration ?? entryIndex + 1,
+      });
+    });
+
+    for (const entry of result.warmupResults ?? []) {
+      warmupResults.push({
+        ...entry,
+        sourceFile,
+      });
+    }
+  });
+
+  return {
+    size: first.size,
+    stats: first.stats,
+    config: {
+      iterations: measuredResults.length,
+      warmupIterations: warmupResults.length,
+      mergedRuns: results.length,
+    },
+    results: measuredResults,
+    warmupResults,
+    summary: calculateSummary(measuredResults),
+    metadata: {
+      timestamp: new Date().toISOString(),
+      duration: results.reduce((total, result) => total + (result.metadata?.duration ?? 0), 0),
+      gitInfo: first.metadata?.gitInfo ?? null,
+      memo: Array.from(memos).join('; ') || undefined,
+      benchmark: {
+        ...(first.metadata?.benchmark ?? {}),
+        mergedFrom: sourceFiles.map((file) => path.basename(file)),
+      },
+      environment: first.metadata?.environment ?? null,
+    },
+  };
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const outputIndex = args.indexOf('--output');
+
+  if (outputIndex === -1 || !args[outputIndex + 1]) {
+    console.error('Usage: node scripts/merge-performance-results.js --output <file> <results...>');
+    process.exit(1);
+  }
+
+  const outputPath = path.resolve(args[outputIndex + 1]);
+  const inputFiles = args.filter((arg, index) => {
+    if (arg === '--output') return false;
+    if (index > 0 && args[index - 1] === '--output') return false;
+    return true;
+  });
+
+  if (inputFiles.length < 2) {
+    console.error('Provide at least two result files to merge.');
+    process.exit(1);
+  }
+
+  const resolvedInputFiles = inputFiles.map((file) => path.resolve(file));
+  const results = await Promise.all(resolvedInputFiles.map(loadPerformanceResults));
+  validateCompatibleResults(results, resolvedInputFiles);
+
+  const merged = mergeResults(results, resolvedInputFiles);
+  await fs.mkdir(path.dirname(outputPath), { recursive: true });
+  await fs.writeFile(outputPath, JSON.stringify(merged, null, 2));
+
+  console.log(outputPath);
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- make generated benchmark diffs deterministic with a seedable input generator
- reuse the same diff artifact for base and head runs in CI instead of regenerating per branch
- discard warm-up iterations and run two benchmark rounds with swapped execution order before comparing merged results
- clarify benchmark reporting as keyboard-navigation-only and include warm-up metadata in the comparison output
- add a merge script for combining multi-round benchmark results before CI comparison

## Testing
- `pnpm check`
- `pnpm test`
- `pnpm build`