### PR TITLE
Set explicit GitHub Actions workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: CI
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     uses: ./.github/workflows/ci.yml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,9 @@ on:
       - published
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     uses: ./.github/workflows/ci.yml


### PR DESCRIPTION
## Summary
- add explicit `permissions` blocks to workflows that relied on default `GITHUB_TOKEN` scopes
- set reusable CI and PR workflows to `contents: read`
- keep publish-specific elevated permissions limited to the publish job

## Testing
- Not run (not requested)