### PR TITLE
Fix comment session synchronization across CLI, browser, and diff selections

### DIFF
--- a/src/cli/comment.ts
+++ b/src/cli/comment.ts
@@ -2,7 +2,31 @@ import { Command, Option } from 'commander';
 
 import { parseCommentImportValue } from '../utils/commentImports.js';
 
-import { readStdin } from './utils.js';
+import { detectStdinSource, readStdin } from './utils.js';
+
+interface CommentImportResponse {
+  success?: boolean;
+  importId?: string;
+  count?: number;
+  warnings?: string[];
+}
+
+async function parseCommentAddInput(json?: string): Promise<string> {
+  if (typeof json === 'string') {
+    return json;
+  }
+
+  if (detectStdinSource() === 'tty') {
+    throw new Error('Provide comment JSON as an argument or via stdin');
+  }
+
+  const stdin = await readStdin();
+  if (!stdin.trim()) {
+    throw new Error('No comment JSON received from stdin');
+  }
+
+  return stdin;
+}
 
 export function createCommentCommand(): Command {
   const comment = new Command('comment').description(
@@ -16,12 +40,7 @@ export function createCommentCommand(): Command {
     .requiredOption('--port <port>', 'port of the running difit server', parseInt)
     .action(async (json: string | undefined, opts: { port: number }) => {
       try {
-        const input = json ?? (await readStdin());
-        if (!input.trim()) {
-          console.error('Error: No comment data provided. Pass JSON as argument or via stdin.');
-          process.exit(1);
-        }
-
+        const input = await parseCommentAddInput(json);
         const imports = parseCommentImportValue(input);
 
         const response = await fetch(`http://localhost:${opts.port}/api/comment-imports`, {
@@ -31,21 +50,18 @@ export function createCommentCommand(): Command {
         });
 
         if (!response.ok) {
-          const error = (await response.json()) as { error?: string };
-          console.error(`Error: ${error.error ?? 'Failed to add comments'}`);
+          const errorBody = (await response.json().catch(() => ({}))) as { error?: string };
+          console.error(`Error: ${errorBody.error ?? 'Failed to add comments'}`);
           process.exit(1);
         }
 
-        const result = (await response.json()) as {
-          success: boolean;
-          importId: string;
-          count: number;
-        };
+        const result = (await response.json()) as CommentImportResponse;
         console.log(
           JSON.stringify({
-            success: result.success,
+            success: result.success ?? true,
             importId: result.importId,
-            count: result.count,
+            count: result.count ?? imports.length,
+            warnings: result.warnings ?? [],
           }),
         );
       } catch (error) {
@@ -86,10 +102,14 @@ export function createCommentCommand(): Command {
             console.log(text);
           }
         }
-      } catch {
-        console.error(
-          `Error: Cannot connect to difit server on port ${opts.port}. Is the server running?`,
-        );
+      } catch (error) {
+        if (error instanceof TypeError && error.message.includes('fetch failed')) {
+          console.error(
+            `Error: Cannot connect to difit server on port ${opts.port}. Is the server running?`,
+          );
+        } else {
+          console.error(`Error: ${error instanceof Error ? error.message : 'Unknown error'}`);
+        }
         process.exit(1);
       }
     });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { spawn } from 'child_process';
 import { Command } from 'commander';
 import React from 'react';
 import { simpleGit, type SimpleGit } from 'simple-git';
@@ -75,6 +76,88 @@ function determineDiffMode(selection: DiffSelection, compareWith?: string): Diff
   return DiffMode.DEFAULT;
 }
 
+async function startBackgroundProcess(): Promise<void> {
+  const scriptPath = process.argv[1];
+  if (!scriptPath) {
+    throw new Error('Unable to determine difit entrypoint for background process');
+  }
+
+  const childArgs = process.argv.slice(2).filter((arg) => arg !== '--background');
+  if (!childArgs.includes('--keep-alive')) {
+    childArgs.push('--keep-alive');
+  }
+  if (!childArgs.includes('--no-open')) {
+    childArgs.push('--no-open');
+  }
+
+  const child = spawn(process.execPath, [scriptPath, ...childArgs], {
+    detached: true,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: {
+      ...process.env,
+      [BACKGROUND_CHILD_ENV]: '1',
+    },
+  });
+
+  child.stdout.setEncoding('utf8');
+  child.stderr.setEncoding('utf8');
+
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error('Timed out while starting background difit server'));
+    }, 10_000);
+    let stderr = '';
+    let settled = false;
+
+    const finish = (callback: () => void) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      callback();
+    };
+
+    child.stdout.on('data', (chunk: string) => {
+      const line = chunk
+        .split(/\r?\n/u)
+        .map((value) => value.trim())
+        .find((value) => value.length > 0);
+
+      if (!line) {
+        return;
+      }
+
+      finish(() => {
+        console.log(line);
+        child.unref();
+        resolve();
+      });
+    });
+
+    child.stderr.on('data', (chunk: string) => {
+      stderr += chunk;
+    });
+
+    child.once('error', (error) => {
+      finish(() => {
+        reject(error);
+      });
+    });
+
+    child.once('exit', (code) => {
+      finish(() => {
+        const trimmedStderr = stderr.trim();
+        reject(
+          new Error(
+            trimmedStderr || `Background difit server exited early (code ${code ?? 'unknown'})`,
+          ),
+        );
+      });
+    });
+  });
+}
+
 interface CliOptions {
   port?: number;
   host?: string;
@@ -86,10 +169,12 @@ interface CliOptions {
   clean?: boolean;
   includeUntracked?: boolean;
   keepAlive?: boolean;
+  background?: boolean;
   context?: number;
   mergeBase?: boolean;
-  background?: boolean;
 }
+
+const BACKGROUND_CHILD_ENV = 'DIFIT_BACKGROUND_CHILD';
 
 const program = new Command();
 
@@ -98,6 +183,7 @@ program
   .description('A lightweight Git diff viewer with GitHub-like interface')
   .version(pkg.version, '-v, --version', 'output the version number')
   .enablePositionalOptions()
+  .addCommand(createCommentCommand())
   .argument(
     '[commit-ish]',
     'Git commit, tag, branch, HEAD~n reference, or "working"/"staged"/"."',
@@ -127,20 +213,16 @@ program
   .option('--clean', 'start with a clean slate by clearing all existing comments')
   .option('--include-untracked', 'automatically include untracked files in diff')
   .option('--keep-alive', 'keep server running even after browser disconnects')
+  .option('--background', 'keep the server running in the background and output JSON info')
   .option('--context <lines>', 'number of context lines shown around each change', parseInt)
   .option(
     '--merge-base',
     'resolve the base revision with git merge-base before diffing (Git revision mode only)',
   )
-  .option('--background', 'start server in background and output JSON with port info')
   .action(async (commitish: string, compareWith: string | undefined, options: CliOptions) => {
     try {
-      // --background implies --keep-alive and --no-open
-      if (options.background) {
-        options.keepAlive = true;
-        options.open = false;
-      }
-
+      const isBackgroundChild = process.env[BACKGROUND_CHILD_ENV] === '1';
+      const backgroundMode = options.background || isBackgroundChild;
       let stdinDiff: string | undefined;
       let stdinReviewLabel = 'diff from stdin';
       let manualCommentImports: CommentImport[] = [];
@@ -154,6 +236,11 @@ program
         process.exit(1);
       }
 
+      if (options.background && !isBackgroundChild) {
+        await startBackgroundProcess();
+        return;
+      }
+
       try {
         manualCommentImports = parseCommentOptions(options.comment);
         commentImports = manualCommentImports;
@@ -162,6 +249,11 @@ program
           `Error: ${error instanceof Error ? error.message : 'Invalid --comment value'}`,
         );
         process.exit(1);
+      }
+
+      if (backgroundMode) {
+        options.keepAlive = true;
+        options.open = false;
       }
 
       if (options.pr) {
@@ -243,7 +335,7 @@ program
           ...(commentImports.length > 0 ? { commentImports } : {}),
         });
 
-        if (options.background) {
+        if (backgroundMode) {
           console.log(JSON.stringify({ port, url, pid: process.pid }));
           return;
         }
@@ -277,10 +369,19 @@ program
 
       if (selection.targetCommitish === 'working' || selection.targetCommitish === '.') {
         const git = simpleGit(repoPath);
-        await handleUntrackedFiles(git, options.includeUntracked);
+        if (isBackgroundChild && !options.includeUntracked) {
+          // Skip interactive prompts in detached background mode.
+        } else {
+          await handleUntrackedFiles(git, options.includeUntracked);
+        }
       }
 
       if (options.tui) {
+        if (backgroundMode) {
+          console.error('Error: --background option cannot be used with --tui');
+          process.exit(1);
+        }
+
         if (commentImports.length > 0) {
           console.error('Error: --comment option cannot be used with --tui');
           process.exit(1);
@@ -330,7 +431,7 @@ program
         ...(commentImports.length > 0 ? { commentImports } : {}),
       });
 
-      if (options.background) {
+      if (backgroundMode) {
         console.log(JSON.stringify({ port, url, pid: process.pid }));
         return;
       }
@@ -381,11 +482,8 @@ program
     }
   });
 
-program.addCommand(createCommentCommand());
+void program.parseAsync();
 
-program.parse();
-
-// Check for untracked files and prompt user to add them for diff visibility
 async function handleUntrackedFiles(git: SimpleGit, addAutomatically?: boolean): Promise<void> {
   const files = await findUntrackedFiles(git);
   if (files.length === 0) {

--- a/src/client/App.test.tsx
+++ b/src/client/App.test.tsx
@@ -22,8 +22,10 @@ vi.mock('./hooks/useViewport', () => ({
 // Mock the useDiffComments hook
 vi.mock('./hooks/useDiffComments', () => ({
   useDiffComments: vi.fn(() => ({
+    hasLoadedComments: true,
     comments: [],
     threads: mockComments,
+    replaceThreads: mockReplaceThreads,
     addComment: vi.fn(),
     addThread: vi.fn(),
     removeComment: vi.fn(),
@@ -119,6 +121,7 @@ Object.defineProperty(window, 'EventSource', {
 });
 
 let mockComments: DiffCommentThread[] = [];
+const mockReplaceThreads = vi.fn();
 const mockClearAllComments = vi.fn();
 const mockApplyCommentImports = vi.fn(() => []);
 
@@ -169,10 +172,15 @@ beforeEach(() => {
   MockEventSource.clearInstances();
   mockViewedFiles = new Set<string>();
   mockHasLoadedInitialViewedFiles = true;
+  mockReplaceThreads.mockReset();
 });
 
 const mockDiffResponse: DiffResponse = {
   commit: 'abc123',
+  baseCommitish: 'HEAD^',
+  targetCommitish: 'HEAD',
+  requestedBaseCommitish: 'HEAD^',
+  requestedTargetCommitish: 'HEAD',
   files: [
     {
       path: 'test.ts',
@@ -335,29 +343,51 @@ describe('App Component - Clear Comments Functionality', () => {
       consoleLogSpy.mockRestore();
     });
 
-    it('applies imported comments after loading the diff response', async () => {
-      const responseWithImports: DiffResponse = {
-        ...mockDiffResponse,
-        commentImportId: 'import-bundle-1',
-        commentImports: [
-          {
-            type: 'thread',
-            filePath: 'test.ts',
-            position: { side: 'new', line: 10 },
-            body: 'Imported comment',
-          },
-        ],
-      };
+    it('hydrates comments from the server comment session on startup', async () => {
+      const serverThreads = [
+        createMockThread({
+          id: 'imported-thread',
+          filePath: 'test.ts',
+          line: 10,
+          body: 'Imported comment',
+        }),
+      ];
 
-      mockFetch(responseWithImports);
+      vi.mocked(global.fetch).mockImplementation((input) => {
+        const url = String(input);
+
+        if (url === '/api/comments-json') {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ threads: serverThreads }),
+          } as Response);
+        }
+
+        if (url === '/api/comments') {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ success: true }),
+          } as Response);
+        }
+
+        if (url === '/api/revisions') {
+          return Promise.resolve({
+            ok: true,
+            json: async () => null,
+          } as Response);
+        }
+
+        return Promise.resolve({
+          ok: true,
+          json: async () => mockDiffResponse,
+          blob: async () => ({ size: 1024 }),
+        } as Response);
+      });
 
       renderApp();
 
       await waitFor(() => {
-        expect(mockApplyCommentImports).toHaveBeenCalledWith(
-          responseWithImports.commentImports,
-          'import-bundle-1',
-        );
+        expect(mockReplaceThreads).toHaveBeenCalledWith(serverThreads);
       });
     });
   });
@@ -442,8 +472,8 @@ describe('App Component - Comment sync', () => {
         threads: [
           expect.objectContaining({
             id: 'test-1',
-            file: 'test.ts',
-            line: 10,
+            filePath: 'test.ts',
+            position: { side: 'new', line: 10 },
             messages: [
               expect.objectContaining({
                 id: 'test-1',
@@ -475,25 +505,25 @@ describe('App Component - Comment sync', () => {
 
   it('sends an empty comment list on unload when no comments remain', async () => {
     mockComments = [];
+    const addEventListenerSpy = vi.spyOn(window, 'addEventListener');
 
     renderApp();
 
     await waitFor(() => {
-      expect(vi.mocked(global.fetch)).toHaveBeenCalledWith(
-        '/api/comments',
-        expect.objectContaining({
-          method: 'POST',
-          body: JSON.stringify({ threads: [] }),
-        }),
-      );
+      expect(addEventListenerSpy).toHaveBeenCalledWith('beforeunload', expect.any(Function));
     });
 
-    fireEvent(window, new Event('beforeunload'));
+    const beforeUnloadHandler = addEventListenerSpy.mock.calls.find(
+      ([eventName]) => eventName === 'beforeunload',
+    )?.[1] as (() => void) | undefined;
+    expect(beforeUnloadHandler).toBeDefined();
+    beforeUnloadHandler?.();
 
     expect(navigator.sendBeacon).toHaveBeenCalledWith(
       '/api/comments',
       JSON.stringify({ threads: [] }),
     );
+    addEventListenerSpy.mockRestore();
   });
 
   it('shows author badges in the comments modal when the diff has multiple authors', async () => {

--- a/src/client/App.test.tsx
+++ b/src/client/App.test.tsx
@@ -356,14 +356,14 @@ describe('App Component - Clear Comments Functionality', () => {
       vi.mocked(global.fetch).mockImplementation((input) => {
         const url = String(input);
 
-        if (url === '/api/comments-json') {
+        if (url.startsWith('/api/comments-json')) {
           return Promise.resolve({
             ok: true,
             json: async () => ({ threads: serverThreads }),
           } as Response);
         }
 
-        if (url === '/api/comments') {
+        if (url.startsWith('/api/comments')) {
           return Promise.resolve({
             ok: true,
             json: async () => ({ success: true }),
@@ -389,6 +389,10 @@ describe('App Component - Clear Comments Functionality', () => {
       await waitFor(() => {
         expect(mockReplaceThreads).toHaveBeenCalledWith(serverThreads);
       });
+
+      expect(vi.mocked(global.fetch)).toHaveBeenCalledWith(
+        '/api/comments-json?base=HEAD%5E&target=HEAD',
+      );
     });
   });
 });
@@ -463,10 +467,13 @@ describe('App Component - Comment sync', () => {
     const { rerender } = renderApp();
 
     await waitFor(() => {
-      const commentCalls = mockGlobalFetch.mock.calls.filter(([url]) => url === '/api/comments');
+      const commentCalls = mockGlobalFetch.mock.calls.filter(([url]) =>
+        String(url).startsWith('/api/comments?'),
+      );
       expect(commentCalls).toHaveLength(1);
 
-      const [, request] = commentCalls[0] as [string, RequestInit];
+      const [url, request] = commentCalls[0] as [string, RequestInit];
+      expect(url).toBe('/api/comments?base=HEAD%5E&target=HEAD');
       expect(request.method).toBe('POST');
       expect(JSON.parse(String(request.body))).toEqual({
         threads: [
@@ -494,10 +501,13 @@ describe('App Component - Comment sync', () => {
     );
 
     await waitFor(() => {
-      const commentCalls = mockGlobalFetch.mock.calls.filter(([url]) => url === '/api/comments');
+      const commentCalls = mockGlobalFetch.mock.calls.filter(([url]) =>
+        String(url).startsWith('/api/comments?'),
+      );
       expect(commentCalls).toHaveLength(2);
 
-      const [, request] = commentCalls[1] as [string, RequestInit];
+      const [url, request] = commentCalls[1] as [string, RequestInit];
+      expect(url).toBe('/api/comments?base=HEAD%5E&target=HEAD');
       expect(request.method).toBe('POST');
       expect(JSON.parse(String(request.body))).toEqual({ threads: [] });
     });
@@ -520,7 +530,7 @@ describe('App Component - Comment sync', () => {
     beforeUnloadHandler?.();
 
     expect(navigator.sendBeacon).toHaveBeenCalledWith(
-      '/api/comments',
+      '/api/comments?base=HEAD%5E&target=HEAD',
       JSON.stringify({ threads: [] }),
     );
     addEventListenerSpy.mockRestore();
@@ -839,7 +849,7 @@ describe('App Component - Revision-aware refetching', () => {
         } as Response);
       }
 
-      if (url.includes('/api/comments')) {
+      if (url.startsWith('/api/comments?')) {
         return Promise.resolve({
           ok: true,
           json: async () => ({ success: true }),

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -2,7 +2,7 @@ import { Columns, AlignLeft, Settings, PanelLeftClose, PanelLeft, Keyboard } fro
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 
 import {
-  type CommentImport,
+  type DiffCommentThread,
   type DiffResponse,
   type DiffSelection,
   type DiffViewMode,
@@ -12,6 +12,7 @@ import {
   type RevisionsResponse,
 } from '../types/diff';
 import { DEFAULT_DIFF_VIEW_MODE, normalizeDiffViewMode } from '../utils/diffMode';
+import { mergeCommentThreads } from '../utils/commentImports';
 import {
   createDiffSelection,
   diffSelectionsEqual,
@@ -151,14 +152,15 @@ function App() {
 
   // New diff-aware comment system
   const {
+    hasLoadedComments,
     threads,
+    replaceThreads,
     addThread,
     replyToThread,
     removeThread,
     removeMessage,
     updateMessage,
     clearAllComments,
-    applyCommentImports,
     generateThreadPrompt,
     generateAllCommentsPrompt,
   } = useDiffComments(
@@ -205,6 +207,43 @@ function App() {
     return map;
   }, [normalizedThreads]);
   const showMobileCommentsBar = isMobile && threads.length > 0;
+  const commentsContextKey = useMemo(() => {
+    if (!resolvedSelectionKey || !diffData?.commit) {
+      return null;
+    }
+
+    return `${diffData.repositoryId ?? 'default'}:${resolvedSelectionKey}:${diffData.commit}`;
+  }, [diffData?.commit, diffData?.repositoryId, resolvedSelectionKey]);
+  const [bootstrappedCommentsKey, setBootstrappedCommentsKey] = useState<string | null>(null);
+  const hasBootstrappedComments =
+    commentsContextKey !== null && commentsContextKey === bootstrappedCommentsKey;
+  const bootstrappingCommentsKeyRef = useRef<string | null>(null);
+  const skipNextCommentSyncRef = useRef(false);
+  const pendingBootstrapAfterLocalResetRef = useRef(false);
+
+  useEffect(() => {
+    if (commentsContextKey !== bootstrappedCommentsKey) {
+      skipNextCommentSyncRef.current = false;
+    }
+  }, [bootstrappedCommentsKey, commentsContextKey]);
+
+  const fetchServerThreads = useCallback(async (): Promise<DiffCommentThread[]> => {
+    const response = await fetch('/api/comments-json');
+    if (!response.ok) {
+      throw new Error(`Failed to fetch comments: ${response.status} ${response.statusText}`);
+    }
+
+    const payload = (await response.json()) as { threads?: DiffCommentThread[] };
+    return Array.isArray(payload.threads) ? payload.threads : [];
+  }, []);
+
+  const syncThreadsToServer = useCallback(async (nextThreads: DiffCommentThread[]) => {
+    await fetch('/api/comments', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ threads: nextThreads }),
+    });
+  }, []);
 
   // Viewed files management
   const { viewedFiles, hasLoadedInitialViewedFiles, toggleFileViewed, clearViewedFiles } =
@@ -370,20 +409,28 @@ function App() {
     chunkIndex: number;
     lineIndex: number;
   } | null>(null);
-
-  // Handle comment imports received via SSE
-  const handleCommentImports = useCallback(
-    (imports: CommentImport[], importId: string) => {
-      const warnings = applyCommentImports(imports, importId);
-      warnings.forEach((warning) => console.warn(warning));
-    },
-    [applyCommentImports],
-  );
+  const fetchDiffDataRef = useRef<((selection?: DiffSelection) => Promise<void>) | null>(null);
+  const handleWatchReload = useCallback(async () => {
+    await fetchDiffDataRef.current?.();
+  }, []);
+  const handleCommentsChanged = useCallback(async () => {
+    try {
+      const serverThreads = await fetchServerThreads();
+      skipNextCommentSyncRef.current = true;
+      replaceThreads(serverThreads);
+      if (commentsContextKey) {
+        setBootstrappedCommentsKey(commentsContextKey);
+      }
+    } catch (commentsError) {
+      console.error('Failed to refresh comments from server:', commentsError);
+    }
+  }, [commentsContextKey, fetchServerThreads, replaceThreads]);
 
   // File watch for reload functionality - initialize with callback
-  const { shouldReload, reload, watchState } = useFileWatch(async () => {
-    await fetchDiffData();
-  }, handleCommentImports);
+  const { shouldReload, reload, watchState } = useFileWatch(
+    handleWatchReload,
+    handleCommentsChanged,
+  );
 
   const { cursor, isHelpOpen, setIsHelpOpen, setCursorPosition } = useKeyboardNavigation({
     files: navigableFiles,
@@ -547,6 +594,7 @@ function App() {
     },
     [ignoreWhitespace],
   );
+  fetchDiffDataRef.current = fetchDiffData;
 
   useEffect(() => {
     void fetchDiffData();
@@ -620,6 +668,7 @@ function App() {
   useEffect(() => {
     if (diffData?.clearComments && !hasCleanedRef.current) {
       hasCleanedRef.current = true;
+      pendingBootstrapAfterLocalResetRef.current = true;
       clearAllComments({ resetAppliedCommentImportIds: true });
       clearViewedFiles();
       console.log(
@@ -629,13 +678,71 @@ function App() {
   }, [diffData?.clearComments, clearAllComments, clearViewedFiles]);
 
   useEffect(() => {
-    if (!diffData?.commentImportId || !diffData.commentImports?.length) {
+    if (!commentsContextKey || !hasLoadedComments) {
       return;
     }
 
-    const warnings = applyCommentImports(diffData.commentImports, diffData.commentImportId);
-    warnings.forEach((warning) => console.warn(warning));
-  }, [applyCommentImports, diffData?.commentImportId, diffData?.commentImports]);
+    if (bootstrappedCommentsKey === commentsContextKey) {
+      return;
+    }
+
+    if (bootstrappingCommentsKeyRef.current === commentsContextKey) {
+      return;
+    }
+
+    if (pendingBootstrapAfterLocalResetRef.current) {
+      pendingBootstrapAfterLocalResetRef.current = false;
+      return;
+    }
+
+    bootstrappingCommentsKeyRef.current = commentsContextKey;
+    let cancelled = false;
+
+    const bootstrapComments = async () => {
+      try {
+        const serverThreads = await fetchServerThreads();
+        const mergedThreads = mergeCommentThreads(serverThreads, threads).threads;
+        if (cancelled) {
+          return;
+        }
+
+        skipNextCommentSyncRef.current = true;
+        replaceThreads(mergedThreads);
+
+        if (JSON.stringify(serverThreads) !== JSON.stringify(mergedThreads)) {
+          await syncThreadsToServer(mergedThreads);
+        }
+      } catch (commentsError) {
+        if (!cancelled) {
+          console.error('Failed to bootstrap comments from server:', commentsError);
+        }
+      } finally {
+        if (!cancelled) {
+          setBootstrappedCommentsKey(commentsContextKey);
+        }
+        if (bootstrappingCommentsKeyRef.current === commentsContextKey) {
+          bootstrappingCommentsKeyRef.current = null;
+        }
+      }
+    };
+
+    void bootstrapComments();
+
+    return () => {
+      cancelled = true;
+      if (bootstrappingCommentsKeyRef.current === commentsContextKey) {
+        bootstrappingCommentsKeyRef.current = null;
+      }
+    };
+  }, [
+    bootstrappedCommentsKey,
+    commentsContextKey,
+    fetchServerThreads,
+    hasLoadedComments,
+    replaceThreads,
+    syncThreadsToServer,
+    threads,
+  ]);
 
   // Trigger sparkle animation when all files are viewed
   useEffect(() => {
@@ -658,15 +765,11 @@ function App() {
 
   // Send comments to server whenever they change and before page unload
   useEffect(() => {
-    const data = JSON.stringify({ threads: normalizedThreads });
+    if (!hasBootstrappedComments) {
+      return;
+    }
 
-    fetch('/api/comments', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: data,
-    }).catch((error) => {
-      console.error('Failed to sync comments:', error);
-    });
+    const data = JSON.stringify({ threads });
 
     // Also handle page unload
     const sendCommentsBeforeUnload = () => {
@@ -676,10 +779,21 @@ function App() {
 
     window.addEventListener('beforeunload', sendCommentsBeforeUnload);
 
+    if (skipNextCommentSyncRef.current) {
+      skipNextCommentSyncRef.current = false;
+      return () => {
+        window.removeEventListener('beforeunload', sendCommentsBeforeUnload);
+      };
+    }
+
+    syncThreadsToServer(threads).catch((syncError) => {
+      console.error('Failed to sync comments:', syncError);
+    });
+
     return () => {
       window.removeEventListener('beforeunload', sendCommentsBeforeUnload);
     };
-  }, [normalizedThreads]);
+  }, [hasBootstrappedComments, syncThreadsToServer, threads]);
 
   // Establish SSE connection for tab close detection
   useEffect(() => {

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -208,12 +208,36 @@ function App() {
   }, [normalizedThreads]);
   const showMobileCommentsBar = isMobile && threads.length > 0;
   const commentsContextKey = useMemo(() => {
-    if (!resolvedSelectionKey || !diffData?.commit) {
+    if (!resolvedSelectionKey) {
       return null;
     }
 
-    return `${diffData.repositoryId ?? 'default'}:${resolvedSelectionKey}:${diffData.commit}`;
-  }, [diffData?.commit, diffData?.repositoryId, resolvedSelectionKey]);
+    return `${diffData?.repositoryId ?? 'default'}:${resolvedSelectionKey}`;
+  }, [diffData?.repositoryId, resolvedSelectionKey]);
+  const commentSessionQueryString = useMemo(() => {
+    if (!resolvedSelection) {
+      return null;
+    }
+
+    const params = new URLSearchParams({
+      base: resolvedSelection.baseCommitish,
+      target: resolvedSelection.targetCommitish,
+    });
+    if (resolvedSelection.baseMode === 'merge-base') {
+      params.set('baseMode', resolvedSelection.baseMode);
+    }
+
+    return params.toString();
+  }, [resolvedSelection]);
+  const getCommentApiUrl = useCallback(
+    (path: string) => {
+      if (!commentSessionQueryString) {
+        return path;
+      }
+      return `${path}?${commentSessionQueryString}`;
+    },
+    [commentSessionQueryString],
+  );
   const [bootstrappedCommentsKey, setBootstrappedCommentsKey] = useState<string | null>(null);
   const hasBootstrappedComments =
     commentsContextKey !== null && commentsContextKey === bootstrappedCommentsKey;
@@ -228,22 +252,25 @@ function App() {
   }, [bootstrappedCommentsKey, commentsContextKey]);
 
   const fetchServerThreads = useCallback(async (): Promise<DiffCommentThread[]> => {
-    const response = await fetch('/api/comments-json');
+    const response = await fetch(getCommentApiUrl('/api/comments-json'));
     if (!response.ok) {
       throw new Error(`Failed to fetch comments: ${response.status} ${response.statusText}`);
     }
 
     const payload = (await response.json()) as { threads?: DiffCommentThread[] };
     return Array.isArray(payload.threads) ? payload.threads : [];
-  }, []);
+  }, [getCommentApiUrl]);
 
-  const syncThreadsToServer = useCallback(async (nextThreads: DiffCommentThread[]) => {
-    await fetch('/api/comments', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ threads: nextThreads }),
-    });
-  }, []);
+  const syncThreadsToServer = useCallback(
+    async (nextThreads: DiffCommentThread[]) => {
+      await fetch(getCommentApiUrl('/api/comments'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ threads: nextThreads }),
+      });
+    },
+    [getCommentApiUrl],
+  );
 
   // Viewed files management
   const { viewedFiles, hasLoadedInitialViewedFiles, toggleFileViewed, clearViewedFiles } =
@@ -770,11 +797,12 @@ function App() {
     }
 
     const data = JSON.stringify({ threads });
+    const commentsApiUrl = getCommentApiUrl('/api/comments');
 
     // Also handle page unload
     const sendCommentsBeforeUnload = () => {
       // Use sendBeacon for reliable delivery during page unload, including empty states.
-      navigator.sendBeacon('/api/comments', data);
+      navigator.sendBeacon(commentsApiUrl, data);
     };
 
     window.addEventListener('beforeunload', sendCommentsBeforeUnload);
@@ -793,7 +821,7 @@ function App() {
     return () => {
       window.removeEventListener('beforeunload', sendCommentsBeforeUnload);
     };
-  }, [hasBootstrappedComments, syncThreadsToServer, threads]);
+  }, [getCommentApiUrl, hasBootstrappedComments, syncThreadsToServer, threads]);
 
   // Establish SSE connection for tab close detection
   useEffect(() => {

--- a/src/client/hooks/useDiffComments.ts
+++ b/src/client/hooks/useDiffComments.ts
@@ -32,8 +32,10 @@ interface ReplyToThreadParams {
 }
 
 interface UseDiffCommentsReturn {
+  hasLoadedComments: boolean;
   comments: LegacyDiffComment[];
   threads: DiffCommentThread[];
+  replaceThreads: (threads: DiffCommentThread[]) => void;
   addComment: (params: AddThreadParams) => LegacyDiffComment;
   addThread: (params: AddThreadParams) => DiffCommentThread;
   removeComment: (commentId: string) => void;
@@ -90,6 +92,7 @@ export function useDiffComments(
   baseMode?: BaseMode,
 ): UseDiffCommentsReturn {
   const [threads, setThreads] = useState<DiffCommentThread[]>([]);
+  const [hasLoadedComments, setHasLoadedComments] = useState(false);
 
   const loadDiffContextData = useCallback(() => {
     if (!baseCommitish || !targetCommitish) {
@@ -126,7 +129,12 @@ export function useDiffComments(
   }, [baseCommitish, targetCommitish, baseMode]);
 
   useEffect(() => {
-    if (!baseCommitish || !targetCommitish) return;
+    if (!baseCommitish || !targetCommitish) {
+      // oxlint-disable-next-line react-hooks-js/set-state-in-effect -- intentional: clear diff-scoped state when selection is unavailable
+      setThreads([]);
+      setHasLoadedComments(false);
+      return;
+    }
 
     const loadedThreads =
       loadDiffContextData()?.threads ||
@@ -138,8 +146,8 @@ export function useDiffComments(
         repositoryId,
         baseMode,
       );
-    // oxlint-disable-next-line react-hooks-js/set-state-in-effect -- intentional: sync state from external storage on prop change
     setThreads(loadedThreads);
+    setHasLoadedComments(true);
   }, [
     baseCommitish,
     targetCommitish,
@@ -164,8 +172,16 @@ export function useDiffComments(
         baseMode,
       );
       setThreads(newThreads);
+      setHasLoadedComments(true);
     },
     [baseCommitish, targetCommitish, currentCommitHash, branchToHash, repositoryId, baseMode],
+  );
+
+  const replaceThreads = useCallback(
+    (newThreads: DiffCommentThread[]) => {
+      saveThreads(newThreads);
+    },
+    [saveThreads],
   );
 
   const addThread = useCallback(
@@ -431,8 +447,10 @@ export function useDiffComments(
     .filter((comment): comment is LegacyDiffComment => comment !== null);
 
   return {
+    hasLoadedComments,
     comments,
     threads,
+    replaceThreads,
     addComment,
     addThread,
     removeComment,

--- a/src/client/hooks/useFileWatch.ts
+++ b/src/client/hooks/useFileWatch.ts
@@ -1,11 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-import type { CommentImport } from '../../types/diff.js';
-import {
-  DiffMode,
-  type ClientWatchState,
-  type CommentImportsWatchEvent,
-} from '../../types/watch.js';
+import { DiffMode, type ClientWatchState, type WatchEvent } from '../../types/watch.js';
 import { resolveEventSourceUrl } from '../utils/eventSourceUrl';
 
 interface FileWatchHook {
@@ -16,25 +11,13 @@ interface FileWatchHook {
   watchState: ClientWatchState;
 }
 
-interface WatchEvent {
-  type: 'reload' | 'error' | 'connected';
-  diffMode: DiffMode;
-  changeType: 'file' | 'commit' | 'staging';
-  timestamp: string;
-  message?: string;
-}
-
-type ServerWatchEvent = WatchEvent | CommentImportsWatchEvent;
-
 export function useFileWatch(
   onReload?: () => Promise<void>,
-  onCommentImports?: (imports: CommentImport[], importId: string) => void,
+  onCommentsChanged?: () => Promise<void>,
 ): FileWatchHook {
   const eventSourceRef = useRef<EventSource | null>(null);
   const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const reconnectAttemptsRef = useRef(0);
-  const onCommentImportsRef = useRef(onCommentImports);
-  onCommentImportsRef.current = onCommentImports;
   const maxReconnectAttempts = 5;
   const reconnectDelay = 3000; // 3 seconds
 
@@ -72,7 +55,7 @@ export function useFileWatch(
       eventSource.onmessage = (event) => {
         try {
           // oxlint-disable-next-line typescript/no-unsafe-assignment
-          const data: ServerWatchEvent = JSON.parse(event.data as string);
+          const data: WatchEvent = JSON.parse(event.data as string);
 
           switch (data.type) {
             case 'connected':
@@ -94,13 +77,15 @@ export function useFileWatch(
               }));
               break;
 
-            case 'commentImports':
-              onCommentImportsRef.current?.(data.commentImports, data.commentImportId);
-              break;
-
             case 'error':
               console.error('File watch error:', data.message);
               setError(data.message || 'File watch error occurred');
+              break;
+
+            case 'commentsChanged':
+              if (onCommentsChanged) {
+                void onCommentsChanged();
+              }
               break;
           }
         } catch (parseError) {
@@ -146,7 +131,7 @@ export function useFileWatch(
       console.error('Failed to connect to file watch service:', connectionError);
       setError('Failed to connect to file watch service');
     }
-  }, [maxReconnectAttempts, reconnectDelay]);
+  }, [maxReconnectAttempts, onCommentsChanged, reconnectDelay]);
 
   const handleReload = useCallback(async () => {
     if (watchState.isReloading) {

--- a/src/server/file-watcher.ts
+++ b/src/server/file-watcher.ts
@@ -4,7 +4,7 @@ import { subscribe } from '@parcel/watcher';
 import { type Response } from 'express';
 import { simpleGit, type SimpleGit } from 'simple-git';
 
-import { DiffMode, type CommentImportsWatchEvent } from '../types/watch.js';
+import { DiffMode, type WatchEvent } from '../types/watch.js';
 
 interface FileWatcherConfig {
   watchPath: string;
@@ -251,7 +251,10 @@ export class FileWatcherService {
     }
   }
 
-  broadcastCommentImport(event: CommentImportsWatchEvent): void {
+  broadcast(event: WatchEvent): void {
+    if (this.clients.length === 0) {
+      return;
+    }
     this.clients.forEach((client) => {
       this.sendToClient(client, event);
     });
@@ -263,7 +266,7 @@ export class FileWatcherService {
     }
 
     const changeType = this.determineChangeType();
-    const event = {
+    const event: WatchEvent = {
       type: 'reload' as const,
       diffMode: this.config.diffMode,
       changeType,
@@ -271,9 +274,7 @@ export class FileWatcherService {
       message: `Changes detected in ${this.config.diffMode} mode`,
     };
 
-    this.clients.forEach((client) => {
-      this.sendToClient(client, event);
-    });
+    this.broadcast(event);
   }
 
   private sendToClient(client: Response, event: unknown): void {

--- a/src/server/server.test.ts
+++ b/src/server/server.test.ts
@@ -801,7 +801,7 @@ describe('Server Integration Tests', () => {
       const jsonResponse = await fetch(`http://localhost:${port}/api/comments-json`);
       const data = (await jsonResponse.json()) as any;
 
-      const thread = data.threads.find((t: any) => t.file === 'src/reply-test.ts');
+      const thread = data.threads.find((t: any) => t.filePath === 'src/reply-test.ts');
       expect(thread).toBeDefined();
       expect(thread.messages).toHaveLength(2);
       expect(thread.messages[0].body).toBe('Original comment');
@@ -833,7 +833,7 @@ describe('Server Integration Tests', () => {
       const jsonResponse = await fetch(`http://localhost:${port}/api/comments-json`);
       const data = (await jsonResponse.json()) as any;
 
-      const threads = data.threads.filter((t: any) => t.file === 'src/dedup.ts');
+      const threads = data.threads.filter((t: any) => t.filePath === 'src/dedup.ts');
       expect(threads).toHaveLength(1);
     });
 

--- a/src/server/server.test.ts
+++ b/src/server/server.test.ts
@@ -837,6 +837,99 @@ describe('Server Integration Tests', () => {
       expect(threads).toHaveLength(1);
     });
 
+    it('isolates comment sessions between different diff selections', async () => {
+      const importServer = await startServer({
+        selection: { targetCommitish: 'HEAD', baseCommitish: 'HEAD^' },
+        preferredPort: 9039,
+        commentImports: [
+          {
+            type: 'thread',
+            filePath: 'src/cli/comment.test.ts',
+            position: { side: 'new', line: 10 },
+            body: 'Startup comment',
+          },
+        ],
+      });
+      servers.push(importServer.server);
+
+      const parser = parserInstances.at(-1);
+      parser?.parseDiff.mockImplementation(async (selection: any) => ({
+        targetCommit: 'abc123',
+        baseCommit: 'def456',
+        baseCommitish: selection.baseCommitish === 'HEAD^' ? 'def4567' : selection.baseCommitish,
+        targetCommitish:
+          selection.targetCommitish === 'HEAD' ? 'abc1234' : selection.targetCommitish,
+        requestedBaseCommitish: selection.baseCommitish,
+        requestedTargetCommitish: selection.targetCommitish,
+        requestedBaseMode: selection.baseMode,
+        targetMessage: 'Test commit',
+        baseMessage: 'Previous commit',
+        files: [
+          {
+            path: 'src/cli/comment.test.ts',
+            additions: 10,
+            deletions: 5,
+            chunks: [],
+          },
+        ],
+        stats: { additions: 10, deletions: 5 },
+        isEmpty: false,
+      }));
+
+      await fetch(`http://localhost:${importServer.port}/api/comment-imports`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify([
+          {
+            type: 'thread',
+            filePath: 'src/cli/comment.test.ts',
+            position: { side: 'new', line: 20 },
+            body: 'API comment',
+          },
+        ]),
+      });
+
+      let response = await fetch(`http://localhost:${importServer.port}/api/comments-output`);
+      let output = await response.text();
+      expect(output).toContain('Startup comment');
+      expect(output).toContain('API comment');
+
+      await fetch(
+        `http://localhost:${importServer.port}/api/diff?base=feat%2F292-comment-read-write&target=codex%2Fcomment-session-state`,
+      );
+
+      response = await fetch(`http://localhost:${importServer.port}/api/comments-output`);
+      output = await response.text();
+      expect(output).toBe('');
+
+      await fetch(`http://localhost:${importServer.port}/api/comment-imports`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify([
+          {
+            type: 'thread',
+            filePath: 'src/cli/comment.test.ts',
+            position: { side: 'new', line: 30 },
+            body: 'Other diff comment',
+          },
+        ]),
+      });
+
+      response = await fetch(`http://localhost:${importServer.port}/api/comments-output`);
+      output = await response.text();
+      expect(output).toContain('Other diff comment');
+      expect(output).not.toContain('Startup comment');
+      expect(output).not.toContain('API comment');
+
+      await fetch(`http://localhost:${importServer.port}/api/diff?base=HEAD%5E&target=HEAD`);
+
+      response = await fetch(`http://localhost:${importServer.port}/api/comments-output`);
+      output = await response.text();
+      expect(output).toContain('Startup comment');
+      expect(output).toContain('API comment');
+      expect(output).not.toContain('Other diff comment');
+    });
+
     it.skip('GET /api/heartbeat returns SSE headers', async () => {
       // Skipped due to connection reset issues in test environment
       // SSE endpoint functionality is verified through manual testing

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -93,6 +93,29 @@ function setCachedDiffResponse(cache: Map<string, DiffResponse>, key: string, va
   }
 }
 
+interface CommentSessionState {
+  threads: DiffCommentThread[];
+  version: number;
+}
+
+function createResolvedCommentSelection(
+  responseDiffData: DiffResponse,
+  fallbackSelection: DiffSelection,
+  stdinDiff: boolean,
+): DiffSelection {
+  const baseCommitish =
+    responseDiffData.baseCommitish ?? (stdinDiff ? 'stdin' : fallbackSelection.baseCommitish);
+  const targetCommitish =
+    responseDiffData.targetCommitish ?? (stdinDiff ? 'stdin' : fallbackSelection.targetCommitish);
+  const baseMode = responseDiffData.requestedBaseMode ?? fallbackSelection.baseMode;
+
+  return createDiffSelection(baseCommitish, targetCommitish, baseMode);
+}
+
+function createCommentSessionKey(selection: DiffSelection): string {
+  return getDiffSelectionKey(selection);
+}
+
 export async function startServer(
   options: ServerOptions,
 ): Promise<{ port: number; url: string; isEmpty?: boolean; server?: Server }> {
@@ -167,6 +190,11 @@ export async function startServer(
 
   // Track current revisions for cache invalidation
   let currentSelection = initialSelection;
+  let currentCommentSelection = createResolvedCommentSelection(
+    initialDiffData,
+    initialSelection,
+    Boolean(options.stdinDiff),
+  );
 
   function parseRepositoryRelativePath(
     filepath: unknown,
@@ -189,6 +217,50 @@ export async function startServer(
     }
 
     return { ok: true, path: normalizedFilepath };
+  }
+
+  const commentSessions = new Map<string, CommentSessionState>();
+  const initialCommentThreads = mergeCommentImports([], initialCommentImports).threads;
+  if (initialCommentThreads.length > 0) {
+    commentSessions.set(createCommentSessionKey(currentCommentSelection), {
+      threads: initialCommentThreads,
+      version: 1,
+    });
+  }
+
+  function getCommentSelectionFromQuery(query: Record<string, unknown>): DiffSelection {
+    const hasBase = typeof query.base === 'string';
+    const hasTarget = typeof query.target === 'string';
+    const hasBaseMode = typeof query.baseMode === 'string';
+
+    if (!hasBase && !hasTarget && !hasBaseMode) {
+      return currentCommentSelection;
+    }
+
+    return createDiffSelection(
+      hasBase ? (query.base as string) : currentCommentSelection.baseCommitish,
+      hasTarget ? (query.target as string) : currentCommentSelection.targetCommitish,
+      hasBaseMode
+        ? parseBaseMode(query.baseMode)
+        : hasBase || hasTarget
+          ? undefined
+          : currentCommentSelection.baseMode,
+    );
+  }
+
+  function getOrCreateCommentSession(selection: DiffSelection): CommentSessionState {
+    const key = createCommentSessionKey(selection);
+    const existing = commentSessions.get(key);
+    if (existing) {
+      return existing;
+    }
+
+    const nextSession: CommentSessionState = {
+      threads: [],
+      version: 0,
+    };
+    commentSessions.set(key, nextSession);
+    return nextSession;
   }
 
   app.get('/api/diff', async (req, res) => {
@@ -226,6 +298,12 @@ export async function startServer(
         generatedStatusCache.clear();
       }
     }
+
+    currentCommentSelection = createResolvedCommentSelection(
+      responseDiffData,
+      requestedSelection,
+      Boolean(options.stdinDiff),
+    );
 
     const baseCommitish =
       responseDiffData.baseCommitish ?? (options.stdinDiff ? 'stdin' : undefined);
@@ -428,9 +506,6 @@ export async function startServer(
     }
   });
 
-  let finalThreads: DiffCommentThread[] = mergeCommentImports([], initialCommentImports).threads;
-  let commentsVersion = finalThreads.length > 0 ? 1 : 0;
-
   function normalizeLineValue(line: unknown): DiffCommentThread['position']['line'] {
     if (Array.isArray(line) && line.length === 2) {
       const start = line[0] as unknown;
@@ -592,19 +667,23 @@ export async function startServer(
     return normalizeCommentImports(body);
   }
 
-  function updateCommentSession(nextThreads: DiffCommentThread[]): boolean {
-    const previous = JSON.stringify(finalThreads);
+  function updateCommentSession(
+    selection: DiffSelection,
+    nextThreads: DiffCommentThread[],
+  ): boolean {
+    const session = getOrCreateCommentSession(selection);
+    const previous = JSON.stringify(session.threads);
     const next = JSON.stringify(nextThreads);
-    finalThreads = nextThreads;
+    session.threads = nextThreads;
 
     if (previous === next) {
       return false;
     }
 
-    commentsVersion += 1;
+    session.version += 1;
     fileWatcher.broadcast({
       type: 'commentsChanged',
-      version: commentsVersion,
+      version: session.version,
       timestamp: new Date().toISOString(),
     });
     return true;
@@ -612,8 +691,9 @@ export async function startServer(
 
   app.post('/api/comments', (req, res) => {
     try {
+      const selection = getCommentSelectionFromQuery(req.query as Record<string, unknown>);
       const nextThreads = parseCommentsPayload(req.body);
-      updateCommentSession(nextThreads);
+      updateCommentSession(selection, nextThreads);
       res.json({ success: true });
     } catch (error) {
       console.error('Error parsing comments:', error);
@@ -623,12 +703,14 @@ export async function startServer(
 
   app.post('/api/comment-imports', (req, res) => {
     try {
+      const selection = getCommentSelectionFromQuery(req.query as Record<string, unknown>);
+      const session = getOrCreateCommentSession(selection);
       const commentImports = parseCommentImportsPayload(req.body);
       const importId = createHash('sha256')
         .update(serializeCommentImports(commentImports))
         .digest('hex');
-      const merged = mergeCommentImports(finalThreads, commentImports);
-      const changed = updateCommentSession(merged.threads);
+      const merged = mergeCommentImports(session.threads, commentImports);
+      const changed = updateCommentSession(selection, merged.threads);
 
       res.json({
         success: true,
@@ -643,18 +725,22 @@ export async function startServer(
     }
   });
 
-  app.get('/api/comments-json', (_req, res) => {
+  app.get('/api/comments-json', (req, res) => {
+    const selection = getCommentSelectionFromQuery(req.query as Record<string, unknown>);
+    const session = getOrCreateCommentSession(selection);
     res.json({
-      version: commentsVersion,
-      threads: finalThreads,
+      version: session.version,
+      threads: session.threads,
     });
   });
 
-  app.get('/api/comments-output', (_req, res) => {
+  app.get('/api/comments-output', (req, res) => {
+    const selection = getCommentSelectionFromQuery(req.query as Record<string, unknown>);
+    const session = getOrCreateCommentSession(selection);
     res.type('text/plain');
 
-    if (finalThreads.length > 0) {
-      const output = formatCommentsOutput(finalThreads.map(toCommentThread));
+    if (session.threads.length > 0) {
+      const output = formatCommentsOutput(session.threads.map(toCommentThread));
       res.send(output);
     } else {
       res.send('');
@@ -748,8 +834,9 @@ export async function startServer(
 
   // Function to output comments when server shuts down
   function outputFinalComments() {
-    if (finalThreads.length > 0) {
-      console.log(formatCommentsOutput(finalThreads.map(toCommentThread)));
+    const session = getOrCreateCommentSession(currentCommentSelection);
+    if (session.threads.length > 0) {
+      console.log(formatCommentsOutput(session.threads.map(toCommentThread)));
     }
   }
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -428,34 +428,71 @@ export async function startServer(
     }
   });
 
-  let finalThreads: CommentThread[] = [];
+  let finalThreads: DiffCommentThread[] = mergeCommentImports([], initialCommentImports).threads;
+  let commentsVersion = finalThreads.length > 0 ? 1 : 0;
 
-  function normalizeComment(comment: Comment): CommentThread {
+  function normalizeLineValue(line: unknown): DiffCommentThread['position']['line'] {
+    if (Array.isArray(line) && line.length === 2) {
+      const start = line[0] as unknown;
+      const end = line[1] as unknown;
+      if (
+        typeof start === 'number' &&
+        typeof end === 'number' &&
+        Number.isInteger(start) &&
+        Number.isInteger(end) &&
+        start > 0 &&
+        end > 0 &&
+        start <= end
+      ) {
+        return { start, end };
+      }
+    }
+
+    if (typeof line === 'number' && Number.isInteger(line) && line > 0) {
+      return line;
+    }
+
+    return 1;
+  }
+
+  function normalizeComment(comment: Comment): DiffCommentThread {
+    const now = new Date().toISOString();
+    const timestamp = typeof comment.timestamp === 'string' ? comment.timestamp : now;
+    const threadId =
+      typeof comment.id === 'string' && comment.id.length > 0
+        ? comment.id
+        : createHash('sha256').update(JSON.stringify(comment)).digest('hex').slice(0, 12);
+    const filePath =
+      typeof comment.file === 'string' && comment.file.length > 0 ? comment.file : '<unknown file>';
+
     return {
-      id: comment.id,
-      file: comment.file,
-      line: comment.line,
-      side: comment.side,
-      createdAt: comment.timestamp,
-      updatedAt: comment.timestamp,
-      codeContent: comment.codeContent,
+      id: threadId,
+      filePath,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      position: {
+        side: comment.side ?? 'new',
+        line: normalizeLineValue(comment.line),
+      },
+      codeSnapshot:
+        typeof comment.codeContent === 'string'
+          ? {
+              content: comment.codeContent,
+            }
+          : undefined,
       messages: [
         {
-          id: comment.id,
+          id: threadId,
           body: comment.body,
           author: comment.author,
-          createdAt: comment.timestamp,
-          updatedAt: comment.timestamp,
+          createdAt: timestamp,
+          updatedAt: timestamp,
         },
       ],
     };
   }
 
-  function normalizeThreadPayload(thread: CommentThread | DiffCommentThread): CommentThread {
-    if ('file' in thread && 'line' in thread) {
-      return thread;
-    }
-
+  function toCommentThread(thread: DiffCommentThread): CommentThread {
     return {
       id: thread.id,
       file: thread.filePath,
@@ -471,7 +508,60 @@ export async function startServer(
     };
   }
 
-  function parseCommentsPayload(body: unknown): CommentThread[] {
+  function normalizeThreadPayload(thread: CommentThread | DiffCommentThread): DiffCommentThread {
+    if ('filePath' in thread && 'position' in thread) {
+      return thread;
+    }
+
+    const threadId =
+      typeof thread.id === 'string' && thread.id.length > 0
+        ? thread.id
+        : createHash('sha256').update(JSON.stringify(thread)).digest('hex').slice(0, 12);
+    const now = new Date().toISOString();
+    const messages =
+      Array.isArray(thread.messages) && thread.messages.length > 0
+        ? thread.messages.map((message, index) => ({
+            id:
+              typeof message.id === 'string' && message.id.length > 0
+                ? message.id
+                : `${threadId}:${index}`,
+            body: message.body,
+            author: message.author,
+            createdAt: message.createdAt || thread.createdAt || now,
+            updatedAt: message.updatedAt || message.createdAt || thread.updatedAt || now,
+          }))
+        : [
+            {
+              id: threadId,
+              body: '',
+              createdAt: thread.createdAt || now,
+              updatedAt: thread.updatedAt || thread.createdAt || now,
+            },
+          ];
+    const firstMessage = messages[0];
+    const lastMessage = messages[messages.length - 1];
+
+    return {
+      id: threadId,
+      filePath:
+        typeof thread.file === 'string' && thread.file.length > 0 ? thread.file : '<unknown file>',
+      createdAt: thread.createdAt || firstMessage?.createdAt || now,
+      updatedAt: thread.updatedAt || lastMessage?.updatedAt || thread.createdAt || now,
+      position: {
+        side: thread.side ?? 'new',
+        line: normalizeLineValue(thread.line),
+      },
+      codeSnapshot:
+        typeof thread.codeContent === 'string'
+          ? {
+              content: thread.codeContent,
+            }
+          : undefined,
+      messages,
+    };
+  }
+
+  function parseCommentsPayload(body: unknown): DiffCommentThread[] {
     const payload =
       typeof body === 'string'
         ? (JSON.parse(body) as {
@@ -494,9 +584,36 @@ export async function startServer(
     return [];
   }
 
+  function parseCommentImportsPayload(body: unknown): CommentImport[] {
+    if (typeof body === 'string') {
+      return normalizeCommentImports(JSON.parse(body));
+    }
+
+    return normalizeCommentImports(body);
+  }
+
+  function updateCommentSession(nextThreads: DiffCommentThread[]): boolean {
+    const previous = JSON.stringify(finalThreads);
+    const next = JSON.stringify(nextThreads);
+    finalThreads = nextThreads;
+
+    if (previous === next) {
+      return false;
+    }
+
+    commentsVersion += 1;
+    fileWatcher.broadcast({
+      type: 'commentsChanged',
+      version: commentsVersion,
+      timestamp: new Date().toISOString(),
+    });
+    return true;
+  }
+
   app.post('/api/comments', (req, res) => {
     try {
-      finalThreads = parseCommentsPayload(req.body);
+      const nextThreads = parseCommentsPayload(req.body);
+      updateCommentSession(nextThreads);
       res.json({ success: true });
     } catch (error) {
       console.error('Error parsing comments:', error);
@@ -504,62 +621,44 @@ export async function startServer(
     }
   });
 
-  app.get('/api/comments-output', (_req, res) => {
-    res.type('text/plain');
-
-    if (finalThreads.length > 0) {
-      const output = formatCommentsOutput(finalThreads);
-      res.send(output);
-    } else {
-      res.send('');
-    }
-  });
-
-  function threadToDiffThread(thread: CommentThread): DiffCommentThread {
-    return {
-      id: thread.id,
-      filePath: thread.file,
-      createdAt: thread.createdAt,
-      updatedAt: thread.updatedAt,
-      position: {
-        side: thread.side ?? 'new',
-        line: Array.isArray(thread.line)
-          ? { start: thread.line[0], end: thread.line[1] }
-          : thread.line,
-      },
-      codeSnapshot: thread.codeContent ? { content: thread.codeContent } : undefined,
-      messages: thread.messages,
-    };
-  }
-
   app.post('/api/comment-imports', (req, res) => {
     try {
-      const body: unknown =
-        typeof req.body === 'string' ? JSON.parse(req.body as string) : req.body;
-      const imports = normalizeCommentImports(body);
-      const importId = createHash('sha256').update(serializeCommentImports(imports)).digest('hex');
+      const commentImports = parseCommentImportsPayload(req.body);
+      const importId = createHash('sha256')
+        .update(serializeCommentImports(commentImports))
+        .digest('hex');
+      const merged = mergeCommentImports(finalThreads, commentImports);
+      const changed = updateCommentSession(merged.threads);
 
-      // Merge imports into server-side threads so they're available via comments-output/comments-json
-      const existingDiffThreads = finalThreads.map(threadToDiffThread);
-      const merged = mergeCommentImports(existingDiffThreads, imports);
-      finalThreads = merged.threads.map(normalizeThreadPayload);
-
-      fileWatcher.broadcastCommentImport({
-        type: 'commentImports',
-        commentImports: imports,
-        commentImportId: importId,
+      res.json({
+        success: true,
+        changed,
+        count: commentImports.length,
+        importId,
+        warnings: merged.warnings,
       });
-
-      res.json({ success: true, importId, count: imports.length });
     } catch (error) {
-      res.status(400).json({
-        error: error instanceof Error ? error.message : 'Invalid comment import data',
-      });
+      console.error('Error parsing comment imports:', error);
+      res.status(400).json({ error: 'Invalid comment import data' });
     }
   });
 
   app.get('/api/comments-json', (_req, res) => {
-    res.json({ threads: finalThreads });
+    res.json({
+      version: commentsVersion,
+      threads: finalThreads,
+    });
+  });
+
+  app.get('/api/comments-output', (_req, res) => {
+    res.type('text/plain');
+
+    if (finalThreads.length > 0) {
+      const output = formatCommentsOutput(finalThreads.map(toCommentThread));
+      res.send(output);
+    } else {
+      res.send('');
+    }
   });
 
   app.post('/api/open-in-editor', async (req, res) => {
@@ -650,7 +749,7 @@ export async function startServer(
   // Function to output comments when server shuts down
   function outputFinalComments() {
     if (finalThreads.length > 0) {
-      console.log(formatCommentsOutput(finalThreads));
+      console.log(formatCommentsOutput(finalThreads.map(toCommentThread)));
     }
   }
 

--- a/src/types/watch.ts
+++ b/src/types/watch.ts
@@ -1,5 +1,3 @@
-import type { CommentImport } from './diff.js';
-
 export enum DiffMode {
   DEFAULT = 'default', // HEAD^ vs HEAD
   WORKING = 'working', // staged vs working
@@ -8,11 +6,43 @@ export enum DiffMode {
   SPECIFIC = 'specific', // commit vs commit (no watching)
 }
 
-export interface CommentImportsWatchEvent {
-  type: 'commentImports';
-  commentImports: CommentImport[];
-  commentImportId: string;
+export type WatchChangeType = 'file' | 'commit' | 'staging';
+
+export interface ConnectedWatchEvent {
+  type: 'connected';
+  diffMode: DiffMode;
+  changeType: WatchChangeType;
+  timestamp: string;
+  message?: string;
 }
+
+export interface ReloadWatchEvent {
+  type: 'reload';
+  diffMode: DiffMode;
+  changeType: WatchChangeType;
+  timestamp: string;
+  message?: string;
+}
+
+export interface ErrorWatchEvent {
+  type: 'error';
+  diffMode: DiffMode;
+  changeType: WatchChangeType;
+  timestamp: string;
+  message?: string;
+}
+
+export interface CommentsChangedWatchEvent {
+  type: 'commentsChanged';
+  version: number;
+  timestamp: string;
+}
+
+export type WatchEvent =
+  | ConnectedWatchEvent
+  | ReloadWatchEvent
+  | ErrorWatchEvent
+  | CommentsChangedWatchEvent;
 
 export interface ClientWatchState {
   isWatchEnabled: boolean;
@@ -20,6 +50,6 @@ export interface ClientWatchState {
   shouldReload: boolean;
   isReloading: boolean;
   lastChangeTime: Date | null;
-  lastChangeType: 'file' | 'commit' | 'staging' | null;
+  lastChangeType: WatchChangeType | null;
   connectionStatus: 'connected' | 'disconnected' | 'reconnecting';
 }

--- a/src/utils/commentImports.ts
+++ b/src/utils/commentImports.ts
@@ -283,6 +283,168 @@ function createImportedReply(commentImport: ReplyCommentImport, now: string): Di
   };
 }
 
+function cloneLineRange(line: DiffLineRange): DiffLineRange {
+  if (typeof line === 'number') {
+    return line;
+  }
+
+  return {
+    start: line.start,
+    end: line.end,
+  };
+}
+
+function clonePosition(position: DiffCommentPosition): DiffCommentPosition {
+  return {
+    side: position.side,
+    line: cloneLineRange(position.line),
+  };
+}
+
+function cloneCodeSnapshot(
+  snapshot: DiffCommentCodeSnapshot | undefined,
+): DiffCommentCodeSnapshot | undefined {
+  if (!snapshot) {
+    return undefined;
+  }
+
+  return {
+    content: snapshot.content,
+    language: snapshot.language,
+  };
+}
+
+function cloneMessage(message: DiffCommentMessage): DiffCommentMessage {
+  return {
+    id: message.id,
+    body: message.body,
+    author: message.author,
+    createdAt: message.createdAt,
+    updatedAt: message.updatedAt,
+  };
+}
+
+function cloneThread(thread: DiffCommentThread): DiffCommentThread {
+  return {
+    id: thread.id,
+    filePath: thread.filePath,
+    createdAt: thread.createdAt,
+    updatedAt: thread.updatedAt,
+    position: clonePosition(thread.position),
+    codeSnapshot: cloneCodeSnapshot(thread.codeSnapshot),
+    messages: thread.messages.map(cloneMessage),
+  };
+}
+
+function messagesMatch(left: DiffCommentMessage, right: DiffCommentMessage): boolean {
+  if (left.id === right.id) {
+    return true;
+  }
+
+  if (normalizeAuthor(left.author) !== normalizeAuthor(right.author)) {
+    return false;
+  }
+
+  return left.body === right.body && left.createdAt === right.createdAt;
+}
+
+function threadsMatch(left: DiffCommentThread, right: DiffCommentThread): boolean {
+  if (left.id === right.id) {
+    return true;
+  }
+
+  if (left.filePath !== right.filePath || !positionsMatch(left.position, right.position)) {
+    return false;
+  }
+
+  const leftRoot = left.messages[0];
+  const rightRoot = right.messages[0];
+  if (!leftRoot || !rightRoot) {
+    return false;
+  }
+
+  return messagesMatch(leftRoot, rightRoot);
+}
+
+function sortReplies(left: DiffCommentMessage, right: DiffCommentMessage): number {
+  const createdAtOrder = left.createdAt.localeCompare(right.createdAt);
+  if (createdAtOrder !== 0) {
+    return createdAtOrder;
+  }
+
+  return left.id.localeCompare(right.id);
+}
+
+function pickNewerMessage(
+  existingMessage: DiffCommentMessage,
+  incomingMessage: DiffCommentMessage,
+): DiffCommentMessage {
+  if (incomingMessage.updatedAt.localeCompare(existingMessage.updatedAt) >= 0) {
+    return cloneMessage(incomingMessage);
+  }
+
+  return cloneMessage(existingMessage);
+}
+
+function mergeThread(
+  existingThread: DiffCommentThread,
+  incomingThread: DiffCommentThread,
+): DiffCommentThread {
+  const mergedMessages = existingThread.messages.map(cloneMessage);
+
+  for (const incomingMessage of incomingThread.messages) {
+    const matchIndex = mergedMessages.findIndex((message) =>
+      messagesMatch(message, incomingMessage),
+    );
+    if (matchIndex >= 0) {
+      mergedMessages[matchIndex] = pickNewerMessage(mergedMessages[matchIndex], incomingMessage);
+      continue;
+    }
+
+    mergedMessages.push(cloneMessage(incomingMessage));
+  }
+
+  const [rootMessage, ...replyMessages] = mergedMessages;
+  const orderedMessages = rootMessage
+    ? [rootMessage, ...replyMessages.sort(sortReplies)]
+    : replyMessages.sort(sortReplies);
+  const updatedAt = orderedMessages.reduce(
+    (latest, message) => maxIsoTimestamp(latest, message.updatedAt),
+    maxIsoTimestamp(existingThread.updatedAt, incomingThread.updatedAt),
+  );
+
+  return {
+    ...cloneThread(existingThread),
+    createdAt:
+      existingThread.createdAt.localeCompare(incomingThread.createdAt) <= 0
+        ? existingThread.createdAt
+        : incomingThread.createdAt,
+    updatedAt,
+    position: clonePosition(existingThread.position),
+    codeSnapshot: cloneCodeSnapshot(incomingThread.codeSnapshot ?? existingThread.codeSnapshot),
+    messages: orderedMessages,
+  };
+}
+
+export function mergeCommentThreads(
+  existingThreads: DiffCommentThread[],
+  incomingThreads: DiffCommentThread[],
+): MergeCommentImportsResult {
+  const threads = existingThreads.map(cloneThread);
+
+  for (const incomingThread of incomingThreads) {
+    const existingIndex = threads.findIndex((thread) => threadsMatch(thread, incomingThread));
+    if (existingIndex < 0) {
+      threads.push(cloneThread(incomingThread));
+      continue;
+    }
+
+    threads[existingIndex] = mergeThread(threads[existingIndex], incomingThread);
+  }
+
+  return { threads, warnings: [] };
+}
+
 function serializeLineRange(line: DiffLineRange): number | { start: number; end: number } {
   if (typeof line === 'number') {
     return line;


### PR DESCRIPTION
## Summary
- unify comment session handling between the CLI and browser-backed server
- sync browser comments through server-side sessions instead of SSE comment import events
- scope stored comment sessions to the active diff selection so comments do not leak across revisions
- update comment merging and related client/server tests to cover the new session behavior

## Testing
- `pnpm run check`
- `pnpm test`
- `pnpm build`
- `pnpm format`