### PR TITLE
Fix working tree blob path validation for code scanning alerts

### DIFF
--- a/src/server/git-diff.test.ts
+++ b/src/server/git-diff.test.ts
@@ -28,6 +28,7 @@ vi.mock('fs', async (importOriginal) => {
   return {
     ...actual,
     readFileSync: vi.fn(),
+    realpathSync: vi.fn((path: string) => path),
   };
 });
 
@@ -35,6 +36,7 @@ describe('GitDiffParser', () => {
   let parser: GitDiffParser;
   let mockExecFileSync: any;
   let mockReadFileSync: any;
+  let mockRealpathSync: any;
 
   beforeEach(async () => {
     parser = new GitDiffParser('/test/repo');
@@ -45,6 +47,8 @@ describe('GitDiffParser', () => {
     const fs = await import('fs');
     mockExecFileSync = childProcess.execFileSync;
     mockReadFileSync = fs.readFileSync;
+    mockRealpathSync = fs.realpathSync;
+    mockRealpathSync.mockImplementation((path: string) => path);
   });
 
   afterEach(() => {
@@ -147,6 +151,21 @@ describe('GitDiffParser', () => {
 
     it('rejects absolute working tree paths', async () => {
       await expect(parser.getBlobContent('/etc/passwd', 'working')).rejects.toThrow(
+        'File path outside repository',
+      );
+
+      expect(mockReadFileSync).not.toHaveBeenCalled();
+    });
+
+    it('rejects working tree symlinks that resolve outside the repository', async () => {
+      mockRealpathSync.mockImplementation((path: string) => {
+        if (path === '/test/repo/link.txt') {
+          return '/etc/passwd';
+        }
+        return path;
+      });
+
+      await expect(parser.getBlobContent('link.txt', 'working')).rejects.toThrow(
         'File path outside repository',
       );
 

--- a/src/server/git-diff.ts
+++ b/src/server/git-diff.ts
@@ -424,14 +424,25 @@ export class GitDiffParser {
 
   async getBlobContent(filepath: string, ref: string): Promise<Buffer> {
     try {
-      const normalizedFilepath = this.normalizeRepositoryRelativePath(filepath);
-
       // For working directory, read directly from filesystem
       if (ref === 'working' || ref === '.') {
         const fs = await import('fs');
-        const absolutePath = resolve(this.repoPath, normalizedFilepath);
+        if (filepath.length === 0) {
+          throw new Error('Invalid file path');
+        }
+
+        const repositoryPath = fs.realpathSync(resolve(this.repoPath));
+        const repositoryRoot = `${repositoryPath}${sep}`;
+        const absolutePath = fs.realpathSync(resolve(repositoryRoot, filepath.replace(/\\/g, '/')));
+
+        if (!absolutePath.startsWith(repositoryRoot)) {
+          throw new Error('File path outside repository');
+        }
+
         return fs.readFileSync(absolutePath);
       }
+
+      const normalizedFilepath = this.normalizeRepositoryRelativePath(filepath);
 
       // For git refs, we need to use child_process to execute git cat-file
       // to properly handle binary data


### PR DESCRIPTION
## Summary
- harden working tree blob reads by resolving the repository root and target file with `realpathSync`
- reject paths that resolve outside the repository before calling `readFileSync`
- add a regression test for symlink-based escape attempts in `getBlobContent`

## Testing
- `pnpm test`
- `pnpm check`
- `pnpm build`