### PR TITLE
feat: add CLI subcommands and API for reading/writing comments on a running server

### DIFF
--- a/src/cli/comment.test.ts
+++ b/src/cli/comment.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { createCommentCommand } from './comment.js';
+
+describe('createCommentCommand', () => {
+  const command = createCommentCommand();
+
+  it('creates a command named "comment"', () => {
+    expect(command.name()).toBe('comment');
+  });
+
+  it('has "add" and "get" subcommands', () => {
+    const subcommandNames = command.commands.map((c) => c.name());
+    expect(subcommandNames).toContain('add');
+    expect(subcommandNames).toContain('get');
+  });
+
+  describe('add subcommand', () => {
+    const addCommand = command.commands.find((c) => c.name() === 'add')!;
+
+    it('requires --port option', () => {
+      const portOption = addCommand.options.find((o) => o.long === '--port');
+      expect(portOption).toBeDefined();
+      expect(portOption?.mandatory).toBe(true);
+    });
+
+    it('accepts optional json argument', () => {
+      const args = addCommand.registeredArguments;
+      expect(args).toHaveLength(1);
+      expect(args[0].name()).toBe('json');
+      expect(args[0].required).toBe(false);
+    });
+  });
+
+  describe('get subcommand', () => {
+    const getCommand = command.commands.find((c) => c.name() === 'get')!;
+
+    it('requires --port option', () => {
+      const portOption = getCommand.options.find((o) => o.long === '--port');
+      expect(portOption).toBeDefined();
+      expect(portOption?.mandatory).toBe(true);
+    });
+
+    it('has --format option with choices', () => {
+      const formatOption = getCommand.options.find((o) => o.long === '--format');
+      expect(formatOption).toBeDefined();
+      expect(formatOption?.defaultValue).toBe('text');
+      expect(formatOption?.argChoices).toEqual(['text', 'json']);
+    });
+  });
+});
+
+describe('comment subcommand integration', () => {
+  let originalFetch: typeof globalThis.fetch;
+  let mockFetch: ReturnType<typeof vi.fn>;
+  let originalProcessExit: typeof process.exit;
+  let consoleOutput: string[];
+  let consoleErrors: string[];
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    mockFetch = vi.fn();
+    globalThis.fetch = mockFetch;
+
+    originalProcessExit = process.exit;
+    process.exit = vi.fn() as any;
+
+    consoleOutput = [];
+    consoleErrors = [];
+    vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      consoleOutput.push(args.join(' '));
+    });
+    vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      consoleErrors.push(args.join(' '));
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    process.exit = originalProcessExit;
+    vi.restoreAllMocks();
+  });
+
+  describe('add', () => {
+    it('sends comment imports to the server', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ success: true, importId: 'abc123', count: 1 }),
+      });
+
+      const command = createCommentCommand();
+      await command.parseAsync([
+        'node',
+        'difit',
+        'add',
+        '--port',
+        '4966',
+        '{"type":"thread","filePath":"test.ts","position":{"side":"new","line":1},"body":"Test"}',
+      ]);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:4966/api/comment-imports',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+      expect(consoleOutput[0]).toContain('"success":true');
+    });
+
+    it('validates JSON before sending', async () => {
+      const command = createCommentCommand();
+      await command.parseAsync(['node', 'difit', 'add', '--port', '4966', 'not-valid-json']);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(consoleErrors[0]).toContain('Error:');
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+
+    it('handles server error response', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        json: () => Promise.resolve({ error: 'Bad request' }),
+      });
+
+      const command = createCommentCommand();
+      await command.parseAsync([
+        'node',
+        'difit',
+        'add',
+        '--port',
+        '4966',
+        '{"type":"thread","filePath":"test.ts","position":{"side":"new","line":1},"body":"Test"}',
+      ]);
+
+      expect(consoleErrors[0]).toContain('Bad request');
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+
+    it('handles connection error', async () => {
+      const fetchError = new TypeError('fetch failed');
+      mockFetch.mockRejectedValue(fetchError);
+
+      const command = createCommentCommand();
+      await command.parseAsync([
+        'node',
+        'difit',
+        'add',
+        '--port',
+        '9999',
+        '{"type":"thread","filePath":"test.ts","position":{"side":"new","line":1},"body":"Test"}',
+      ]);
+
+      expect(consoleErrors[0]).toContain('Cannot connect');
+      expect(consoleErrors[0]).toContain('9999');
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('get', () => {
+    it('fetches comments in text format by default', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve('Comments output text'),
+      });
+
+      const command = createCommentCommand();
+      await command.parseAsync(['node', 'difit', 'get', '--port', '4966']);
+
+      expect(mockFetch).toHaveBeenCalledWith('http://localhost:4966/api/comments-output');
+      expect(consoleOutput[0]).toBe('Comments output text');
+    });
+
+    it('fetches comments in json format', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ threads: [{ id: '1' }] }),
+      });
+
+      const command = createCommentCommand();
+      await command.parseAsync(['node', 'difit', 'get', '--port', '4966', '--format', 'json']);
+
+      expect(mockFetch).toHaveBeenCalledWith('http://localhost:4966/api/comments-json');
+      expect(consoleOutput[0]).toContain('"threads"');
+    });
+
+    it('handles connection error', async () => {
+      mockFetch.mockRejectedValue(new TypeError('fetch failed'));
+
+      const command = createCommentCommand();
+      await command.parseAsync(['node', 'difit', 'get', '--port', '9999']);
+
+      expect(consoleErrors[0]).toContain('Cannot connect');
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+
+    it('handles empty text output silently', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve('  '),
+      });
+
+      const command = createCommentCommand();
+      await command.parseAsync(['node', 'difit', 'get', '--port', '4966']);
+
+      expect(consoleOutput).toHaveLength(0);
+    });
+  });
+});

--- a/src/cli/comment.test.ts
+++ b/src/cli/comment.test.ts
@@ -50,16 +50,29 @@ describe('createCommentCommand', () => {
   });
 });
 
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function textResponse(body: string, status = 200): Response {
+  return new Response(body, {
+    status,
+    headers: { 'Content-Type': 'text/plain' },
+  });
+}
+
 describe('comment subcommand integration', () => {
-  let originalFetch: typeof globalThis.fetch;
-  let mockFetch: ReturnType<typeof vi.fn>;
+  const originalFetch = globalThis.fetch;
+  let mockFetch: ReturnType<typeof vi.fn<typeof fetch>>;
   let originalProcessExit: typeof process.exit;
   let consoleOutput: string[];
   let consoleErrors: string[];
 
   beforeEach(() => {
-    originalFetch = globalThis.fetch;
-    mockFetch = vi.fn();
+    mockFetch = vi.fn<typeof fetch>();
     globalThis.fetch = mockFetch;
 
     originalProcessExit = process.exit;
@@ -83,10 +96,7 @@ describe('comment subcommand integration', () => {
 
   describe('add', () => {
     it('sends comment imports to the server', async () => {
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({ success: true, importId: 'abc123', count: 1 }),
-      });
+      mockFetch.mockResolvedValue(jsonResponse({ success: true, importId: 'abc123', count: 1 }));
 
       const command = createCommentCommand();
       await command.parseAsync([
@@ -118,10 +128,7 @@ describe('comment subcommand integration', () => {
     });
 
     it('handles server error response', async () => {
-      mockFetch.mockResolvedValue({
-        ok: false,
-        json: () => Promise.resolve({ error: 'Bad request' }),
-      });
+      mockFetch.mockResolvedValue(jsonResponse({ error: 'Bad request' }, 400));
 
       const command = createCommentCommand();
       await command.parseAsync([
@@ -159,10 +166,7 @@ describe('comment subcommand integration', () => {
 
   describe('get', () => {
     it('fetches comments in text format by default', async () => {
-      mockFetch.mockResolvedValue({
-        ok: true,
-        text: () => Promise.resolve('Comments output text'),
-      });
+      mockFetch.mockResolvedValue(textResponse('Comments output text'));
 
       const command = createCommentCommand();
       await command.parseAsync(['node', 'difit', 'get', '--port', '4966']);
@@ -172,10 +176,7 @@ describe('comment subcommand integration', () => {
     });
 
     it('fetches comments in json format', async () => {
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({ threads: [{ id: '1' }] }),
-      });
+      mockFetch.mockResolvedValue(jsonResponse({ threads: [{ id: '1' }] }));
 
       const command = createCommentCommand();
       await command.parseAsync(['node', 'difit', 'get', '--port', '4966', '--format', 'json']);
@@ -195,10 +196,7 @@ describe('comment subcommand integration', () => {
     });
 
     it('handles empty text output silently', async () => {
-      mockFetch.mockResolvedValue({
-        ok: true,
-        text: () => Promise.resolve('  '),
-      });
+      mockFetch.mockResolvedValue(textResponse('  '));
 
       const command = createCommentCommand();
       await command.parseAsync(['node', 'difit', 'get', '--port', '4966']);

--- a/src/cli/comment.ts
+++ b/src/cli/comment.ts
@@ -1,0 +1,98 @@
+import { Command, Option } from 'commander';
+
+import { parseCommentImportValue } from '../utils/commentImports.js';
+
+import { readStdin } from './utils.js';
+
+export function createCommentCommand(): Command {
+  const comment = new Command('comment').description(
+    'Add or retrieve comments on a running difit server',
+  );
+
+  comment
+    .command('add')
+    .description('Add comments to a running difit server')
+    .argument('[json]', 'comment import JSON (object or array)')
+    .requiredOption('--port <port>', 'port of the running difit server', parseInt)
+    .action(async (json: string | undefined, opts: { port: number }) => {
+      try {
+        const input = json ?? (await readStdin());
+        if (!input.trim()) {
+          console.error('Error: No comment data provided. Pass JSON as argument or via stdin.');
+          process.exit(1);
+        }
+
+        const imports = parseCommentImportValue(input);
+
+        const response = await fetch(`http://localhost:${opts.port}/api/comment-imports`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(imports),
+        });
+
+        if (!response.ok) {
+          const error = (await response.json()) as { error?: string };
+          console.error(`Error: ${error.error ?? 'Failed to add comments'}`);
+          process.exit(1);
+        }
+
+        const result = (await response.json()) as {
+          success: boolean;
+          importId: string;
+          count: number;
+        };
+        console.log(
+          JSON.stringify({
+            success: result.success,
+            importId: result.importId,
+            count: result.count,
+          }),
+        );
+      } catch (error) {
+        if (error instanceof TypeError && error.message.includes('fetch failed')) {
+          console.error(
+            `Error: Cannot connect to difit server on port ${opts.port}. Is the server running?`,
+          );
+        } else {
+          console.error(`Error: ${error instanceof Error ? error.message : 'Unknown error'}`);
+        }
+        process.exit(1);
+      }
+    });
+
+  comment
+    .command('get')
+    .description('Retrieve comments from a running difit server')
+    .requiredOption('--port <port>', 'port of the running difit server', parseInt)
+    .addOption(
+      new Option('--format <format>', 'output format').choices(['text', 'json']).default('text'),
+    )
+    .action(async (opts: { port: number; format: string }) => {
+      try {
+        const endpoint = opts.format === 'json' ? '/api/comments-json' : '/api/comments-output';
+        const response = await fetch(`http://localhost:${opts.port}${endpoint}`);
+
+        if (!response.ok) {
+          console.error('Error: Failed to retrieve comments');
+          process.exit(1);
+        }
+
+        if (opts.format === 'json') {
+          const data: unknown = await response.json();
+          console.log(JSON.stringify(data));
+        } else {
+          const text = await response.text();
+          if (text.trim()) {
+            console.log(text);
+          }
+        }
+      } catch {
+        console.error(
+          `Error: Cannot connect to difit server on port ${opts.port}. Is the server running?`,
+        );
+        process.exit(1);
+      }
+    });
+
+  return comment;
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,7 +19,9 @@ import {
   parseCommentOptions,
   validateDiffArguments,
   getGitRoot,
+  readStdin,
 } from './utils.js';
+import { createCommentCommand } from './comment.js';
 import { getPrPatch, getPrCommentImports } from './github.js';
 import { warnAboutTuiDeprecation } from './tuiDeprecation.js';
 
@@ -86,6 +88,7 @@ interface CliOptions {
   keepAlive?: boolean;
   context?: number;
   mergeBase?: boolean;
+  background?: boolean;
 }
 
 const program = new Command();
@@ -94,6 +97,7 @@ program
   .name('difit')
   .description('A lightweight Git diff viewer with GitHub-like interface')
   .version(pkg.version, '-v, --version', 'output the version number')
+  .enablePositionalOptions()
   .argument(
     '[commit-ish]',
     'Git commit, tag, branch, HEAD~n reference, or "working"/"staged"/"."',
@@ -128,8 +132,15 @@ program
     '--merge-base',
     'resolve the base revision with git merge-base before diffing (Git revision mode only)',
   )
+  .option('--background', 'start server in background and output JSON with port info')
   .action(async (commitish: string, compareWith: string | undefined, options: CliOptions) => {
     try {
+      // --background implies --keep-alive and --no-open
+      if (options.background) {
+        options.keepAlive = true;
+        options.open = false;
+      }
+
       let stdinDiff: string | undefined;
       let stdinReviewLabel = 'diff from stdin';
       let manualCommentImports: CommentImport[] = [];
@@ -221,7 +232,7 @@ program
 
       if (stdinDiff) {
         // Start server with stdin diff (including --pr patch)
-        const { url } = await startServer({
+        const { url, port } = await startServer({
           stdinDiff,
           preferredPort: options.port,
           host: options.host,
@@ -231,6 +242,11 @@ program
           keepAlive: options.keepAlive,
           ...(commentImports.length > 0 ? { commentImports } : {}),
         });
+
+        if (options.background) {
+          console.log(JSON.stringify({ port, url, pid: process.pid }));
+          return;
+        }
 
         console.log(`\n🚀 difit server started on ${url}`);
         console.log(`📋 Reviewing: ${stdinReviewLabel}`);
@@ -314,6 +330,11 @@ program
         ...(commentImports.length > 0 ? { commentImports } : {}),
       });
 
+      if (options.background) {
+        console.log(JSON.stringify({ port, url, pid: process.pid }));
+        return;
+      }
+
       console.log(`\n🚀 difit server started on ${url}`);
       console.log(`📋 Reviewing: ${selection.targetCommitish}`);
 
@@ -360,17 +381,11 @@ program
     }
   });
 
+program.addCommand(createCommentCommand());
+
 program.parse();
 
 // Check for untracked files and prompt user to add them for diff visibility
-async function readStdin(): Promise<string> {
-  const chunks: Buffer[] = [];
-  for await (const chunk of process.stdin) {
-    chunks.push(chunk as Buffer);
-  }
-  return Buffer.concat(chunks).toString('utf8');
-}
-
 async function handleUntrackedFiles(git: SimpleGit, addAutomatically?: boolean): Promise<void> {
   const files = await findUntrackedFiles(git);
   if (files.length === 0) {

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -265,3 +265,11 @@ export async function waitForEnter(message: string): Promise<void> {
     rl.close();
   }
 }
+
+export async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -2,6 +2,7 @@ import { Columns, AlignLeft, Settings, PanelLeftClose, PanelLeft, Keyboard } fro
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 
 import {
+  type CommentImport,
   type DiffResponse,
   type DiffSelection,
   type DiffViewMode,
@@ -370,10 +371,19 @@ function App() {
     lineIndex: number;
   } | null>(null);
 
+  // Handle comment imports received via SSE
+  const handleCommentImports = useCallback(
+    (imports: CommentImport[], importId: string) => {
+      const warnings = applyCommentImports(imports, importId);
+      warnings.forEach((warning) => console.warn(warning));
+    },
+    [applyCommentImports],
+  );
+
   // File watch for reload functionality - initialize with callback
   const { shouldReload, reload, watchState } = useFileWatch(async () => {
     await fetchDiffData();
-  });
+  }, handleCommentImports);
 
   const { cursor, isHelpOpen, setIsHelpOpen, setCursorPosition } = useKeyboardNavigation({
     files: navigableFiles,

--- a/src/client/hooks/useFileWatch.ts
+++ b/src/client/hooks/useFileWatch.ts
@@ -1,6 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-import { DiffMode, type ClientWatchState } from '../../types/watch.js';
+import type { CommentImport } from '../../types/diff.js';
+import {
+  DiffMode,
+  type ClientWatchState,
+  type CommentImportsWatchEvent,
+} from '../../types/watch.js';
 import { resolveEventSourceUrl } from '../utils/eventSourceUrl';
 
 interface FileWatchHook {
@@ -19,10 +24,17 @@ interface WatchEvent {
   message?: string;
 }
 
-export function useFileWatch(onReload?: () => Promise<void>): FileWatchHook {
+type ServerWatchEvent = WatchEvent | CommentImportsWatchEvent;
+
+export function useFileWatch(
+  onReload?: () => Promise<void>,
+  onCommentImports?: (imports: CommentImport[], importId: string) => void,
+): FileWatchHook {
   const eventSourceRef = useRef<EventSource | null>(null);
   const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const reconnectAttemptsRef = useRef(0);
+  const onCommentImportsRef = useRef(onCommentImports);
+  onCommentImportsRef.current = onCommentImports;
   const maxReconnectAttempts = 5;
   const reconnectDelay = 3000; // 3 seconds
 
@@ -60,7 +72,7 @@ export function useFileWatch(onReload?: () => Promise<void>): FileWatchHook {
       eventSource.onmessage = (event) => {
         try {
           // oxlint-disable-next-line typescript/no-unsafe-assignment
-          const data: WatchEvent = JSON.parse(event.data as string);
+          const data: ServerWatchEvent = JSON.parse(event.data as string);
 
           switch (data.type) {
             case 'connected':
@@ -80,6 +92,10 @@ export function useFileWatch(onReload?: () => Promise<void>): FileWatchHook {
                 lastChangeTime: new Date(),
                 lastChangeType: data.changeType,
               }));
+              break;
+
+            case 'commentImports':
+              onCommentImportsRef.current?.(data.commentImports, data.commentImportId);
               break;
 
             case 'error':

--- a/src/server/file-watcher.ts
+++ b/src/server/file-watcher.ts
@@ -4,7 +4,7 @@ import { subscribe } from '@parcel/watcher';
 import { type Response } from 'express';
 import { simpleGit, type SimpleGit } from 'simple-git';
 
-import { DiffMode } from '../types/watch.js';
+import { DiffMode, type CommentImportsWatchEvent } from '../types/watch.js';
 
 interface FileWatcherConfig {
   watchPath: string;
@@ -249,6 +249,12 @@ export class FileWatcherService {
     if (index > -1) {
       this.clients.splice(index, 1);
     }
+  }
+
+  broadcastCommentImport(event: CommentImportsWatchEvent): void {
+    this.clients.forEach((client) => {
+      this.sendToClient(client, event);
+    });
   }
 
   private broadcastChange(): void {

--- a/src/server/server.test.ts
+++ b/src/server/server.test.ts
@@ -663,6 +663,180 @@ describe('Server Integration Tests', () => {
       expect(output).toContain('Total comments: 2');
     });
 
+    it('POST /api/comment-imports accepts valid comment imports', async () => {
+      const imports = [
+        {
+          type: 'thread',
+          filePath: 'src/example.ts',
+          position: { side: 'new', line: 10 },
+          body: 'Review comment',
+        },
+      ];
+
+      const response = await fetch(`http://localhost:${port}/api/comment-imports`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(imports),
+      });
+
+      expect(response.ok).toBe(true);
+      const data = (await response.json()) as any;
+      expect(data.success).toBe(true);
+      expect(data.importId).toEqual(expect.any(String));
+      expect(data.count).toBe(1);
+    });
+
+    it('POST /api/comment-imports accepts a single object', async () => {
+      const singleImport = {
+        type: 'thread',
+        filePath: 'src/example.ts',
+        position: { side: 'new', line: 5 },
+        body: 'Single object import',
+      };
+
+      const response = await fetch(`http://localhost:${port}/api/comment-imports`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(singleImport),
+      });
+
+      expect(response.ok).toBe(true);
+      const data = (await response.json()) as any;
+      expect(data.success).toBe(true);
+      expect(data.count).toBe(1);
+    });
+
+    it('POST /api/comment-imports rejects invalid data', async () => {
+      const response = await fetch(`http://localhost:${port}/api/comment-imports`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ invalid: true }),
+      });
+
+      expect(response.status).toBe(400);
+      const data = (await response.json()) as any;
+      expect(data).toHaveProperty('error');
+    });
+
+    it('GET /api/comments-json returns empty threads by default', async () => {
+      const response = await fetch(`http://localhost:${port}/api/comments-json`);
+
+      expect(response.ok).toBe(true);
+      const data = (await response.json()) as any;
+      expect(data).toHaveProperty('threads');
+      expect(data.threads).toEqual([]);
+    });
+
+    it('GET /api/comments-json returns threads after posting comments', async () => {
+      const comments = [{ file: 'test.js', line: 10, body: 'JSON test comment' }];
+
+      await fetch(`http://localhost:${port}/api/comments`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ comments }),
+      });
+
+      const response = await fetch(`http://localhost:${port}/api/comments-json`);
+
+      expect(response.ok).toBe(true);
+      const data = (await response.json()) as any;
+      expect(data.threads).toHaveLength(1);
+      expect(data.threads[0].messages[0].body).toBe('JSON test comment');
+    });
+
+    it('POST /api/comment-imports merges into server-side threads for comments-output', async () => {
+      const imports = [
+        {
+          type: 'thread',
+          filePath: 'src/example.ts',
+          position: { side: 'new', line: 42 },
+          body: 'Merged server-side comment',
+        },
+      ];
+
+      await fetch(`http://localhost:${port}/api/comment-imports`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(imports),
+      });
+
+      const outputResponse = await fetch(`http://localhost:${port}/api/comments-output`);
+      const output = await outputResponse.text();
+
+      expect(output).toContain('src/example.ts:L42');
+      expect(output).toContain('Merged server-side comment');
+    });
+
+    it('POST /api/comment-imports merges reply into existing thread', async () => {
+      // First add a thread
+      await fetch(`http://localhost:${port}/api/comment-imports`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify([
+          {
+            type: 'thread',
+            filePath: 'src/reply-test.ts',
+            position: { side: 'new', line: 5 },
+            body: 'Original comment',
+            author: 'User',
+          },
+        ]),
+      });
+
+      // Then add a reply
+      await fetch(`http://localhost:${port}/api/comment-imports`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify([
+          {
+            type: 'reply',
+            filePath: 'src/reply-test.ts',
+            position: { side: 'new', line: 5 },
+            body: 'Reply to comment',
+            author: 'AI',
+          },
+        ]),
+      });
+
+      const jsonResponse = await fetch(`http://localhost:${port}/api/comments-json`);
+      const data = (await jsonResponse.json()) as any;
+
+      const thread = data.threads.find((t: any) => t.file === 'src/reply-test.ts');
+      expect(thread).toBeDefined();
+      expect(thread.messages).toHaveLength(2);
+      expect(thread.messages[0].body).toBe('Original comment');
+      expect(thread.messages[1].body).toBe('Reply to comment');
+    });
+
+    it('POST /api/comment-imports deduplicates identical imports', async () => {
+      const imports = [
+        {
+          type: 'thread',
+          filePath: 'src/dedup.ts',
+          position: { side: 'new', line: 1 },
+          body: 'Unique comment',
+        },
+      ];
+
+      // Send the same import twice
+      await fetch(`http://localhost:${port}/api/comment-imports`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(imports),
+      });
+      await fetch(`http://localhost:${port}/api/comment-imports`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(imports),
+      });
+
+      const jsonResponse = await fetch(`http://localhost:${port}/api/comments-json`);
+      const data = (await jsonResponse.json()) as any;
+
+      const threads = data.threads.filter((t: any) => t.file === 'src/dedup.ts');
+      expect(threads).toHaveLength(1);
+    });
+
     it.skip('GET /api/heartbeat returns SSE headers', async () => {
       // Skipped due to connection reset issues in test environment
       // SSE endpoint functionality is verified through manual testing

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -11,7 +11,11 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 import { type DiffMode } from '../types/watch.js';
 import { formatCommentsOutput } from '../utils/commentFormatting.js';
-import { serializeCommentImports } from '../utils/commentImports.js';
+import {
+  mergeCommentImports,
+  normalizeCommentImports,
+  serializeCommentImports,
+} from '../utils/commentImports.js';
 import { normalizeDiffViewMode } from '../utils/diffMode.js';
 import { resolveEditorOption } from '../utils/editorOptions.js';
 import { getFileExtension } from '../utils/fileUtils.js';
@@ -509,6 +513,53 @@ export async function startServer(
     } else {
       res.send('');
     }
+  });
+
+  function threadToDiffThread(thread: CommentThread): DiffCommentThread {
+    return {
+      id: thread.id,
+      filePath: thread.file,
+      createdAt: thread.createdAt,
+      updatedAt: thread.updatedAt,
+      position: {
+        side: thread.side ?? 'new',
+        line: Array.isArray(thread.line)
+          ? { start: thread.line[0], end: thread.line[1] }
+          : thread.line,
+      },
+      codeSnapshot: thread.codeContent ? { content: thread.codeContent } : undefined,
+      messages: thread.messages,
+    };
+  }
+
+  app.post('/api/comment-imports', (req, res) => {
+    try {
+      const body: unknown =
+        typeof req.body === 'string' ? JSON.parse(req.body as string) : req.body;
+      const imports = normalizeCommentImports(body);
+      const importId = createHash('sha256').update(serializeCommentImports(imports)).digest('hex');
+
+      // Merge imports into server-side threads so they're available via comments-output/comments-json
+      const existingDiffThreads = finalThreads.map(threadToDiffThread);
+      const merged = mergeCommentImports(existingDiffThreads, imports);
+      finalThreads = merged.threads.map(normalizeThreadPayload);
+
+      fileWatcher.broadcastCommentImport({
+        type: 'commentImports',
+        commentImports: imports,
+        commentImportId: importId,
+      });
+
+      res.json({ success: true, importId, count: imports.length });
+    } catch (error) {
+      res.status(400).json({
+        error: error instanceof Error ? error.message : 'Invalid comment import data',
+      });
+    }
+  });
+
+  app.get('/api/comments-json', (_req, res) => {
+    res.json({ threads: finalThreads });
   });
 
   app.post('/api/open-in-editor', async (req, res) => {

--- a/src/types/watch.ts
+++ b/src/types/watch.ts
@@ -1,9 +1,17 @@
+import type { CommentImport } from './diff.js';
+
 export enum DiffMode {
   DEFAULT = 'default', // HEAD^ vs HEAD
   WORKING = 'working', // staged vs working
   STAGED = 'staged', // HEAD vs staged
   DOT = 'dot', // HEAD vs working (all changes)
   SPECIFIC = 'specific', // commit vs commit (no watching)
+}
+
+export interface CommentImportsWatchEvent {
+  type: 'commentImports';
+  commentImports: CommentImport[];
+  commentImportId: string;
 }
 
 export interface ClientWatchState {

--- a/src/utils/commentImports.ts
+++ b/src/utils/commentImports.ts
@@ -149,7 +149,7 @@ function normalizeCommentImportEntry(value: unknown): CommentImport {
   return normalized as CommentImport;
 }
 
-function normalizeCommentImports(input: unknown): CommentImport[] {
+export function normalizeCommentImports(input: unknown): CommentImport[] {
   if (Array.isArray(input)) {
     return input.map((entry) => normalizeCommentImportEntry(entry));
   }


### PR DESCRIPTION
Closes #292

## Summary

Adds the ability to inject and retrieve comments on a running difit server, enabling an interactive review workflow where AI agents can read/write comments without restarting difit.

- Add `--background` flag for async server startup with JSON output (`{port, url, pid}`)
- Add `difit comment add --port <port> <json>` to inject comments into a running server
- Add `difit comment get --port <port> [--format text|json]` to retrieve comments
- Add `POST /api/comment-imports` endpoint with validation, dedup, server-side merge, and SSE broadcast
- Add `GET /api/comments-json` endpoint for programmatic comment retrieval
- Real-time browser updates via SSE when comments are injected via CLI

### Usage

```bash
# Start server in background (for AI agents)
difit . --background
# => {"port":4966,"url":"http://localhost:4966","pid":12345}

# Add a comment to a running server
difit comment add --port 4966 '{"type":"thread","filePath":"src/index.ts","position":{"side":"new","line":10},"body":"Review comment"}'

# Add via stdin pipe
echo '[...]' | difit comment add --port 4966

# Retrieve comments (text format, default)
difit comment get --port 4966

# Retrieve comments (JSON format)
difit comment get --port 4966 --format json
```

## Test plan

- [x] `pnpm run build` passes
- [x] `pnpm run check` (oxlint) passes with 0 errors/warnings
- [x] `pnpm run knip` passes
- [x] `pnpm run test` passes (643 tests, including 20 new tests)
- [x] Manual test: `difit . --background` starts server and outputs JSON
- [x] Manual test: `difit comment add` injects comments and they appear in browser via SSE
- [x] Manual test: `difit comment get` retrieves comments in text/json format
- [x] Manual test: Reply comments are threaded correctly
- [x] Manual test: stdin pipe input works
- [x] Manual test: Invalid `--format` is rejected with helpful error

🤖 Generated with [Claude Code](https://claude.com/claude-code)