### PR TITLE
Fix fenced code block rendering in markdown diff preview

### DIFF
--- a/src/client/viewers/MarkdownDiffViewer.test.tsx
+++ b/src/client/viewers/MarkdownDiffViewer.test.tsx
@@ -104,6 +104,49 @@ const htmlCommentChunks: MergedChunk[] = [
   },
 ];
 
+const codeFenceDiffChunks: MergedChunk[] = [
+  {
+    header: '@@ -1,7 +1,9 @@',
+    oldStart: 1,
+    oldLines: 7,
+    newStart: 1,
+    newLines: 9,
+    lines: [
+      {
+        type: 'context',
+        content: 'AIエージェントから使えるようにする',
+        oldLineNumber: 1,
+        newLineNumber: 1,
+      },
+      { type: 'context', content: '', oldLineNumber: 2, newLineNumber: 2 },
+      { type: 'context', content: '```bash', oldLineNumber: 3, newLineNumber: 3 },
+      {
+        type: 'delete',
+        content: 'npx skills add yoshiko-pg/difit # エージェントにスキルを追加',
+        oldLineNumber: 4,
+        newLineNumber: undefined,
+      },
+      {
+        type: 'add',
+        content: 'npx skills add yoshiko-pg/difit # エージェントにスキル群を追加',
+        oldLineNumber: undefined,
+        newLineNumber: 4,
+      },
+      { type: 'context', content: '```', oldLineNumber: 5, newLineNumber: 5 },
+      { type: 'context', content: '', oldLineNumber: 6, newLineNumber: 6 },
+      {
+        type: 'context',
+        content: 'インストールされる主な skill:',
+        oldLineNumber: 7,
+        newLineNumber: 7,
+      },
+    ],
+    originalIndices: [0, 1, 2, 3, 4, 5, 6, 7],
+    hiddenLinesBefore: 0,
+    hiddenLinesAfter: 0,
+  },
+];
+
 const setMatchMedia = (matches: boolean) => {
   Object.defineProperty(window, 'matchMedia', {
     configurable: true,
@@ -206,6 +249,24 @@ describe('MarkdownDiffViewer', () => {
           element?.tagName === 'PRE' && element.textContent === '<!-- hidden note -->',
       ),
     ).toBeInTheDocument();
+  });
+
+  it('renders changed fenced code blocks without dropping surrounding markdown in Diff Preview', () => {
+    renderViewer({ mergedChunks: codeFenceDiffChunks });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Diff Preview' }));
+
+    const oldLine = screen.getByText(
+      'npx skills add yoshiko-pg/difit # エージェントにスキルを追加',
+    );
+    const newLine = screen.getByText(
+      'npx skills add yoshiko-pg/difit # エージェントにスキル群を追加',
+    );
+
+    expect(oldLine.closest('.markdown-preview-code')).toContainElement(newLine);
+    expect(screen.getByText('インストールされる主な skill:')).toBeInTheDocument();
+    expect(screen.queryByText('```bash')).not.toBeInTheDocument();
+    expect(screen.queryByText('```')).not.toBeInTheDocument();
   });
 
   it('renders Mermaid diagrams in Full Preview', async () => {

--- a/src/client/viewers/MarkdownDiffViewer.tsx
+++ b/src/client/viewers/MarkdownDiffViewer.tsx
@@ -20,6 +20,30 @@ type PreviewBlock = {
   lines: string[];
 };
 
+type PreviewLineEntry = {
+  type: PreviewBlockType;
+  content: string;
+};
+
+type MarkdownRenderBlock = {
+  kind: 'markdown';
+  type: PreviewBlockType;
+  lines: string[];
+};
+
+type FencedCodeRenderBlock = {
+  kind: 'fenced-code';
+  lines: PreviewLineEntry[];
+};
+
+type PreviewRenderBlock = MarkdownRenderBlock | FencedCodeRenderBlock;
+
+type FenceInfo = {
+  marker: '`' | '~';
+  length: number;
+  raw: string;
+};
+
 const isFetchableRef = (ref?: string) => Boolean(ref && ref !== 'stdin');
 
 const headingStyles = [
@@ -256,6 +280,115 @@ const isNonRenderableLine = (line: string) =>
 
 const isPlainPreviewBlock = (lines: string[]) => lines.every(isNonRenderableLine);
 
+const parseFenceStart = (line: string): FenceInfo | null => {
+  const match = line.match(/^\s{0,3}(`{3,}|~{3,})(.*)$/);
+  if (!match) return null;
+
+  const marker = match[1];
+  if (!marker) return null;
+
+  return {
+    marker: marker[0] as '`' | '~',
+    length: marker.length,
+    raw: line,
+  };
+};
+
+const isFenceEnd = (line: string, fence: FenceInfo) => {
+  const match = line.match(/^\s{0,3}(`{3,}|~{3,})\s*$/);
+  if (!match?.[1]) return false;
+
+  return match[1][0] === fence.marker && match[1].length >= fence.length;
+};
+
+const buildRenderBlocks = (blocks: PreviewBlock[]): PreviewRenderBlock[] => {
+  const renderBlocks: PreviewRenderBlock[] = [];
+  let currentMarkdownBlock: MarkdownRenderBlock | null = null;
+  let currentFence: { fence: FenceInfo; lines: PreviewLineEntry[] } | null = null;
+
+  const flushMarkdownBlock = () => {
+    if (!currentMarkdownBlock) return;
+    renderBlocks.push(currentMarkdownBlock);
+    currentMarkdownBlock = null;
+  };
+
+  const pushMarkdownLine = (type: PreviewBlockType, line: string) => {
+    if (currentMarkdownBlock?.type === type) {
+      currentMarkdownBlock.lines.push(line);
+      return;
+    }
+
+    flushMarkdownBlock();
+    currentMarkdownBlock = {
+      kind: 'markdown',
+      type,
+      lines: [line],
+    };
+  };
+
+  const flushFence = (closingFenceLine?: string) => {
+    if (!currentFence) return;
+
+    const hasOnlyContextLines = currentFence.lines.every((line) => line.type === 'context');
+
+    if (closingFenceLine && hasOnlyContextLines) {
+      pushMarkdownLine('context', currentFence.fence.raw);
+      currentFence.lines.forEach((line) => {
+        pushMarkdownLine('context', line.content);
+      });
+      pushMarkdownLine('context', closingFenceLine);
+    } else {
+      flushMarkdownBlock();
+      renderBlocks.push({
+        kind: 'fenced-code',
+        lines: currentFence.lines,
+      });
+    }
+
+    currentFence = null;
+  };
+
+  blocks.forEach((block) => {
+    block.lines.forEach((line) => {
+      if (currentFence) {
+        if (isFenceEnd(line, currentFence.fence)) {
+          flushFence(line);
+          return;
+        }
+
+        currentFence.lines.push({ type: block.type, content: line });
+        return;
+      }
+
+      const fence = parseFenceStart(line);
+      if (fence) {
+        flushMarkdownBlock();
+        currentFence = { fence, lines: [] };
+        return;
+      }
+
+      pushMarkdownLine(block.type, line);
+    });
+  });
+
+  flushFence();
+  flushMarkdownBlock();
+
+  return renderBlocks;
+};
+
+const getCodeLineClass = (type: PreviewBlockType) => {
+  switch (type) {
+    case 'add':
+    case 'change':
+      return 'border-l-4 border-diff-addition-border bg-diff-addition-bg';
+    case 'delete':
+      return 'border-l-4 border-diff-deletion-border bg-diff-deletion-bg';
+    default:
+      return 'border-l-4 border-transparent';
+  }
+};
+
 const MarkdownDiffPreview = ({
   blocks,
   syntaxTheme,
@@ -264,10 +397,28 @@ const MarkdownDiffPreview = ({
   syntaxTheme?: DiffViewerBodyProps['syntaxTheme'];
 }) => {
   const components = useMemo(() => getMarkdownComponents(syntaxTheme), [syntaxTheme]);
+  const renderBlocks = useMemo(() => buildRenderBlocks(blocks), [blocks]);
 
   return (
     <div className="space-y-4">
-      {blocks.map((block, index) => {
+      {renderBlocks.map((block, index) => {
+        if (block.kind === 'fenced-code') {
+          return (
+            <div key={`preview-block-${index}`} className="px-4">
+              <div className="markdown-preview-code overflow-x-auto rounded border border-github-border bg-github-bg-secondary text-sm font-mono text-github-text-primary">
+                {block.lines.map((line, lineIndex) => (
+                  <div
+                    key={`preview-code-line-${index}-${lineIndex}`}
+                    className={`${getCodeLineClass(line.type)} whitespace-pre px-3 py-1`}
+                  >
+                    {line.content || ' '}
+                  </div>
+                ))}
+              </div>
+            </div>
+          );
+        }
+
         const rawContent = block.lines.join('\n');
         const trimmedContent = rawContent.trim();
         if (!trimmedContent) return null;


### PR DESCRIPTION
## Summary
- detect fenced code blocks while building markdown diff preview render blocks
- render changed fenced code blocks as line-by-line code output instead of broken markdown
- add a regression test covering a diff where the first changed block is inside a fenced code block

## before/after

<img width="579" height="285" alt="image" src="https://github.com/user-attachments/assets/d030591b-ae9d-4cef-bf58-22351eecf376" />

<img width="591" height="196" alt="image" src="https://github.com/user-attachments/assets/a7aa9c6b-b5bc-4209-8248-d9c33508734a" />


## Testing
- `pnpm run format`
- `pnpm run check`
- `pnpm run knip`
- `pnpm test`
- `pnpm run build`