### PR TITLE
Fix notebook full preview to hide until content loads

### DIFF
--- a/src/client/viewers/MarkdownDiffViewer.tsx
+++ b/src/client/viewers/MarkdownDiffViewer.tsx
@@ -1,4 +1,3 @@
-import { Eye, FileDiff } from 'lucide-react';
 import React, { useEffect, useMemo, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -8,10 +7,9 @@ import { MermaidDiagram } from '../components/MermaidDiagram';
 import { PrismSyntaxHighlighter } from '../components/PrismSyntaxHighlighter';
 import type { MergedChunk } from '../hooks/useExpandedLines';
 
+import { PreviewModeTabs, type PreviewMode } from './PreviewModeTabs';
 import { TextDiffViewer } from './TextDiffViewer';
 import type { DiffViewerBodyProps } from './types';
-
-type PreviewMode = 'diff' | 'diff-preview' | 'full-preview';
 
 type PreviewBlockType = 'add' | 'delete' | 'change' | 'context';
 
@@ -582,46 +580,7 @@ export function MarkdownDiffViewer(props: DiffViewerBodyProps) {
   return (
     <div className="bg-github-bg-primary">
       <div className="flex items-center justify-between border-b border-github-border px-4 py-2">
-        <div className="flex items-center gap-1.5">
-          <button
-            onClick={() => setMode('diff')}
-            className={`px-2 py-1 text-xs font-medium rounded transition-colors duration-200 flex items-center gap-1 cursor-pointer ${
-              mode === 'diff'
-                ? 'text-github-text-primary'
-                : 'text-github-text-secondary hover:text-github-text-primary'
-            }`}
-            title="Code Diff"
-          >
-            <FileDiff size={14} />
-            Diff
-          </button>
-          <button
-            onClick={() => setMode('diff-preview')}
-            className={`px-2 py-1 text-xs font-medium rounded transition-colors duration-200 flex items-center gap-1 cursor-pointer ${
-              mode === 'diff-preview'
-                ? 'text-github-text-primary'
-                : 'text-github-text-secondary hover:text-github-text-primary'
-            }`}
-            title="Diff Preview"
-          >
-            <Eye size={14} />
-            Diff Preview
-          </button>
-          {hasFullPreview && (
-            <button
-              onClick={() => setMode('full-preview')}
-              className={`px-2 py-1 text-xs font-medium rounded transition-colors duration-200 flex items-center gap-1 cursor-pointer ${
-                mode === 'full-preview'
-                  ? 'text-github-text-primary'
-                  : 'text-github-text-secondary hover:text-github-text-primary'
-              }`}
-              title="Full Preview"
-            >
-              <Eye size={14} />
-              Full Preview
-            </button>
-          )}
-        </div>
+        <PreviewModeTabs mode={mode} hasFullPreview={hasFullPreview} onModeChange={setMode} />
       </div>
 
       {mode === 'diff' && <TextDiffViewer {...props} />}

--- a/src/client/viewers/NotebookDiffViewer.test.tsx
+++ b/src/client/viewers/NotebookDiffViewer.test.tsx
@@ -1,0 +1,130 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { DiffFile } from '../../types/diff';
+import { WordHighlightProvider } from '../contexts/WordHighlightContext';
+import type { MergedChunk } from '../hooks/useExpandedLines';
+
+import { NotebookDiffViewer } from './NotebookDiffViewer';
+import type { DiffViewerBodyProps } from './types';
+
+const notebookContent = JSON.stringify({
+  cells: [
+    {
+      cell_type: 'markdown',
+      source: ['# Notebook title\n'],
+      metadata: {},
+    },
+    {
+      cell_type: 'code',
+      source: ['print("hi")\n'],
+      execution_count: 1,
+      metadata: {},
+    },
+  ],
+  metadata: {
+    language_info: {
+      name: 'python',
+    },
+  },
+  nbformat: 4,
+  nbformat_minor: 5,
+});
+
+const createFile = (overrides: Partial<DiffFile> = {}): DiffFile => ({
+  path: 'docs/notebook.ipynb',
+  status: 'modified',
+  additions: 1,
+  deletions: 1,
+  chunks: [],
+  ...overrides,
+});
+
+const mergedChunks: MergedChunk[] = [
+  {
+    header: '@@ -1 +1 @@',
+    oldStart: 1,
+    oldLines: 1,
+    newStart: 1,
+    newLines: 1,
+    lines: [
+      {
+        type: 'context',
+        content: notebookContent,
+        oldLineNumber: 1,
+        newLineNumber: 1,
+      },
+    ],
+    originalIndices: [0],
+    hiddenLinesBefore: 0,
+    hiddenLinesAfter: 0,
+  },
+];
+
+const createProps = (overrides: Partial<DiffViewerBodyProps> = {}): DiffViewerBodyProps => ({
+  file: createFile(),
+  threads: [],
+  diffMode: 'unified',
+  mergedChunks,
+  isExpandLoading: false,
+  expandHiddenLines: vi.fn().mockResolvedValue(undefined),
+  expandAllBetweenChunks: vi.fn().mockResolvedValue(undefined),
+  onAddComment: vi.fn().mockResolvedValue(undefined),
+  onGenerateThreadPrompt: vi.fn(),
+  onRemoveThread: vi.fn(),
+  onReplyToThread: vi.fn().mockResolvedValue(undefined),
+  onRemoveMessage: vi.fn(),
+  onUpdateMessage: vi.fn(),
+  baseCommitish: 'HEAD~1',
+  targetCommitish: 'HEAD',
+  ...overrides,
+});
+
+const renderViewer = (overrides: Partial<DiffViewerBodyProps> = {}) =>
+  render(
+    <WordHighlightProvider>
+      <NotebookDiffViewer {...createProps(overrides)} />
+    </WordHighlightProvider>,
+  );
+
+describe('NotebookDiffViewer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows Full Preview tab only after notebook content loads', async () => {
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      text: async () => notebookContent,
+    });
+
+    renderViewer();
+
+    expect(screen.queryByRole('button', { name: 'Full Preview' })).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Full Preview' })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Full Preview' }));
+
+    expect(await screen.findByText('Notebook title')).toBeInTheDocument();
+    expect(global.fetch).toHaveBeenCalledWith('/api/blob/docs%2Fnotebook.ipynb?ref=HEAD~1');
+    expect(global.fetch).toHaveBeenCalledWith('/api/blob/docs%2Fnotebook.ipynb?ref=HEAD');
+  });
+
+  it('does not show Full Preview tab when notebook content cannot be fetched', async () => {
+    (global.fetch as any).mockResolvedValue({
+      ok: false,
+      text: async () => '',
+    });
+
+    renderViewer();
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    expect(screen.queryByRole('button', { name: 'Full Preview' })).not.toBeInTheDocument();
+  });
+});

--- a/src/client/viewers/NotebookDiffViewer.tsx
+++ b/src/client/viewers/NotebookDiffViewer.tsx
@@ -1,5 +1,4 @@
 import { diffLines } from 'diff';
-import { Eye, FileDiff } from 'lucide-react';
 import React, { useEffect, useMemo, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -9,10 +8,9 @@ import { EnhancedPrismSyntaxHighlighter } from '../components/EnhancedPrismSynta
 import { PrismSyntaxHighlighter } from '../components/PrismSyntaxHighlighter';
 import type { MergedChunk } from '../hooks/useExpandedLines';
 
+import { PreviewModeTabs, type PreviewMode } from './PreviewModeTabs';
 import { TextDiffViewer } from './TextDiffViewer';
 import type { DiffViewerBodyProps } from './types';
-
-type PreviewMode = 'diff' | 'diff-preview' | 'full-preview';
 
 type PreviewLineType = 'add' | 'delete' | 'context';
 
@@ -1022,6 +1020,19 @@ export function NotebookDiffViewer(props: DiffViewerBodyProps) {
 
       const canFetchOld = file.status !== 'added' && isFetchableRef(baseRef);
       const canFetchNew = file.status !== 'deleted' && isFetchableRef(targetRef);
+      const canLoadFullPreview =
+        Boolean(previewSource && previewSourceKey) && isFetchableRef(previewSource?.ref);
+
+      if (!canLoadFullPreview) {
+        setFullPreviewCells(null);
+        setLoadedFullPreviewKey(null);
+        setFullPreviewError(null);
+        setIsFullPreviewLoading(false);
+      } else {
+        setFullPreviewCells(null);
+        setFullPreviewError(null);
+        setIsFullPreviewLoading(true);
+      }
 
       if (!canFetchOld && !canFetchNew) {
         setPreviewState({
@@ -1063,6 +1074,13 @@ export function NotebookDiffViewer(props: DiffViewerBodyProps) {
 
         const language = newDoc?.language ?? oldDoc?.language ?? fallbackPreview.language;
         const cells = buildCellsFromNotebookContent(oldDoc?.cells ?? [], newDoc?.cells ?? []);
+        const fullPreviewDoc =
+          previewSource?.ref === targetRef && previewSource.path === file.path
+            ? newDoc
+            : previewSource?.ref === baseRef && previewSource.path === oldPath
+              ? oldDoc
+              : null;
+
         if (!cancelled) {
           setPreviewState({
             status: 'ready',
@@ -1070,6 +1088,16 @@ export function NotebookDiffViewer(props: DiffViewerBodyProps) {
             source: 'blob',
             language,
           });
+          if (fullPreviewDoc && previewSourceKey) {
+            setFullPreviewCells(fullPreviewDoc.cells);
+            setFullPreviewLanguage(fullPreviewDoc.language ?? fallbackPreview.language);
+            setLoadedFullPreviewKey(previewSourceKey);
+            setFullPreviewError(null);
+          } else {
+            setFullPreviewCells(null);
+            setLoadedFullPreviewKey(null);
+            setFullPreviewError(null);
+          }
         }
       } catch (error) {
         if (!cancelled) {
@@ -1080,6 +1108,13 @@ export function NotebookDiffViewer(props: DiffViewerBodyProps) {
             source: 'diff',
             message: error instanceof Error ? error.message : 'Failed to load notebook preview.',
           });
+          setFullPreviewCells(null);
+          setLoadedFullPreviewKey(null);
+          setFullPreviewError(error instanceof Error ? error.message : 'Failed to load preview');
+        }
+      } finally {
+        if (!cancelled) {
+          setIsFullPreviewLoading(false);
         }
       }
     };
@@ -1095,6 +1130,8 @@ export function NotebookDiffViewer(props: DiffViewerBodyProps) {
     file.path,
     file.status,
     props.mergedChunks,
+    previewSource,
+    previewSourceKey,
     targetCommitish,
     fallbackPreview,
   ]);
@@ -1163,47 +1200,21 @@ export function NotebookDiffViewer(props: DiffViewerBodyProps) {
     previewSourceKey,
   ]);
 
+  const hasFullPreview = useMemo(
+    () => previewSourceKey === loadedFullPreviewKey && fullPreviewCells !== null,
+    [fullPreviewCells, loadedFullPreviewKey, previewSourceKey],
+  );
+
+  useEffect(() => {
+    if (mode === 'full-preview' && !hasFullPreview) {
+      setMode('diff-preview');
+    }
+  }, [hasFullPreview, mode]);
+
   return (
     <div className="bg-github-bg-primary">
       <div className="flex items-center justify-between border-b border-github-border px-4 py-2">
-        <div className="flex items-center gap-1.5">
-          <button
-            onClick={() => setMode('diff')}
-            className={`px-2 py-1 text-xs font-medium rounded transition-colors duration-200 flex items-center gap-1 cursor-pointer ${
-              mode === 'diff'
-                ? 'text-github-text-primary'
-                : 'text-github-text-secondary hover:text-github-text-primary'
-            }`}
-            title="Code Diff"
-          >
-            <FileDiff size={14} />
-            Diff
-          </button>
-          <button
-            onClick={() => setMode('diff-preview')}
-            className={`px-2 py-1 text-xs font-medium rounded transition-colors duration-200 flex items-center gap-1 cursor-pointer ${
-              mode === 'diff-preview'
-                ? 'text-github-text-primary'
-                : 'text-github-text-secondary hover:text-github-text-primary'
-            }`}
-            title="Diff Preview"
-          >
-            <Eye size={14} />
-            Diff Preview
-          </button>
-          <button
-            onClick={() => setMode('full-preview')}
-            className={`px-2 py-1 text-xs font-medium rounded transition-colors duration-200 flex items-center gap-1 cursor-pointer ${
-              mode === 'full-preview'
-                ? 'text-github-text-primary'
-                : 'text-github-text-secondary hover:text-github-text-primary'
-            }`}
-            title="Full Preview"
-          >
-            <Eye size={14} />
-            Full Preview
-          </button>
-        </div>
+        <PreviewModeTabs mode={mode} hasFullPreview={hasFullPreview} onModeChange={setMode} />
       </div>
 
       {mode === 'diff' && <TextDiffViewer {...props} />}

--- a/src/client/viewers/PreviewModeTabs.tsx
+++ b/src/client/viewers/PreviewModeTabs.tsx
@@ -1,0 +1,52 @@
+import { Eye, FileDiff } from 'lucide-react';
+
+export type PreviewMode = 'diff' | 'diff-preview' | 'full-preview';
+
+type PreviewModeTabsProps = {
+  mode: PreviewMode;
+  hasFullPreview: boolean;
+  onModeChange: (mode: PreviewMode) => void;
+};
+
+export const PreviewModeTabs = ({ mode, hasFullPreview, onModeChange }: PreviewModeTabsProps) => (
+  <div className="flex items-center gap-1.5">
+    <button
+      onClick={() => onModeChange('diff')}
+      className={`px-2 py-1 text-xs font-medium rounded transition-colors duration-200 flex items-center gap-1 cursor-pointer ${
+        mode === 'diff'
+          ? 'text-github-text-primary'
+          : 'text-github-text-secondary hover:text-github-text-primary'
+      }`}
+      title="Code Diff"
+    >
+      <FileDiff size={14} />
+      Diff
+    </button>
+    <button
+      onClick={() => onModeChange('diff-preview')}
+      className={`px-2 py-1 text-xs font-medium rounded transition-colors duration-200 flex items-center gap-1 cursor-pointer ${
+        mode === 'diff-preview'
+          ? 'text-github-text-primary'
+          : 'text-github-text-secondary hover:text-github-text-primary'
+      }`}
+      title="Diff Preview"
+    >
+      <Eye size={14} />
+      Diff Preview
+    </button>
+    {hasFullPreview && (
+      <button
+        onClick={() => onModeChange('full-preview')}
+        className={`px-2 py-1 text-xs font-medium rounded transition-colors duration-200 flex items-center gap-1 cursor-pointer ${
+          mode === 'full-preview'
+            ? 'text-github-text-primary'
+            : 'text-github-text-secondary hover:text-github-text-primary'
+        }`}
+        title="Full Preview"
+      >
+        <Eye size={14} />
+        Full Preview
+      </button>
+    )}
+  </div>
+);


### PR DESCRIPTION
## Summary
- Hide notebook `Full Preview` until the underlying blob fetch succeeds, matching markdown behavior.
- Factor the preview mode tabs into a shared component so the visibility rule stays consistent across viewers.
- Add notebook viewer coverage for the success and failure cases.

## Testing
- `pnpm run check`
- `pnpm run format`
- `pnpm test`
- `pnpm run build`
- Added and ran targeted notebook/markdown viewer tests