### PR TITLE
Fix auto theme syntax colors on OS theme change

### DIFF
--- a/src/client/components/SettingsModal.tsx
+++ b/src/client/components/SettingsModal.tsx
@@ -5,7 +5,11 @@ import { useHotkeysContext } from 'react-hotkeys-hook';
 import { DEFAULT_EDITOR_ID, EDITOR_OPTIONS, type EditorOptionId } from '../../utils/editorOptions';
 import type { ColorVisionMode } from '../utils/appearanceTheme';
 import { formatAutoViewedPatterns, parseAutoViewedPatterns } from '../utils/autoViewedPatterns';
-import { LIGHT_THEMES, DARK_THEMES } from '../utils/themeLoader';
+import {
+  getFallbackSyntaxTheme,
+  getThemesForResolvedTheme,
+  isSyntaxThemeForResolvedTheme,
+} from '../utils/themeLoader';
 import { Tooltip } from './Tooltip';
 
 interface AppearanceSettings {
@@ -103,8 +107,7 @@ export function SettingsModal({ isOpen, onClose, settings, onSettingsChange }: S
 
   // Get available themes based on current background color
   const getAvailableThemes = () => {
-    const currentTheme = getCurrentTheme();
-    return currentTheme === 'light' ? LIGHT_THEMES : DARK_THEMES;
+    return getThemesForResolvedTheme(getCurrentTheme());
   };
 
   // Handle theme change and auto-select valid syntax theme
@@ -119,13 +122,11 @@ export function SettingsModal({ isOpen, onClose, settings, onSettingsChange }: S
           : 'light'
         : theme;
 
-    // Check if current syntax theme is valid for the new theme
-    const availableThemes = effectiveTheme === 'light' ? LIGHT_THEMES : DARK_THEMES;
-    const isCurrentThemeValid = availableThemes.some((t) => t.id === settings.syntaxTheme);
+    const isCurrentThemeValid = isSyntaxThemeForResolvedTheme(settings.syntaxTheme, effectiveTheme);
 
     // If current theme becomes invalid, auto-select first item
-    if (!isCurrentThemeValid && availableThemes.length > 0) {
-      const firstTheme = availableThemes[0];
+    if (!isCurrentThemeValid) {
+      const firstTheme = getFallbackSyntaxTheme(effectiveTheme);
       if (firstTheme) {
         newSettings.syntaxTheme = firstTheme.id;
       }

--- a/src/client/hooks/useAppearanceSettings.test.ts
+++ b/src/client/hooks/useAppearanceSettings.test.ts
@@ -1,0 +1,88 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { APPEARANCE_STORAGE_KEY } from '../utils/appearanceTheme';
+
+import { useAppearanceSettings } from './useAppearanceSettings';
+
+const setMatchMedia = (initialMatches: boolean) => {
+  let matches = initialMatches;
+  const listeners = new Set<(event: MediaQueryListEvent) => void>();
+
+  const mediaQueryList = {
+    get matches() {
+      return matches;
+    },
+    media: '(prefers-color-scheme: dark)',
+    onchange: null,
+    addEventListener: vi.fn((type: string, listener: EventListenerOrEventListenerObject) => {
+      if (type === 'change' && typeof listener === 'function') {
+        listeners.add(listener as (event: MediaQueryListEvent) => void);
+      }
+    }),
+    removeEventListener: vi.fn((type: string, listener: EventListenerOrEventListenerObject) => {
+      if (type === 'change' && typeof listener === 'function') {
+        listeners.delete(listener as (event: MediaQueryListEvent) => void);
+      }
+    }),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  } as MediaQueryList;
+
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: vi.fn(() => mediaQueryList),
+  });
+
+  return {
+    setMatches(nextMatches: boolean) {
+      matches = nextMatches;
+      const event = { matches: nextMatches, media: mediaQueryList.media } as MediaQueryListEvent;
+      listeners.forEach((listener) => listener(event));
+    },
+  };
+};
+
+describe('useAppearanceSettings', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute('data-color-vision');
+    document.documentElement.removeAttribute('data-theme');
+    document.documentElement.removeAttribute('style');
+    document.body.removeAttribute('style');
+  });
+
+  it('updates syntax highlighting theme when auto theme follows OS changes', async () => {
+    localStorage.setItem(
+      APPEARANCE_STORAGE_KEY,
+      JSON.stringify({
+        theme: 'auto',
+        syntaxTheme: 'vsDark',
+      }),
+    );
+    const matchMedia = setMatchMedia(true);
+
+    const { result } = renderHook(() => useAppearanceSettings());
+
+    await waitFor(() => {
+      expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+      expect(result.current.settings.syntaxTheme).toBe('vsDark');
+    });
+
+    act(() => {
+      matchMedia.setMatches(false);
+    });
+
+    await waitFor(() => {
+      expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+      expect(result.current.settings.syntaxTheme).toBe('github');
+    });
+
+    expect(JSON.parse(localStorage.getItem(APPEARANCE_STORAGE_KEY) ?? '{}')).toMatchObject({
+      theme: 'auto',
+      syntaxTheme: 'github',
+    });
+  });
+});

--- a/src/client/hooks/useAppearanceSettings.ts
+++ b/src/client/hooks/useAppearanceSettings.ts
@@ -8,7 +8,9 @@ import {
   applyResolvedTheme,
   resolveThemePreference,
   type ColorVisionMode,
+  type ResolvedTheme,
 } from '../utils/appearanceTheme';
+import { getFallbackSyntaxTheme, isSyntaxThemeForResolvedTheme } from '../utils/themeLoader';
 
 const DEFAULT_SETTINGS: AppearanceSettings = {
   fontSize: 14,
@@ -49,6 +51,33 @@ export function useAppearanceSettings() {
     [],
   );
 
+  const saveSettings = useCallback((newSettings: AppearanceSettings) => {
+    try {
+      localStorage.setItem(APPEARANCE_STORAGE_KEY, JSON.stringify(newSettings));
+    } catch (error) {
+      console.warn('Failed to save appearance settings to localStorage:', error);
+    }
+  }, []);
+
+  const getSettingsForResolvedTheme = useCallback(
+    (currentSettings: AppearanceSettings, resolvedTheme: ResolvedTheme) => {
+      if (isSyntaxThemeForResolvedTheme(currentSettings.syntaxTheme, resolvedTheme)) {
+        return currentSettings;
+      }
+
+      const fallbackSyntaxTheme = getFallbackSyntaxTheme(resolvedTheme);
+      if (!fallbackSyntaxTheme) {
+        return currentSettings;
+      }
+
+      return {
+        ...currentSettings,
+        syntaxTheme: fallbackSyntaxTheme.id,
+      };
+    },
+    [],
+  );
+
   // Apply settings to document
   useEffect(() => {
     const root = document.documentElement;
@@ -61,34 +90,37 @@ export function useAppearanceSettings() {
 
     // Apply theme
     const colorVision = settings.colorVision ?? 'normal';
+    const applyResolvedAppearance = (resolvedTheme: ResolvedTheme) => {
+      applyTheme(resolvedTheme, colorVision);
+
+      const nextSettings = getSettingsForResolvedTheme(settings, resolvedTheme);
+      if (nextSettings !== settings) {
+        setSettings(nextSettings);
+        saveSettings(nextSettings);
+      }
+    };
+
     if (settings.theme === 'auto') {
       const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
-      applyTheme(
+      applyResolvedAppearance(
         resolveThemePreference('auto', mediaQuery.matches ? 'dark' : 'light'),
-        colorVision,
       );
 
       const handleChange = (e: MediaQueryListEvent) => {
-        applyTheme(resolveThemePreference('auto', e.matches ? 'dark' : 'light'), colorVision);
+        applyResolvedAppearance(resolveThemePreference('auto', e.matches ? 'dark' : 'light'));
       };
 
       mediaQuery.addEventListener('change', handleChange);
       return () => mediaQuery.removeEventListener('change', handleChange);
     } else {
-      applyTheme(settings.theme, colorVision);
+      applyResolvedAppearance(settings.theme);
       return undefined;
     }
-  }, [settings, applyTheme]);
+  }, [settings, applyTheme, getSettingsForResolvedTheme, saveSettings]);
 
   const updateSettings = (newSettings: AppearanceSettings) => {
     setSettings(newSettings);
-
-    // Save to localStorage
-    try {
-      localStorage.setItem(APPEARANCE_STORAGE_KEY, JSON.stringify(newSettings));
-    } catch (error) {
-      console.warn('Failed to save appearance settings to localStorage:', error);
-    }
+    saveSettings(newSettings);
   };
 
   return {

--- a/src/client/utils/themeLoader.ts
+++ b/src/client/utils/themeLoader.ts
@@ -1,5 +1,5 @@
 // Theme configuration
-export const LIGHT_THEMES = [
+const LIGHT_THEMES = [
   { id: 'github', label: 'GitHub Light' },
   { id: 'vsLight', label: 'VS Light' },
   { id: 'oneLight', label: 'One Light' },
@@ -7,7 +7,7 @@ export const LIGHT_THEMES = [
   { id: 'nightOwlLight', label: 'Night Owl Light' },
 ];
 
-export const DARK_THEMES = [
+const DARK_THEMES = [
   { id: 'vsDark', label: 'VS Dark' },
   { id: 'oneDark', label: 'One Dark' },
   { id: 'gruvboxMaterialDark', label: 'Gruvbox Material Dark' },
@@ -17,3 +17,14 @@ export const DARK_THEMES = [
 ];
 
 // Built-in themes don't require CSS management
+
+type SyntaxThemeOption = (typeof LIGHT_THEMES | typeof DARK_THEMES)[number];
+
+export const getThemesForResolvedTheme = (theme: 'light' | 'dark') =>
+  theme === 'light' ? LIGHT_THEMES : DARK_THEMES;
+
+export const isSyntaxThemeForResolvedTheme = (syntaxTheme: string, theme: 'light' | 'dark') =>
+  getThemesForResolvedTheme(theme).some((themeOption) => themeOption.id === syntaxTheme);
+
+export const getFallbackSyntaxTheme = (theme: 'light' | 'dark'): SyntaxThemeOption | undefined =>
+  getThemesForResolvedTheme(theme)[0];


### PR DESCRIPTION
Resolved #311

## Summary
- Keep syntax highlighting theme in sync when `Theme` is set to `Auto` and the OS color scheme changes.
- Reuse resolved-theme helpers in the settings modal so syntax theme choices stay valid for the current theme.
- Add a regression test covering `matchMedia('(prefers-color-scheme: dark)')` change handling.

## Testing
- `pnpm run check`
- `pnpm run format`
- `pnpm run build`
- `pnpm test`
- Added a new hook test to verify syntax theme updates when the system theme flips while Auto mode is active.