### PR TITLE
Fix direct diff comparisons to honor merge-base only when requested

### DIFF
--- a/src/server/git-diff-tui.test.ts
+++ b/src/server/git-diff-tui.test.ts
@@ -43,8 +43,8 @@ describe('loadGitDiff', () => {
       name: 'commit comparisons',
       targetCommitish: 'HEAD',
       baseCommitish: 'HEAD^',
-      expectedListArgs: ['HEAD^...HEAD', '--name-status'],
-      expectedFileArgs: ['HEAD^...HEAD', '-U5', '--', 'src/file.ts'],
+      expectedListArgs: ['HEAD^', 'HEAD', '--name-status'],
+      expectedFileArgs: ['HEAD^', 'HEAD', '-U5', '--', 'src/file.ts'],
     },
   ])(
     'passes context lines for $name',

--- a/src/server/git-diff-tui.ts
+++ b/src/server/git-diff-tui.ts
@@ -1,6 +1,6 @@
 import simpleGit from 'simple-git';
 
-import { validateDiffArguments, createCommitRangeString } from '../cli/utils.js';
+import { validateDiffArguments } from '../cli/utils.js';
 import type { DiffSelection, FileDiff } from '../types/diff.js';
 import { getMergeBaseTargetRef, normalizeBaseMode } from '../utils/diffSelection.js';
 
@@ -38,10 +38,7 @@ export async function loadGitDiff(
     diff = await git.diff([effectiveBaseCommitish, '--name-status']);
   } else {
     // Both are regular commits: standard commit-to-commit comparison
-    diff = await git.diff([
-      createCommitRangeString(effectiveBaseCommitish, targetCommitish),
-      '--name-status',
-    ]);
+    diff = await git.diff([effectiveBaseCommitish, targetCommitish, '--name-status']);
 
     if (!diff.trim()) {
       // Try without parent (for initial commit)
@@ -83,7 +80,8 @@ export async function loadGitDiff(
         try {
           // Both are regular commits: standard commit-to-commit comparison
           fileDiff = await git.diff([
-            createCommitRangeString(effectiveBaseCommitish, targetCommitish),
+            effectiveBaseCommitish,
+            targetCommitish,
             ...contextArgs,
             '--',
             path,

--- a/src/server/git-diff.test.ts
+++ b/src/server/git-diff.test.ts
@@ -1294,7 +1294,8 @@ index abc123..def456 100644
       );
 
       expect(gitDiff).toHaveBeenCalledWith([
-        'abcdef1...1234567',
+        'abcdef1234567890abcdef1234567890abcdef12',
+        '1234567890abcdef1234567890abcdef12345678',
         '-U5',
         '--no-ext-diff',
         '--color=never',
@@ -1327,7 +1328,12 @@ index abc123..def456 100644
 
       expect(gitRevparse).toHaveBeenNthCalledWith(1, ['codex/comment-thread']);
       expect(gitRevparse).toHaveBeenNthCalledWith(2, ['codex/comment-thread^']);
-      expect(gitDiff).toHaveBeenCalledWith(['abcdef1...1234567', '--no-ext-diff', '--color=never']);
+      expect(gitDiff).toHaveBeenCalledWith([
+        'abcdef1234567890abcdef1234567890abcdef12',
+        '1234567890abcdef1234567890abcdef12345678',
+        '--no-ext-diff',
+        '--color=never',
+      ]);
       expect(response).toEqual({
         commit: 'abcdef1...1234567',
         files: [],

--- a/src/server/git-diff.ts
+++ b/src/server/git-diff.ts
@@ -101,7 +101,7 @@ export class GitDiffParser {
         resolvedCommit = createCommitRangeString(shortHash(baseHash), shortHash(targetHash));
         resolvedBaseCommitish = shortHash(baseHash);
         resolvedTargetCommitish = shortHash(targetHash);
-        diffArgs = [resolvedCommit];
+        diffArgs = [baseHash, targetHash];
       }
 
       if (ignoreWhitespace) {


### PR DESCRIPTION
## Summary
- stop using `...` commit ranges for normal commit-to-commit diffs in server diff loading and parsing
- keep `merge-base` behavior gated behind explicit `baseMode: 'merge-base'`
- update server and TUI tests to assert direct `git diff <base> <target>` arguments

## Testing
- `pnpm test src/server/git-diff.test.ts src/server/git-diff-tui.test.ts`
- `pnpm run check`