### PR TITLE
Fix Safari sidebar sticky headers for performance

### DIFF
--- a/src/client/components/FileList.tsx
+++ b/src/client/components/FileList.tsx
@@ -15,6 +15,7 @@ import {
 import { memo, useMemo, useRef, useState, type CSSProperties, type MouseEvent } from 'react';
 
 import { type DiffFile, type CommentThread } from '../../types/diff';
+import { isSafariBrowser } from '../utils/browser';
 
 import { Checkbox } from './Checkbox';
 
@@ -161,6 +162,10 @@ export const FileList = memo(function FileList({
   selectedFileIndex,
 }: FileListProps) {
   const fileTree = useMemo(() => buildFileTree(files), [files]);
+  const shouldUseStickyDirectoryHeaders = useMemo(
+    () => !isSafariBrowser(typeof navigator === 'undefined' ? '' : navigator.userAgent),
+    [],
+  );
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const dirContainerRefs = useRef<Map<string, HTMLDivElement>>(new Map());
   const stickyContainerStyle = {
@@ -266,6 +271,11 @@ export const FileList = memo(function FileList({
   };
 
   const handleDirectoryClick = (event: MouseEvent<HTMLDivElement>, path: string) => {
+    if (!shouldUseStickyDirectoryHeaders) {
+      toggleDirectory(path);
+      return;
+    }
+
     const container = scrollContainerRef.current;
     const row = event.currentTarget;
 
@@ -323,7 +333,7 @@ export const FileList = memo(function FileList({
         >
           {node.name && (
             <div
-              className={`sticky flex h-9 items-center gap-2 bg-github-bg-secondary px-4 hover:bg-github-bg-tertiary cursor-pointer ${
+              className={`${shouldUseStickyDirectoryHeaders ? 'sticky ' : ''}flex h-9 items-center gap-2 bg-github-bg-secondary px-4 hover:bg-github-bg-tertiary cursor-pointer ${
                 isReviewed ? 'opacity-70' : ''
               }`}
               data-dir-header="true"
@@ -331,8 +341,10 @@ export const FileList = memo(function FileList({
               data-depth={depth}
               style={{
                 paddingLeft: getTreeRowPaddingLeft(depth),
-                top: `calc(${depth} * var(--dir-row-height))`,
-                zIndex: 1000 - depth,
+                top: shouldUseStickyDirectoryHeaders
+                  ? `calc(${depth} * var(--dir-row-height))`
+                  : undefined,
+                zIndex: shouldUseStickyDirectoryHeaders ? 1000 - depth : undefined,
               }}
               onClick={(event) => handleDirectoryClick(event, node.path)}
             >

--- a/src/client/utils/browser.test.ts
+++ b/src/client/utils/browser.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { isSafariBrowser } from './browser';
+
+describe('isSafariBrowser', () => {
+  it('returns true for Safari on macOS', () => {
+    expect(
+      isSafariBrowser(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15',
+      ),
+    ).toBe(true);
+  });
+
+  it('returns true for Safari on iOS', () => {
+    expect(
+      isSafariBrowser(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1',
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false for Chrome', () => {
+    expect(
+      isSafariBrowser(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36',
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false for Chrome on iOS', () => {
+    expect(
+      isSafariBrowser(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/135.0.7049.83 Mobile/15E148 Safari/604.1',
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/client/utils/browser.ts
+++ b/src/client/utils/browser.ts
@@ -1,0 +1,17 @@
+export function isSafariBrowser(userAgent: string): boolean {
+  if (!userAgent) {
+    return false;
+  }
+
+  const normalizedUserAgent = userAgent.toLowerCase();
+
+  return (
+    normalizedUserAgent.includes('safari') &&
+    !normalizedUserAgent.includes('chrome') &&
+    !normalizedUserAgent.includes('chromium') &&
+    !normalizedUserAgent.includes('crios') &&
+    !normalizedUserAgent.includes('fxios') &&
+    !normalizedUserAgent.includes('edg/') &&
+    !normalizedUserAgent.includes('android')
+  );
+}


### PR DESCRIPTION
Resolved #302

## Summary
- Disable sticky directory headers in the file sidebar on Safari to avoid the layout bug there
- Keep sticky behavior for other browsers and preserve the reviewed-state styling
- Add unit coverage for Safari detection, including Chrome on desktop and iOS

## Testing
- Ran the focused Vitest suite for `isSafariBrowser`
- Rebased onto `main` and resolved the `FileList` conflict