### PR TITLE
add syntax highlighting for nix and haskell

### DIFF
--- a/src/client/utils/languageDetection.ts
+++ b/src/client/utils/languageDetection.ts
@@ -44,6 +44,9 @@ const DIFF_EXTENSION_LANGUAGE_MAP: Record<string, string> = {
   ex: 'elixir',
   exs: 'elixir',
   heex: 'elixir',
+  nix: 'nix',
+  hs: 'haskell',
+  lhs: 'haskell',
 };
 
 // Prism syntax highlighting: use Prism language IDs (e.g. tsx -> tsx, scss -> css).
@@ -104,6 +107,9 @@ const PRISM_EXTENSION_LANGUAGE_MAP: Record<string, string> = {
   ex: 'elixir',
   exs: 'elixir',
   heex: 'elixir',
+  nix: 'nix',
+  hs: 'haskell',
+  lhs: 'haskell',
 };
 
 const PRISM_FILENAME_LANGUAGE_MAP: Record<string, string> = {

--- a/src/client/utils/languageLoader.ts
+++ b/src/client/utils/languageLoader.ts
@@ -32,6 +32,8 @@ export function loadPrismLanguage(lang: string): Promise<void> {
       hcl: () => import('prismjs/components/prism-hcl.js'),
       perl: () => import('prismjs/components/prism-perl.js'),
       elixir: () => import('prismjs/components/prism-elixir.js'),
+      nix: () => import('prismjs/components/prism-nix.js'),
+      haskell: () => import('prismjs/components/prism-haskell.js'),
     };
 
     const importFn = languageImports[lang];


### PR DESCRIPTION
register prism-nix and prism-haskell grammars in languageLoader and map .nix, .hs, .lhs extensions in both language detection maps.