### PR TITLE
Add merge-base...Uncommitted quick diff preset

### DIFF
--- a/src/client/components/DiffQuickMenu.test.ts
+++ b/src/client/components/DiffQuickMenu.test.ts
@@ -164,4 +164,60 @@ describe('DiffQuickMenu', () => {
 
     expect(onSelectDiff).toHaveBeenCalledWith('origin/main', '.');
   });
+
+  it('shows merge-base preset button when originDefaultBranch is available', () => {
+    render(
+      createElement(DiffQuickMenu, {
+        options,
+        baseRevision: 'HEAD',
+        targetRevision: '.',
+        onSelectDiff: vi.fn(),
+        onOpenAdvanced: vi.fn(),
+      }),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Revision menu:/ }));
+
+    expect(
+      screen.getByRole('button', { name: 'origin/main (merge-base)...Uncommitted' }),
+    ).toBeInTheDocument();
+  });
+
+  it('selects merge-base preset when clicked', () => {
+    const onSelectDiff = vi.fn();
+    render(
+      createElement(DiffQuickMenu, {
+        options,
+        baseRevision: 'HEAD',
+        targetRevision: '.',
+        onSelectDiff,
+        onOpenAdvanced: vi.fn(),
+      }),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Revision menu:/ }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'origin/main (merge-base)...Uncommitted' }),
+    );
+
+    expect(onSelectDiff).toHaveBeenCalledWith('merge-base', '.');
+  });
+
+  it('does not show merge-base preset when originDefaultBranch is absent', () => {
+    render(
+      createElement(DiffQuickMenu, {
+        options: { ...options, originDefaultBranch: undefined },
+        baseRevision: 'HEAD',
+        targetRevision: '.',
+        onSelectDiff: vi.fn(),
+        onOpenAdvanced: vi.fn(),
+      }),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Revision menu:/ }));
+
+    expect(
+      screen.queryByRole('button', { name: /merge-base/ }),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/client/components/DiffQuickMenu.tsx
+++ b/src/client/components/DiffQuickMenu.tsx
@@ -314,6 +314,14 @@ export function DiffQuickMenu({
                   {originDefaultBranch}...Uncommitted
                 </button>
               )}
+              {originDefaultBranch && (
+                <button
+                  onClick={() => handleSelect('merge-base', '.')}
+                  className={getItemClasses(isPresetActive('merge-base', '.'), false)}
+                >
+                  {originDefaultBranch} (merge-base)...Uncommitted
+                </button>
+              )}
             </div>
 
             <div className="border-b border-github-border">

--- a/src/server/git-diff.ts
+++ b/src/server/git-diff.ts
@@ -54,6 +54,13 @@ export class GitDiffParser {
       let resolvedCommit: string;
       let diffArgs: string[];
 
+      // Resolve merge-base shorthand before any other processing
+      if (baseCommitish === 'merge-base') {
+        const originBranch = await this.getOriginDefaultBranch();
+        if (!originBranch) throw new Error('No origin default branch found for merge-base');
+        baseCommitish = (await this.git.raw(['merge-base', 'HEAD', originBranch])).trim();
+      }
+
       // Handle target special chars (base is always a regular commit)
       if (targetCommitish === 'working') {
         // Show unstaged changes (working vs staged)
@@ -541,6 +548,13 @@ export class GitDiffParser {
     const cached = this.resolvedCommitCache.get(commitish);
     if (cached && cached.expiresAt > now) {
       return cached.value;
+    }
+
+    if (commitish === 'merge-base') {
+      const originBranch = await this.getOriginDefaultBranch();
+      if (originBranch) {
+        commitish = (await this.git.raw(['merge-base', 'HEAD', originBranch])).trim();
+      }
     }
 
     const hash = await this.git.revparse([commitish]);

--- a/src/server/server.test.ts
+++ b/src/server/server.test.ts
@@ -713,7 +713,11 @@ describe('Server Integration Tests', () => {
       const data = (await response.json()) as any;
 
       expect(response.ok).toBe(true);
-      expect(data.specialOptions).toHaveLength(3);
+      expect(data.specialOptions).toHaveLength(4);
+      expect(data.specialOptions).toContainEqual({
+        value: 'merge-base',
+        label: 'origin/main (merge-base)',
+      });
       expect(data.branches).toEqual([{ name: 'main', current: true }]);
       expect(data.commits).toEqual([
         { hash: 'abc1234', shortHash: 'abc1234', message: 'Test commit' },

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -269,6 +269,9 @@ export async function startServer(
           { value: '.', label: 'All Uncommitted Changes' },
           { value: 'staged', label: 'Staging Area' },
           { value: 'working', label: 'Working Directory' },
+          ...(originDefaultBranch
+            ? [{ value: 'merge-base', label: `${originDefaultBranch} (merge-base)` }]
+            : []),
         ],
         branches,
         commits,


### PR DESCRIPTION
Closes #289

## Summary

- Adds a new `origin/main (merge-base)...Uncommitted` button to the revision quick menu, sitting right below the existing `origin/main...Uncommitted` preset
- The special base commitish `merge-base` is resolved on demand via `git merge-base HEAD <originDefaultBranch>` in `parseDiff()` and `resolveCommitish()`
- The display label is wired through `specialOptions` in `/api/revisions`, so the trigger button header automatically shows `origin/main (merge-base)...Uncommitted Changes` when this preset is active

## Test plan

- [x] Unit tests pass (`vitest run`) — 624 passing
- [x] Manual: open difit on a branch that has diverged from `origin/main`; verify the new button appears and diffs only the branch's own changes (no upstream noise)

🤖 Generated with [Claude Code](https://claude.com/claude-code)