### PR TITLE
feat: add Clojure language support

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -197,7 +197,7 @@ npx skills add yoshiko-pg/difit
 - **JavaScript/TypeScript**：`.js`, `.jsx`, `.ts`, `.tsx`
 - **Web技術**：HTML, CSS, JSON, XML, Markdown
 - **シェルスクリプト**：`.sh`, `.bash`, `.zsh`, `.fish`
-- **バックエンド言語**：PHP, SQL, Ruby, Java, Scala, Perl, Elixir, Haskell
+- **バックエンド言語**：PHP, SQL, Ruby, Java, Scala, Perl, Elixir, Haskell, Clojure
 - **システム言語**：C, C++, C#, Rust, Go
 - **モバイル言語**：Swift, Kotlin, Dart
 - **IaC**：Terraform (HCL), Nix

--- a/README.ko.md
+++ b/README.ko.md
@@ -197,7 +197,7 @@ npx skills add yoshiko-pg/difit
 - **JavaScript/TypeScript**: `.js`, `.jsx`, `.ts`, `.tsx`
 - **웹 기술**: HTML, CSS, JSON, XML, Markdown
 - **셸 스크립트**: `.sh`, `.bash`, `.zsh`, `.fish`
-- **백엔드 언어**: PHP, SQL, Ruby, Java, Scala, Perl, Elixir, Haskell
+- **백엔드 언어**: PHP, SQL, Ruby, Java, Scala, Perl, Elixir, Haskell, Clojure
 - **시스템 언어**: C, C++, C#, Rust, Go
 - **모바일 언어**: Swift, Kotlin, Dart
 - **인프라 코드**: Terraform (HCL), Nix

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ After code edits or automated review, the agent can start the difit server with 
 - **JavaScript/TypeScript**: `.js`, `.jsx`, `.ts`, `.tsx`
 - **Web Technologies**: HTML, CSS, JSON, XML, Markdown
 - **Shell Scripts**: `.sh`, `.bash`, `.zsh`, `.fish`
-- **Backend Languages**: PHP, SQL, Ruby, Java, Scala, Perl, Elixir, Haskell
+- **Backend Languages**: PHP, SQL, Ruby, Java, Scala, Perl, Elixir, Haskell, Clojure
 - **Systems Languages**: C, C++, C#, Rust, Go
 - **Mobile Languages**: Swift, Kotlin, Dart
 - **Infrastructure as Code**: Terraform (HCL), Nix

--- a/README.zh.md
+++ b/README.zh.md
@@ -197,7 +197,7 @@ npx skills add yoshiko-pg/difit
 - **JavaScript/TypeScript**：`.js`, `.jsx`, `.ts`, `.tsx`
 - **Web 技术**：HTML, CSS, JSON, XML, Markdown
 - **Shell 脚本**：`.sh`, `.bash`, `.zsh`, `.fish`
-- **后端语言**：PHP, SQL, Ruby, Java, Scala, Perl, Elixir, Haskell
+- **后端语言**：PHP, SQL, Ruby, Java, Scala, Perl, Elixir, Haskell, Clojure
 - **系统语言**：C, C++, C#, Rust, Go
 - **移动语言**：Swift, Kotlin, Dart
 - **基础设施即代码**：Terraform (HCL), Nix

--- a/src/client/utils/languageDetection.ts
+++ b/src/client/utils/languageDetection.ts
@@ -47,6 +47,10 @@ const DIFF_EXTENSION_LANGUAGE_MAP: Record<string, string> = {
   nix: 'nix',
   hs: 'haskell',
   lhs: 'haskell',
+  clj: 'clojure',
+  cljs: 'clojure',
+  cljc: 'clojure',
+  edn: 'clojure',
 };
 
 // Prism syntax highlighting: use Prism language IDs (e.g. tsx -> tsx, scss -> css).
@@ -110,6 +114,10 @@ const PRISM_EXTENSION_LANGUAGE_MAP: Record<string, string> = {
   nix: 'nix',
   hs: 'haskell',
   lhs: 'haskell',
+  clj: 'clojure',
+  cljs: 'clojure',
+  cljc: 'clojure',
+  edn: 'clojure',
 };
 
 const PRISM_FILENAME_LANGUAGE_MAP: Record<string, string> = {

--- a/src/client/utils/languageLoader.ts
+++ b/src/client/utils/languageLoader.ts
@@ -34,6 +34,7 @@ export function loadPrismLanguage(lang: string): Promise<void> {
       elixir: () => import('prismjs/components/prism-elixir.js'),
       nix: () => import('prismjs/components/prism-nix.js'),
       haskell: () => import('prismjs/components/prism-haskell.js'),
+      clojure: () => import('prismjs/components/prism-clojure.js'),
     };
 
     const importFn = languageImports[lang];


### PR DESCRIPTION
## Summary
  - Add syntax highlighting for [Clojure](https://clojure.org/) files (`.clj`, `.cljs`, `.cljc`, `.edn`)
  - Map these extensions to the `clojure` language in diff detection and Prism highlighting
  - Lazy-load `prism-clojure` on demand
  - Document Clojure support in README (en/ja/ko/zh)