### PR TITLE
feat: add auto-viewed file patterns

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -186,6 +186,7 @@ function App() {
     undefined,
     diffData?.files,
     diffData?.repositoryId, // Repository identifier for storage isolation
+    settings.autoViewedPatterns,
   );
 
   // Reset initialization flag when diff context changes
@@ -1127,12 +1128,14 @@ function App() {
           </div>
         )}
 
-        <SettingsModal
-          isOpen={isSettingsOpen}
-          onClose={() => setIsSettingsOpen(false)}
-          settings={settings}
-          onSettingsChange={updateSettings}
-        />
+        {isSettingsOpen && (
+          <SettingsModal
+            isOpen={isSettingsOpen}
+            onClose={() => setIsSettingsOpen(false)}
+            settings={settings}
+            onSettingsChange={updateSettings}
+          />
+        )}
 
         <HelpModal isOpen={isHelpOpen} onClose={() => setIsHelpOpen(false)} />
 

--- a/src/client/components/SettingsModal.test.tsx
+++ b/src/client/components/SettingsModal.test.tsx
@@ -25,6 +25,7 @@ const baseSettings = {
   syntaxTheme: 'vsDark',
   editor: 'cursor' as const,
   colorVision: 'normal' as const,
+  autoViewedPatterns: [],
 };
 
 describe('SettingsModal', () => {
@@ -86,6 +87,30 @@ describe('SettingsModal', () => {
     await waitFor(() => {
       expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
       expect(deuteranopiaButton).not.toHaveAttribute('aria-describedby');
+    });
+  });
+
+  it('edits auto-viewed patterns from the system section as newline-delimited values', () => {
+    const onSettingsChange = vi.fn();
+
+    render(
+      <SettingsModal
+        isOpen={true}
+        onClose={vi.fn()}
+        settings={baseSettings}
+        onSettingsChange={onSettingsChange}
+      />,
+      { wrapper },
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /^System/ }));
+
+    const textarea = screen.getByLabelText('Auto-Mark Viewed Patterns');
+    fireEvent.change(textarea, { target: { value: '*.test.ts\nsrc/generated/**' } });
+
+    expect(onSettingsChange).toHaveBeenLastCalledWith({
+      ...baseSettings,
+      autoViewedPatterns: ['*.test.ts', 'src/generated/**'],
     });
   });
 });

--- a/src/client/components/SettingsModal.tsx
+++ b/src/client/components/SettingsModal.tsx
@@ -4,6 +4,7 @@ import { useHotkeysContext } from 'react-hotkeys-hook';
 
 import { DEFAULT_EDITOR_ID, EDITOR_OPTIONS, type EditorOptionId } from '../../utils/editorOptions';
 import type { ColorVisionMode } from '../utils/appearanceTheme';
+import { formatAutoViewedPatterns, parseAutoViewedPatterns } from '../utils/autoViewedPatterns';
 import { LIGHT_THEMES, DARK_THEMES } from '../utils/themeLoader';
 import { Tooltip } from './Tooltip';
 
@@ -14,6 +15,7 @@ interface AppearanceSettings {
   syntaxTheme: string;
   editor: EditorOptionId;
   colorVision: ColorVisionMode;
+  autoViewedPatterns: string[];
 }
 
 interface SettingsModalProps {
@@ -33,6 +35,7 @@ const DEFAULT_SETTINGS: AppearanceSettings = {
   syntaxTheme: 'vsDark',
   editor: DEFAULT_EDITOR_ID,
   colorVision: 'normal',
+  autoViewedPatterns: [],
 };
 
 const FONT_FAMILIES = [
@@ -68,24 +71,11 @@ const SETTINGS_SECTIONS = [
 ] as const;
 
 export function SettingsModal({ isOpen, onClose, settings, onSettingsChange }: SettingsModalProps) {
-  const [localSettings, setLocalSettings] = useState<AppearanceSettings>(settings);
+  const [autoViewedPatternsInput, setAutoViewedPatternsInput] = useState(
+    formatAutoViewedPatterns(settings.autoViewedPatterns),
+  );
   const [activeSection, setActiveSection] = useState<SettingsSection>('appearance');
   const { enableScope, disableScope } = useHotkeysContext();
-
-  useEffect(() => {
-    setLocalSettings(settings);
-  }, [settings]);
-
-  useEffect(() => {
-    if (isOpen) {
-      setActiveSection('appearance');
-    }
-  }, [isOpen]);
-
-  // Apply changes immediately for real-time preview
-  useEffect(() => {
-    onSettingsChange(localSettings);
-  }, [localSettings, onSettingsChange]);
 
   // Manage scopes when modal opens/closes
   useEffect(() => {
@@ -105,10 +95,10 @@ export function SettingsModal({ isOpen, onClose, settings, onSettingsChange }: S
 
   // Get current theme (resolve 'auto' to actual theme)
   const getCurrentTheme = (): 'light' | 'dark' => {
-    if (localSettings.theme === 'auto') {
+    if (settings.theme === 'auto') {
       return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
     }
-    return localSettings.theme;
+    return settings.theme;
   };
 
   // Get available themes based on current background color
@@ -119,7 +109,7 @@ export function SettingsModal({ isOpen, onClose, settings, onSettingsChange }: S
 
   // Handle theme change and auto-select valid syntax theme
   const handleThemeChange = (theme: 'light' | 'dark' | 'auto') => {
-    const newSettings = { ...localSettings, theme };
+    const newSettings = { ...settings, theme };
 
     // Determine the effective theme
     const effectiveTheme =
@@ -131,7 +121,7 @@ export function SettingsModal({ isOpen, onClose, settings, onSettingsChange }: S
 
     // Check if current syntax theme is valid for the new theme
     const availableThemes = effectiveTheme === 'light' ? LIGHT_THEMES : DARK_THEMES;
-    const isCurrentThemeValid = availableThemes.some((t) => t.id === localSettings.syntaxTheme);
+    const isCurrentThemeValid = availableThemes.some((t) => t.id === settings.syntaxTheme);
 
     // If current theme becomes invalid, auto-select first item
     if (!isCurrentThemeValid && availableThemes.length > 0) {
@@ -141,13 +131,13 @@ export function SettingsModal({ isOpen, onClose, settings, onSettingsChange }: S
       }
     }
 
-    setLocalSettings(newSettings);
+    onSettingsChange(newSettings);
   };
 
   const handleReset = () => {
     if (activeSection === 'appearance') {
-      setLocalSettings({
-        ...localSettings,
+      onSettingsChange({
+        ...settings,
         fontSize: DEFAULT_SETTINGS.fontSize,
         fontFamily: DEFAULT_SETTINGS.fontFamily,
         theme: DEFAULT_SETTINGS.theme,
@@ -157,10 +147,12 @@ export function SettingsModal({ isOpen, onClose, settings, onSettingsChange }: S
       return;
     }
 
-    setLocalSettings({
-      ...localSettings,
+    onSettingsChange({
+      ...settings,
       editor: DEFAULT_SETTINGS.editor,
+      autoViewedPatterns: DEFAULT_SETTINGS.autoViewedPatterns,
     });
+    setAutoViewedPatternsInput(formatAutoViewedPatterns(DEFAULT_SETTINGS.autoViewedPatterns));
   };
 
   if (!isOpen) return null;
@@ -221,17 +213,17 @@ export function SettingsModal({ isOpen, onClose, settings, onSettingsChange }: S
                       min="10"
                       max="20"
                       step="1"
-                      value={localSettings.fontSize}
+                      value={settings.fontSize}
                       onChange={(e) =>
-                        setLocalSettings({
-                          ...localSettings,
+                        onSettingsChange({
+                          ...settings,
                           fontSize: Number.parseInt(e.target.value, 10),
                         })
                       }
                       className="flex-1 accent-github-accent"
                     />
                     <span className="text-sm text-github-text-secondary w-8 text-right">
-                      {localSettings.fontSize}px
+                      {settings.fontSize}px
                     </span>
                   </div>
                 </div>
@@ -241,10 +233,8 @@ export function SettingsModal({ isOpen, onClose, settings, onSettingsChange }: S
                     Font Family
                   </label>
                   <select
-                    value={localSettings.fontFamily}
-                    onChange={(e) =>
-                      setLocalSettings({ ...localSettings, fontFamily: e.target.value })
-                    }
+                    value={settings.fontFamily}
+                    onChange={(e) => onSettingsChange({ ...settings, fontFamily: e.target.value })}
                     className="w-full p-2 bg-github-bg-tertiary border border-github-border rounded text-github-text-primary text-sm"
                   >
                     {FONT_FAMILIES.map((font) => (
@@ -266,7 +256,7 @@ export function SettingsModal({ isOpen, onClose, settings, onSettingsChange }: S
                         type="button"
                         onClick={() => handleThemeChange(theme)}
                         className={`px-3 py-2 text-sm rounded border transition-colors ${
-                          localSettings.theme === theme
+                          settings.theme === theme
                             ? 'bg-github-accent text-white border-github-accent'
                             : 'bg-github-bg-tertiary text-github-text-secondary border-github-border hover:text-github-text-primary'
                         }`}
@@ -283,14 +273,12 @@ export function SettingsModal({ isOpen, onClose, settings, onSettingsChange }: S
                   </label>
                   <div className="flex gap-2">
                     {COLOR_VISION_MODES.map((mode) => {
-                      const isSelected = (localSettings.colorVision ?? 'normal') === mode.id;
+                      const isSelected = (settings.colorVision ?? 'normal') === mode.id;
                       const button = (
                         <button
                           key={mode.id}
                           type="button"
-                          onClick={() =>
-                            setLocalSettings({ ...localSettings, colorVision: mode.id })
-                          }
+                          onClick={() => onSettingsChange({ ...settings, colorVision: mode.id })}
                           className={`px-3 py-2 text-sm rounded border transition-colors ${
                             isSelected
                               ? 'bg-github-accent text-white border-github-accent'
@@ -319,10 +307,10 @@ export function SettingsModal({ isOpen, onClose, settings, onSettingsChange }: S
                     Syntax Highlighting Theme
                   </label>
                   <select
-                    value={localSettings.syntaxTheme}
+                    value={settings.syntaxTheme}
                     onChange={(e) =>
-                      setLocalSettings({
-                        ...localSettings,
+                      onSettingsChange({
+                        ...settings,
                         syntaxTheme: e.target.value,
                       })
                     }
@@ -345,10 +333,10 @@ export function SettingsModal({ isOpen, onClose, settings, onSettingsChange }: S
                     Open In Editor
                   </label>
                   <select
-                    value={localSettings.editor}
+                    value={settings.editor}
                     onChange={(e) =>
-                      setLocalSettings({
-                        ...localSettings,
+                      onSettingsChange({
+                        ...settings,
                         editor: e.target.value as AppearanceSettings['editor'],
                       })
                     }
@@ -360,6 +348,34 @@ export function SettingsModal({ isOpen, onClose, settings, onSettingsChange }: S
                       </option>
                     ))}
                   </select>
+                </div>
+
+                <div>
+                  <label
+                    htmlFor="auto-viewed-patterns"
+                    className="block text-sm font-medium text-github-text-primary mb-2"
+                  >
+                    Auto-Mark Viewed Patterns
+                  </label>
+                  <p className="text-sm text-github-text-secondary mb-2">
+                    Files matching these glob patterns are marked as Viewed automatically. Enter one
+                    pattern per line.
+                  </p>
+                  <textarea
+                    id="auto-viewed-patterns"
+                    value={autoViewedPatternsInput}
+                    onChange={(e) => {
+                      setAutoViewedPatternsInput(e.target.value);
+                      onSettingsChange({
+                        ...settings,
+                        autoViewedPatterns: parseAutoViewedPatterns(e.target.value),
+                      });
+                    }}
+                    rows={6}
+                    spellCheck={false}
+                    placeholder={'*.test.ts\n*.stories.tsx\nsrc/generated/**'}
+                    className="w-full p-3 bg-github-bg-tertiary border border-github-border rounded text-github-text-primary text-sm font-mono"
+                  />
                 </div>
               </div>
             )}

--- a/src/client/hooks/useAppearanceSettings.ts
+++ b/src/client/hooks/useAppearanceSettings.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 
 import { DEFAULT_EDITOR_ID } from '../../utils/editorOptions';
 import type { AppearanceSettings } from '../components/SettingsModal';
+import { normalizeAutoViewedPatterns } from '../utils/autoViewedPatterns';
 import {
   APPEARANCE_STORAGE_KEY,
   applyResolvedTheme,
@@ -17,6 +18,7 @@ const DEFAULT_SETTINGS: AppearanceSettings = {
   syntaxTheme: 'vsDark',
   editor: DEFAULT_EDITOR_ID,
   colorVision: 'normal',
+  autoViewedPatterns: [],
 };
 
 export function useAppearanceSettings() {
@@ -24,7 +26,15 @@ export function useAppearanceSettings() {
     try {
       const stored = localStorage.getItem(APPEARANCE_STORAGE_KEY);
       if (stored) {
-        return { ...DEFAULT_SETTINGS, ...(JSON.parse(stored) as AppearanceSettings) };
+        const parsed = JSON.parse(stored) as Partial<AppearanceSettings> & {
+          autoViewedPatterns?: unknown;
+        };
+
+        return {
+          ...DEFAULT_SETTINGS,
+          ...parsed,
+          autoViewedPatterns: normalizeAutoViewedPatterns(parsed.autoViewedPatterns),
+        };
       }
     } catch (error) {
       console.warn('Failed to load appearance settings from localStorage:', error);

--- a/src/client/hooks/useViewedFiles.test.ts
+++ b/src/client/hooks/useViewedFiles.test.ts
@@ -115,6 +115,26 @@ describe('useViewedFiles', () => {
       expect(mockSaveViewedFiles).toHaveBeenCalled();
     });
 
+    it('should auto-mark files matching configured auto-viewed patterns', async () => {
+      const initialFiles: DiffFile[] = [
+        createMockDiffFile('src/app.test.ts', 'modified', false),
+        createMockDiffFile('src/app.ts', 'modified', false),
+      ];
+
+      const { result } = renderHook(() =>
+        useViewedFiles('main', 'feature-branch', 'abc123', undefined, initialFiles, undefined, [
+          '*.test.ts',
+        ]),
+      );
+
+      await waitFor(() => {
+        expect(result.current.viewedFiles.has('src/app.test.ts')).toBe(true);
+      });
+
+      expect(result.current.viewedFiles.has('src/app.ts')).toBe(false);
+      expect(mockSaveViewedFiles).toHaveBeenCalled();
+    });
+
     it('should auto-mark both generated and deleted files as viewed', async () => {
       const initialFiles: DiffFile[] = [
         createMockDiffFile('package-lock.json', 'modified', true),

--- a/src/client/hooks/useViewedFiles.ts
+++ b/src/client/hooks/useViewedFiles.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useMemo } from 'react';
 
 import { type ViewedFileRecord, type DiffFile } from '../../types/diff';
 import { storageService } from '../services/StorageService';
+import { matchesAutoViewedPatterns } from '../utils/autoViewedPatterns';
 import { generateDiffHash, getDiffContentForHashing } from '../utils/diffUtils';
 
 interface UseViewedFilesReturn {
@@ -19,11 +20,12 @@ export function useViewedFiles(
   branchToHash?: Map<string, string>,
   initialFiles?: DiffFile[],
   repositoryId?: string,
+  autoViewedPatterns: string[] = [],
 ): UseViewedFilesReturn {
   const [viewedFileRecords, setViewedFileRecords] = useState<ViewedFileRecord[]>([]);
   const [fileHashes, setFileHashes] = useState<Map<string, string>>(new Map());
 
-  // Load viewed files from storage and auto-mark lock files
+  // Load viewed files from storage and auto-mark configured/generated files
   useEffect(() => {
     if (!baseCommitish || !targetCommitish) return;
 
@@ -35,7 +37,9 @@ export function useViewedFiles(
       repositoryId,
     );
 
-    // Auto-mark generated/deleted files as viewed if we have initial files and they are not already viewed
+    // Auto-mark generated, deleted, or pattern-matched files as viewed if they
+    // are not already marked. Pattern changes are intentionally not reactive here
+    // so editing the textarea does not immediately re-mark the current diff.
     const processAutoCollapsedFiles = async () => {
       if (initialFiles && initialFiles.length > 0) {
         const autoCollapsedFilesToAdd: ViewedFileRecord[] = [];
@@ -43,11 +47,15 @@ export function useViewedFiles(
         // Create a Set of already viewed file paths for quick lookup
         const viewedPaths = new Set(loadedFiles.map((f) => f.filePath));
 
-        // Find generated files or deleted files that aren't already marked as viewed
+        // Find generated, deleted, or configured files that aren't already marked as viewed
         for (const file of initialFiles) {
-          if ((file.isGenerated || file.status === 'deleted') && !viewedPaths.has(file.path)) {
+          const shouldAutoMarkViewed =
+            file.isGenerated ||
+            file.status === 'deleted' ||
+            matchesAutoViewedPatterns(file.path, autoViewedPatterns);
+
+          if (shouldAutoMarkViewed && !viewedPaths.has(file.path)) {
             try {
-              // Generate hash for the file
               const content = getDiffContentForHashing(file);
               const hash = await generateDiffHash(content);
 
@@ -85,7 +93,7 @@ export function useViewedFiles(
 
     void processAutoCollapsedFiles();
     // oxlint-disable-next-line react/exhaustive-deps
-  }, [baseCommitish, targetCommitish, currentCommitHash, branchToHash, repositoryId]); // initialFiles intentionally omitted to run only on mount
+  }, [baseCommitish, targetCommitish, currentCommitHash, branchToHash, repositoryId]); // initialFiles and autoViewedPatterns intentionally omitted to run only on diff init
 
   // Save viewed files to storage
   const saveViewedFiles = useCallback(

--- a/src/client/utils/autoViewedPatterns.test.ts
+++ b/src/client/utils/autoViewedPatterns.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  formatAutoViewedPatterns,
+  matchesAutoViewedPattern,
+  matchesAutoViewedPatterns,
+  normalizeAutoViewedPatterns,
+  parseAutoViewedPatterns,
+} from './autoViewedPatterns';
+
+describe('autoViewedPatterns', () => {
+  it('normalizes stored patterns', () => {
+    expect(
+      normalizeAutoViewedPatterns(['  *.test.ts  ', '', 'src/**/*.snap', '*.test.ts', 42]),
+    ).toEqual(['*.test.ts', 'src/**/*.snap']);
+  });
+
+  it('parses textarea input into normalized patterns', () => {
+    expect(parseAutoViewedPatterns('*.test.ts\n\n src/**/*.snap \n')).toEqual([
+      '*.test.ts',
+      'src/**/*.snap',
+    ]);
+  });
+
+  it('formats patterns for the textarea', () => {
+    expect(formatAutoViewedPatterns(['*.test.ts', 'src/**/*.snap'])).toBe(
+      '*.test.ts\nsrc/**/*.snap',
+    );
+  });
+
+  it('matches basename-only patterns against nested files', () => {
+    expect(matchesAutoViewedPattern('src/client/App.test.tsx', '*.test.tsx')).toBe(true);
+    expect(matchesAutoViewedPattern('src/client/App.tsx', '*.test.tsx')).toBe(false);
+  });
+
+  it('matches globstar path patterns across directories', () => {
+    expect(matchesAutoViewedPattern('src/components/Button.test.tsx', 'src/**/*.test.tsx')).toBe(
+      true,
+    );
+    expect(matchesAutoViewedPattern('src/Button.test.tsx', 'src/**/*.test.tsx')).toBe(true);
+    expect(matchesAutoViewedPattern('test/components/Button.test.tsx', 'src/**/*.test.tsx')).toBe(
+      false,
+    );
+  });
+
+  it('matches when any configured pattern matches', () => {
+    expect(
+      matchesAutoViewedPatterns('packages/vscode/src/extension.test.ts', [
+        '*.spec.ts',
+        'packages/**/src/*.test.ts',
+      ]),
+    ).toBe(true);
+  });
+});

--- a/src/client/utils/autoViewedPatterns.ts
+++ b/src/client/utils/autoViewedPatterns.ts
@@ -1,0 +1,132 @@
+function normalizePath(value: string): string {
+  return value.replaceAll('\\', '/').replace(/^\.\/+/, '');
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[|\\{}()[\]^$+?.]/g, '\\$&');
+}
+
+function normalizePatterns(patterns: string[]): string[] {
+  const uniquePatterns = new Set<string>();
+
+  patterns.forEach((pattern) => {
+    const trimmedPattern = pattern.trim();
+    if (trimmedPattern) {
+      uniquePatterns.add(normalizePath(trimmedPattern));
+    }
+  });
+
+  return [...uniquePatterns];
+}
+
+function splitPathSegments(value: string): string[] {
+  return normalizePath(value)
+    .split('/')
+    .filter((segment) => segment.length > 0);
+}
+
+function matchesSegment(pathSegment: string, patternSegment: string): boolean {
+  let regexSource = '^';
+
+  for (const character of patternSegment) {
+    if (character === '*') {
+      regexSource += '.*';
+      continue;
+    }
+
+    if (character === '?') {
+      regexSource += '.';
+      continue;
+    }
+
+    regexSource += escapeRegex(character);
+  }
+
+  regexSource += '$';
+
+  return new RegExp(regexSource).test(pathSegment);
+}
+
+function matchesPathSegments(
+  pathSegments: string[],
+  patternSegments: string[],
+  pathIndex = 0,
+  patternIndex = 0,
+): boolean {
+  if (patternIndex >= patternSegments.length) {
+    return pathIndex >= pathSegments.length;
+  }
+
+  const currentPattern = patternSegments[patternIndex];
+  if (!currentPattern) {
+    return pathIndex >= pathSegments.length;
+  }
+
+  if (currentPattern === '**') {
+    const nextPatternIndex = patternIndex + 1;
+
+    if (nextPatternIndex >= patternSegments.length) {
+      return true;
+    }
+
+    for (let nextPathIndex = pathIndex; nextPathIndex <= pathSegments.length; nextPathIndex += 1) {
+      if (matchesPathSegments(pathSegments, patternSegments, nextPathIndex, nextPatternIndex)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  const currentPathSegment = pathSegments[pathIndex];
+  if (!currentPathSegment || !matchesSegment(currentPathSegment, currentPattern)) {
+    return false;
+  }
+
+  return matchesPathSegments(pathSegments, patternSegments, pathIndex + 1, patternIndex + 1);
+}
+
+export function normalizeAutoViewedPatterns(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return normalizePatterns(
+    value.filter((pattern): pattern is string => typeof pattern === 'string'),
+  );
+}
+
+export function parseAutoViewedPatterns(input: string): string[] {
+  return normalizePatterns(input.split(/\r?\n/));
+}
+
+export function formatAutoViewedPatterns(patterns: string[]): string {
+  return normalizeAutoViewedPatterns(patterns).join('\n');
+}
+
+export function matchesAutoViewedPattern(filePath: string, pattern: string): boolean {
+  const normalizedPattern = normalizePath(pattern.trim());
+  if (!normalizedPattern) {
+    return false;
+  }
+
+  const normalizedFilePath = normalizePath(filePath);
+
+  // Patterns without a path separator match against the basename, so `*.test.ts`
+  // works for files nested anywhere in the repository.
+  if (!normalizedPattern.includes('/')) {
+    const fileName = normalizedFilePath.split('/').pop() ?? normalizedFilePath;
+    return matchesSegment(fileName, normalizedPattern);
+  }
+
+  return matchesPathSegments(
+    splitPathSegments(normalizedFilePath),
+    splitPathSegments(normalizedPattern),
+  );
+}
+
+export function matchesAutoViewedPatterns(filePath: string, patterns: string[]): boolean {
+  return normalizeAutoViewedPatterns(patterns).some((pattern) =>
+    matchesAutoViewedPattern(filePath, pattern),
+  );
+}


### PR DESCRIPTION
## Summary
- add a system setting for auto-marking matching files as Viewed
- support newline-delimited glob patterns such as *.test.ts and src/generated/**
- apply the configured patterns during initial auto-viewed file detection and add coverage for the new behavior

## Testing
- pnpm format
- pnpm check
- pnpm test
- pnpm build