### PR TITLE
Fix reviewed directory styling in the file tree

### DIFF
--- a/src/client/components/FileList.test.tsx
+++ b/src/client/components/FileList.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom';
+
+import type { DiffFile } from '../../types/diff';
+
+import { FileList } from './FileList';
+
+const createFile = (path: string): DiffFile => ({
+  path,
+  status: 'modified',
+  additions: 1,
+  deletions: 1,
+  chunks: [],
+});
+
+function getTreeRowPaddingLeft(title: string): string {
+  const row = screen.getByTitle(title).closest<HTMLElement>('[data-tree-row="true"]');
+  expect(row).not.toBeNull();
+  return row?.style.paddingLeft ?? '';
+}
+
+describe('FileList', () => {
+  it('includes the row gap in nested tree indentation', () => {
+    render(
+      <FileList
+        files={[
+          createFile('README.md'),
+          createFile('src/cli/index.ts'),
+          createFile('src/client/App.tsx'),
+        ]}
+        onScrollToFile={vi.fn()}
+        comments={[]}
+        reviewedFiles={new Set()}
+        onToggleReviewed={vi.fn()}
+        selectedFileIndex={null}
+      />,
+    );
+
+    expect(getTreeRowPaddingLeft('README.md')).toBe('16px');
+    expect(getTreeRowPaddingLeft('src')).toBe('16px');
+    expect(getTreeRowPaddingLeft('cli')).toBe('40px');
+    expect(getTreeRowPaddingLeft('src/cli/index.ts')).toBe('64px');
+  });
+});

--- a/src/client/components/FileList.test.tsx
+++ b/src/client/components/FileList.test.tsx
@@ -20,6 +20,10 @@ function getTreeRowPaddingLeft(title: string): string {
   return row?.style.paddingLeft ?? '';
 }
 
+function getLabel(title: string): HTMLElement {
+  return screen.getByTitle(title);
+}
+
 describe('FileList', () => {
   it('includes the row gap in nested tree indentation', () => {
     render(
@@ -41,5 +45,38 @@ describe('FileList', () => {
     expect(getTreeRowPaddingLeft('src')).toBe('16px');
     expect(getTreeRowPaddingLeft('cli')).toBe('40px');
     expect(getTreeRowPaddingLeft('src/cli/index.ts')).toBe('64px');
+  });
+
+  it('strikes through directories when all descendant files are reviewed', () => {
+    const files = [
+      createFile('src/cli/index.ts'),
+      createFile('src/client/App.tsx'),
+      createFile('README.md'),
+    ];
+    const props = {
+      files,
+      onScrollToFile: vi.fn(),
+      comments: [],
+      onToggleReviewed: vi.fn(),
+      selectedFileIndex: null,
+    };
+    const { rerender } = render(
+      <FileList {...props} reviewedFiles={new Set(['README.md', 'src/cli/index.ts'])} />,
+    );
+
+    expect(getLabel('src')).not.toHaveClass('line-through');
+    expect(getLabel('cli')).toHaveClass('line-through');
+    expect(getLabel('client')).not.toHaveClass('line-through');
+
+    rerender(
+      <FileList
+        {...props}
+        reviewedFiles={new Set(['README.md', 'src/cli/index.ts', 'src/client/App.tsx'])}
+      />,
+    );
+
+    expect(getLabel('src')).toHaveClass('line-through');
+    expect(getLabel('cli')).toHaveClass('line-through');
+    expect(getLabel('client')).toHaveClass('line-through');
   });
 });

--- a/src/client/components/FileList.test.tsx
+++ b/src/client/components/FileList.test.tsx
@@ -20,6 +20,12 @@ function getTreeRowPaddingLeft(title: string): string {
   return row?.style.paddingLeft ?? '';
 }
 
+function getTreeRow(title: string): HTMLElement {
+  const row = screen.getByTitle(title).closest<HTMLElement>('[data-tree-row="true"]');
+  expect(row).not.toBeNull();
+  return row as HTMLElement;
+}
+
 function getLabel(title: string): HTMLElement {
   return screen.getByTitle(title);
 }
@@ -65,8 +71,11 @@ describe('FileList', () => {
     );
 
     expect(getLabel('src')).not.toHaveClass('line-through');
+    expect(getTreeRow('src')).not.toHaveClass('opacity-70');
     expect(getLabel('cli')).toHaveClass('line-through');
+    expect(getTreeRow('cli')).toHaveClass('opacity-70');
     expect(getLabel('client')).not.toHaveClass('line-through');
+    expect(getTreeRow('client')).not.toHaveClass('opacity-70');
 
     rerender(
       <FileList
@@ -76,7 +85,10 @@ describe('FileList', () => {
     );
 
     expect(getLabel('src')).toHaveClass('line-through');
+    expect(getTreeRow('src')).toHaveClass('opacity-70');
     expect(getLabel('cli')).toHaveClass('line-through');
+    expect(getTreeRow('cli')).toHaveClass('opacity-70');
     expect(getLabel('client')).toHaveClass('line-through');
+    expect(getTreeRow('client')).toHaveClass('opacity-70');
   });
 });

--- a/src/client/components/FileList.tsx
+++ b/src/client/components/FileList.tsx
@@ -55,6 +55,30 @@ function getAllDirectoryPaths(node: TreeNode): string[] {
   return paths;
 }
 
+function getReviewedDirectoryPaths(node: TreeNode, reviewedFiles: Set<string>): Set<string> {
+  const reviewedDirectoryPaths = new Set<string>();
+
+  const visit = (currentNode: TreeNode): boolean => {
+    if (currentNode.file) {
+      return reviewedFiles.has(currentNode.file.path);
+    }
+
+    if (!currentNode.isDirectory || !currentNode.children || currentNode.children.length === 0) {
+      return false;
+    }
+
+    const childrenReviewed = currentNode.children.map((child) => visit(child));
+    const areAllChildrenReviewed = childrenReviewed.every(Boolean);
+    if (areAllChildrenReviewed && currentNode.path) {
+      reviewedDirectoryPaths.add(currentNode.path);
+    }
+    return areAllChildrenReviewed;
+  };
+
+  visit(node);
+  return reviewedDirectoryPaths;
+}
+
 function buildFileTree(files: DiffFile[]): TreeNode {
   const root: TreeNode = {
     name: '',
@@ -164,6 +188,10 @@ export const FileList = memo(function FileList({
     });
     return indices;
   }, [files]);
+  const reviewedDirectoryPaths = useMemo(
+    () => getReviewedDirectoryPaths(fileTree, reviewedFiles),
+    [fileTree, reviewedFiles],
+  );
 
   // Filter the file tree based on search text
   const filteredFileTree = useMemo(() => {
@@ -278,6 +306,7 @@ export const FileList = memo(function FileList({
   const renderTreeNode = (node: TreeNode, depth: number = 0): React.ReactNode => {
     if (node.isDirectory && node.children) {
       const isExpanded = expandedDirs.has(node.path);
+      const isReviewed = reviewedDirectoryPaths.has(node.path);
 
       return (
         <div
@@ -312,7 +341,9 @@ export const FileList = memo(function FileList({
                 <Folder size={16} className="text-github-text-secondary" />
               )}
               <span
-                className="text-sm text-github-text-primary font-medium flex-1 overflow-hidden text-ellipsis whitespace-nowrap"
+                className={`text-sm text-github-text-primary font-medium flex-1 overflow-hidden text-ellipsis whitespace-nowrap ${
+                  isReviewed ? 'line-through text-github-text-muted' : ''
+                }`}
                 title={node.name}
               >
                 {node.name}

--- a/src/client/components/FileList.tsx
+++ b/src/client/components/FileList.tsx
@@ -36,6 +36,15 @@ interface TreeNode {
   file?: DiffFile;
 }
 
+const TREE_ROW_PADDING_LEFT_PX = 16;
+const TREE_ICON_SIZE_PX = 16;
+const TREE_ROW_GAP_PX = 8;
+const TREE_INDENT_STEP_PX = TREE_ICON_SIZE_PX + TREE_ROW_GAP_PX;
+
+function getTreeRowPaddingLeft(depth: number): string {
+  return `${depth * TREE_INDENT_STEP_PX + TREE_ROW_PADDING_LEFT_PX}px`;
+}
+
 function getAllDirectoryPaths(node: TreeNode): string[] {
   if (!node.isDirectory || !node.children) return [];
   const paths: string[] = [];
@@ -290,7 +299,7 @@ export const FileList = memo(function FileList({
               data-tree-row="true"
               data-depth={depth}
               style={{
-                paddingLeft: `${depth * 16 + 16}px`,
+                paddingLeft: getTreeRowPaddingLeft(depth),
                 top: `calc(${depth} * var(--dir-row-height))`,
                 zIndex: 1000 - depth,
               }}
@@ -330,7 +339,7 @@ export const FileList = memo(function FileList({
           data-file-row="true"
           data-tree-row="true"
           data-depth={depth}
-          style={{ paddingLeft: `${depth * 16 + 16}px` }}
+          style={{ paddingLeft: getTreeRowPaddingLeft(depth) }}
           onClick={() => {
             onScrollToFile(file.path);
             onFileSelected?.();

--- a/src/client/components/FileList.tsx
+++ b/src/client/components/FileList.tsx
@@ -323,7 +323,9 @@ export const FileList = memo(function FileList({
         >
           {node.name && (
             <div
-              className="sticky flex h-9 items-center gap-2 bg-github-bg-secondary px-4 hover:bg-github-bg-tertiary cursor-pointer"
+              className={`sticky flex h-9 items-center gap-2 bg-github-bg-secondary px-4 hover:bg-github-bg-tertiary cursor-pointer ${
+                isReviewed ? 'opacity-70' : ''
+              }`}
               data-dir-header="true"
               data-tree-row="true"
               data-depth={depth}


### PR DESCRIPTION
Resolved #305

## Summary
- Strike through directory labels when every descendant file is marked as reviewed
- Dim reviewed directory rows the same way as reviewed files
- Add targeted tests for nested directory review state and indentation behavior

## Testing
- Added unit coverage for reviewed directory styling in `FileList`
- Local validation passed for formatting and type checks during implementation