### PR TITLE
Add comment session synchronization and restore CLI comment support

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -151,6 +151,7 @@ git diff --cached | difit -
 | `--clean`             | false           | 起動時に既存コメントと閲覧済みファイルをすべてクリア                                       |
 | `--include-untracked` | false           | diffにuntrackedファイルを自動的に含める（`.`または`working`のみ有効）                      |
 | `--keep-alive`        | false           | ブラウザ切断後もサーバーを終了せず起動したままにする（Ctrl+Cで手動停止）                   |
+| `--background`        | false           | サーバーをバックグラウンドで起動したままにし、接続情報をJSONで出力                         |
 | `--context <lines>`   | Gitの既定値 (3) | 変更ごとの前後コンテキスト行数を制限（`0` は変更行のみ表示。`--pr` と stdin では使用不可） |
 
 ## 💬 コメントシステム

--- a/README.ko.md
+++ b/README.ko.md
@@ -151,6 +151,7 @@ git diff --cached | difit -
 | `--clean`             | false          | 시작 시 모든 기존 코멘트와 열람된 파일 표시 초기화                                            |
 | `--include-untracked` | false          | diff에 untracked 파일 자동 포함 (`.` 또는 `working`에서만 유효)                               |
 | `--keep-alive`        | false          | 브라우저 연결이 끊겨도 서버 유지 (Ctrl+C로 수동 종료)                                         |
+| `--background`        | false          | 서버를 백그라운드에서 계속 실행하고 JSON 연결 정보 출력                                       |
 | `--context <lines>`   | Git 기본값 (3) | 변경 주변의 컨텍스트 줄 수를 제한 (`0`이면 변경된 줄만 표시, `--pr` 및 stdin에서는 사용 불가) |
 
 ## 💬 코멘트 시스템

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Stdin mode is selected with intent-first rules:
 | `--clean`             | false           | Clear all existing comments and viewed files on startup                                                 |
 | `--include-untracked` | false           | Automatically include untracked files in diff (only with `.` or `working`)                              |
 | `--keep-alive`        | false           | Keep server running after browser disconnects (stop manually with Ctrl+C)                               |
+| `--background`        | false           | Keep the server running in the background and output JSON connection info                               |
 | `--context <lines>`   | git default (3) | Limit surrounding context lines per change (`0` shows changes only; not available with `--pr` or stdin) |
 
 ## 💬 Comment System

--- a/README.zh.md
+++ b/README.zh.md
@@ -151,6 +151,7 @@ git diff --cached | difit -
 | `--clean`             | false          | 启动时清除所有现有评论和已查看的文件                                              |
 | `--include-untracked` | false          | 自动将 untracked 文件包含在 diff 中（仅在 `.` 或 `working` 时有效）               |
 | `--keep-alive`        | false          | 浏览器断开后保持服务器运行（使用 Ctrl+C 手动停止）                                |
+| `--background`        | false          | 在后台保持服务器运行，并输出 JSON 连接信息                                        |
 | `--context <lines>`   | Git 默认值 (3) | 限制每处变更周围的上下文行数（`0` 仅显示变更行；不可与 `--pr` 或 stdin 一起使用） |
 
 ## 💬 评论系统

--- a/src/cli/comment.test.ts
+++ b/src/cli/comment.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { createCommentCommand } from './comment.js';
+
+describe('createCommentCommand', () => {
+  const command = createCommentCommand();
+
+  it('creates a command named "comment"', () => {
+    expect(command.name()).toBe('comment');
+  });
+
+  it('has "add" and "get" subcommands', () => {
+    const subcommandNames = command.commands.map((c) => c.name());
+    expect(subcommandNames).toContain('add');
+    expect(subcommandNames).toContain('get');
+  });
+
+  describe('add subcommand', () => {
+    const addCommand = command.commands.find((c) => c.name() === 'add')!;
+
+    it('requires --port option', () => {
+      const portOption = addCommand.options.find((o) => o.long === '--port');
+      expect(portOption).toBeDefined();
+      expect(portOption?.mandatory).toBe(true);
+    });
+
+    it('accepts optional json argument', () => {
+      const args = addCommand.registeredArguments;
+      expect(args).toHaveLength(1);
+      expect(args[0].name()).toBe('json');
+      expect(args[0].required).toBe(false);
+    });
+  });
+
+  describe('get subcommand', () => {
+    const getCommand = command.commands.find((c) => c.name() === 'get')!;
+
+    it('requires --port option', () => {
+      const portOption = getCommand.options.find((o) => o.long === '--port');
+      expect(portOption).toBeDefined();
+      expect(portOption?.mandatory).toBe(true);
+    });
+
+    it('has --format option with choices', () => {
+      const formatOption = getCommand.options.find((o) => o.long === '--format');
+      expect(formatOption).toBeDefined();
+      expect(formatOption?.defaultValue).toBe('text');
+      expect(formatOption?.argChoices).toEqual(['text', 'json']);
+    });
+  });
+});
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function textResponse(body: string, status = 200): Response {
+  return new Response(body, {
+    status,
+    headers: { 'Content-Type': 'text/plain' },
+  });
+}
+
+describe('comment subcommand integration', () => {
+  const originalFetch = globalThis.fetch;
+  let mockFetch: ReturnType<typeof vi.fn<typeof fetch>>;
+  let originalProcessExit: typeof process.exit;
+  let consoleOutput: string[];
+  let consoleErrors: string[];
+
+  beforeEach(() => {
+    mockFetch = vi.fn<typeof fetch>();
+    globalThis.fetch = mockFetch;
+
+    originalProcessExit = process.exit;
+    process.exit = vi.fn() as any;
+
+    consoleOutput = [];
+    consoleErrors = [];
+    vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      consoleOutput.push(args.join(' '));
+    });
+    vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      consoleErrors.push(args.join(' '));
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    process.exit = originalProcessExit;
+    vi.restoreAllMocks();
+  });
+
+  describe('add', () => {
+    it('sends comment imports to the server', async () => {
+      mockFetch.mockResolvedValue(jsonResponse({ success: true, importId: 'abc123', count: 1 }));
+
+      const command = createCommentCommand();
+      await command.parseAsync([
+        'node',
+        'difit',
+        'add',
+        '--port',
+        '4966',
+        '{"type":"thread","filePath":"test.ts","position":{"side":"new","line":1},"body":"Test"}',
+      ]);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:4966/api/comment-imports',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+      expect(consoleOutput[0]).toContain('"success":true');
+    });
+
+    it('validates JSON before sending', async () => {
+      const command = createCommentCommand();
+      await command.parseAsync(['node', 'difit', 'add', '--port', '4966', 'not-valid-json']);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(consoleErrors[0]).toContain('Error:');
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+
+    it('handles server error response', async () => {
+      mockFetch.mockResolvedValue(jsonResponse({ error: 'Bad request' }, 400));
+
+      const command = createCommentCommand();
+      await command.parseAsync([
+        'node',
+        'difit',
+        'add',
+        '--port',
+        '4966',
+        '{"type":"thread","filePath":"test.ts","position":{"side":"new","line":1},"body":"Test"}',
+      ]);
+
+      expect(consoleErrors[0]).toContain('Bad request');
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+
+    it('handles connection error', async () => {
+      const fetchError = new TypeError('fetch failed');
+      mockFetch.mockRejectedValue(fetchError);
+
+      const command = createCommentCommand();
+      await command.parseAsync([
+        'node',
+        'difit',
+        'add',
+        '--port',
+        '9999',
+        '{"type":"thread","filePath":"test.ts","position":{"side":"new","line":1},"body":"Test"}',
+      ]);
+
+      expect(consoleErrors[0]).toContain('Cannot connect');
+      expect(consoleErrors[0]).toContain('9999');
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('get', () => {
+    it('fetches comments in text format by default', async () => {
+      mockFetch.mockResolvedValue(textResponse('Comments output text'));
+
+      const command = createCommentCommand();
+      await command.parseAsync(['node', 'difit', 'get', '--port', '4966']);
+
+      expect(mockFetch).toHaveBeenCalledWith('http://localhost:4966/api/comments-output');
+      expect(consoleOutput[0]).toBe('Comments output text');
+    });
+
+    it('fetches comments in json format', async () => {
+      mockFetch.mockResolvedValue(jsonResponse({ threads: [{ id: '1' }] }));
+
+      const command = createCommentCommand();
+      await command.parseAsync(['node', 'difit', 'get', '--port', '4966', '--format', 'json']);
+
+      expect(mockFetch).toHaveBeenCalledWith('http://localhost:4966/api/comments-json');
+      expect(consoleOutput[0]).toContain('"threads"');
+    });
+
+    it('handles connection error', async () => {
+      mockFetch.mockRejectedValue(new TypeError('fetch failed'));
+
+      const command = createCommentCommand();
+      await command.parseAsync(['node', 'difit', 'get', '--port', '9999']);
+
+      expect(consoleErrors[0]).toContain('Cannot connect');
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+
+    it('handles empty text output silently', async () => {
+      mockFetch.mockResolvedValue(textResponse('  '));
+
+      const command = createCommentCommand();
+      await command.parseAsync(['node', 'difit', 'get', '--port', '4966']);
+
+      expect(consoleOutput).toHaveLength(0);
+    });
+  });
+});

--- a/src/cli/comment.ts
+++ b/src/cli/comment.ts
@@ -1,0 +1,118 @@
+import { Command, Option } from 'commander';
+
+import { parseCommentImportValue } from '../utils/commentImports.js';
+
+import { detectStdinSource, readStdin } from './utils.js';
+
+interface CommentImportResponse {
+  success?: boolean;
+  importId?: string;
+  count?: number;
+  warnings?: string[];
+}
+
+async function parseCommentAddInput(json?: string): Promise<string> {
+  if (typeof json === 'string') {
+    return json;
+  }
+
+  if (detectStdinSource() === 'tty') {
+    throw new Error('Provide comment JSON as an argument or via stdin');
+  }
+
+  const stdin = await readStdin();
+  if (!stdin.trim()) {
+    throw new Error('No comment JSON received from stdin');
+  }
+
+  return stdin;
+}
+
+export function createCommentCommand(): Command {
+  const comment = new Command('comment').description(
+    'Add or retrieve comments on a running difit server',
+  );
+
+  comment
+    .command('add')
+    .description('Add comments to a running difit server')
+    .argument('[json]', 'comment import JSON (object or array)')
+    .requiredOption('--port <port>', 'port of the running difit server', parseInt)
+    .action(async (json: string | undefined, opts: { port: number }) => {
+      try {
+        const input = await parseCommentAddInput(json);
+        const imports = parseCommentImportValue(input);
+
+        const response = await fetch(`http://localhost:${opts.port}/api/comment-imports`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(imports),
+        });
+
+        if (!response.ok) {
+          const errorBody = (await response.json().catch(() => ({}))) as { error?: string };
+          console.error(`Error: ${errorBody.error ?? 'Failed to add comments'}`);
+          process.exit(1);
+        }
+
+        const result = (await response.json()) as CommentImportResponse;
+        console.log(
+          JSON.stringify({
+            success: result.success ?? true,
+            importId: result.importId,
+            count: result.count ?? imports.length,
+            warnings: result.warnings ?? [],
+          }),
+        );
+      } catch (error) {
+        if (error instanceof TypeError && error.message.includes('fetch failed')) {
+          console.error(
+            `Error: Cannot connect to difit server on port ${opts.port}. Is the server running?`,
+          );
+        } else {
+          console.error(`Error: ${error instanceof Error ? error.message : 'Unknown error'}`);
+        }
+        process.exit(1);
+      }
+    });
+
+  comment
+    .command('get')
+    .description('Retrieve comments from a running difit server')
+    .requiredOption('--port <port>', 'port of the running difit server', parseInt)
+    .addOption(
+      new Option('--format <format>', 'output format').choices(['text', 'json']).default('text'),
+    )
+    .action(async (opts: { port: number; format: string }) => {
+      try {
+        const endpoint = opts.format === 'json' ? '/api/comments-json' : '/api/comments-output';
+        const response = await fetch(`http://localhost:${opts.port}${endpoint}`);
+
+        if (!response.ok) {
+          console.error('Error: Failed to retrieve comments');
+          process.exit(1);
+        }
+
+        if (opts.format === 'json') {
+          const data: unknown = await response.json();
+          console.log(JSON.stringify(data));
+        } else {
+          const text = await response.text();
+          if (text.trim()) {
+            console.log(text);
+          }
+        }
+      } catch (error) {
+        if (error instanceof TypeError && error.message.includes('fetch failed')) {
+          console.error(
+            `Error: Cannot connect to difit server on port ${opts.port}. Is the server running?`,
+          );
+        } else {
+          console.error(`Error: ${error instanceof Error ? error.message : 'Unknown error'}`);
+        }
+        process.exit(1);
+      }
+    });
+
+  return comment;
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { spawn } from 'child_process';
 import { Command } from 'commander';
 import React from 'react';
 import { simpleGit, type SimpleGit } from 'simple-git';
@@ -19,7 +20,9 @@ import {
   parseCommentOptions,
   validateDiffArguments,
   getGitRoot,
+  readStdin,
 } from './utils.js';
+import { createCommentCommand } from './comment.js';
 import { getPrPatch, getPrCommentImports } from './github.js';
 import { warnAboutTuiDeprecation } from './tuiDeprecation.js';
 
@@ -73,6 +76,88 @@ function determineDiffMode(selection: DiffSelection, compareWith?: string): Diff
   return DiffMode.DEFAULT;
 }
 
+async function startBackgroundProcess(): Promise<void> {
+  const scriptPath = process.argv[1];
+  if (!scriptPath) {
+    throw new Error('Unable to determine difit entrypoint for background process');
+  }
+
+  const childArgs = process.argv.slice(2).filter((arg) => arg !== '--background');
+  if (!childArgs.includes('--keep-alive')) {
+    childArgs.push('--keep-alive');
+  }
+  if (!childArgs.includes('--no-open')) {
+    childArgs.push('--no-open');
+  }
+
+  const child = spawn(process.execPath, [scriptPath, ...childArgs], {
+    detached: true,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: {
+      ...process.env,
+      [BACKGROUND_CHILD_ENV]: '1',
+    },
+  });
+
+  child.stdout.setEncoding('utf8');
+  child.stderr.setEncoding('utf8');
+
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error('Timed out while starting background difit server'));
+    }, 10_000);
+    let stderr = '';
+    let settled = false;
+
+    const finish = (callback: () => void) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      callback();
+    };
+
+    child.stdout.on('data', (chunk: string) => {
+      const line = chunk
+        .split(/\r?\n/u)
+        .map((value) => value.trim())
+        .find((value) => value.length > 0);
+
+      if (!line) {
+        return;
+      }
+
+      finish(() => {
+        console.log(line);
+        child.unref();
+        resolve();
+      });
+    });
+
+    child.stderr.on('data', (chunk: string) => {
+      stderr += chunk;
+    });
+
+    child.once('error', (error) => {
+      finish(() => {
+        reject(error);
+      });
+    });
+
+    child.once('exit', (code) => {
+      finish(() => {
+        const trimmedStderr = stderr.trim();
+        reject(
+          new Error(
+            trimmedStderr || `Background difit server exited early (code ${code ?? 'unknown'})`,
+          ),
+        );
+      });
+    });
+  });
+}
+
 interface CliOptions {
   port?: number;
   host?: string;
@@ -84,9 +169,12 @@ interface CliOptions {
   clean?: boolean;
   includeUntracked?: boolean;
   keepAlive?: boolean;
+  background?: boolean;
   context?: number;
   mergeBase?: boolean;
 }
+
+const BACKGROUND_CHILD_ENV = 'DIFIT_BACKGROUND_CHILD';
 
 const program = new Command();
 
@@ -94,6 +182,8 @@ program
   .name('difit')
   .description('A lightweight Git diff viewer with GitHub-like interface')
   .version(pkg.version, '-v, --version', 'output the version number')
+  .enablePositionalOptions()
+  .addCommand(createCommentCommand())
   .argument(
     '[commit-ish]',
     'Git commit, tag, branch, HEAD~n reference, or "working"/"staged"/"."',
@@ -123,6 +213,7 @@ program
   .option('--clean', 'start with a clean slate by clearing all existing comments')
   .option('--include-untracked', 'automatically include untracked files in diff')
   .option('--keep-alive', 'keep server running even after browser disconnects')
+  .option('--background', 'keep the server running in the background and output JSON info')
   .option('--context <lines>', 'number of context lines shown around each change', parseInt)
   .option(
     '--merge-base',
@@ -130,6 +221,8 @@ program
   )
   .action(async (commitish: string, compareWith: string | undefined, options: CliOptions) => {
     try {
+      const isBackgroundChild = process.env[BACKGROUND_CHILD_ENV] === '1';
+      const backgroundMode = options.background || isBackgroundChild;
       let stdinDiff: string | undefined;
       let stdinReviewLabel = 'diff from stdin';
       let manualCommentImports: CommentImport[] = [];
@@ -143,6 +236,11 @@ program
         process.exit(1);
       }
 
+      if (options.background && !isBackgroundChild) {
+        await startBackgroundProcess();
+        return;
+      }
+
       try {
         manualCommentImports = parseCommentOptions(options.comment);
         commentImports = manualCommentImports;
@@ -151,6 +249,11 @@ program
           `Error: ${error instanceof Error ? error.message : 'Invalid --comment value'}`,
         );
         process.exit(1);
+      }
+
+      if (backgroundMode) {
+        options.keepAlive = true;
+        options.open = false;
       }
 
       if (options.pr) {
@@ -221,7 +324,7 @@ program
 
       if (stdinDiff) {
         // Start server with stdin diff (including --pr patch)
-        const { url } = await startServer({
+        const { url, port } = await startServer({
           stdinDiff,
           preferredPort: options.port,
           host: options.host,
@@ -231,6 +334,11 @@ program
           keepAlive: options.keepAlive,
           ...(commentImports.length > 0 ? { commentImports } : {}),
         });
+
+        if (backgroundMode) {
+          console.log(JSON.stringify({ port, url, pid: process.pid }));
+          return;
+        }
 
         console.log(`\n🚀 difit server started on ${url}`);
         console.log(`📋 Reviewing: ${stdinReviewLabel}`);
@@ -261,10 +369,19 @@ program
 
       if (selection.targetCommitish === 'working' || selection.targetCommitish === '.') {
         const git = simpleGit(repoPath);
-        await handleUntrackedFiles(git, options.includeUntracked);
+        if (isBackgroundChild && !options.includeUntracked) {
+          // Skip interactive prompts in detached background mode.
+        } else {
+          await handleUntrackedFiles(git, options.includeUntracked);
+        }
       }
 
       if (options.tui) {
+        if (backgroundMode) {
+          console.error('Error: --background option cannot be used with --tui');
+          process.exit(1);
+        }
+
         if (commentImports.length > 0) {
           console.error('Error: --comment option cannot be used with --tui');
           process.exit(1);
@@ -314,6 +431,11 @@ program
         ...(commentImports.length > 0 ? { commentImports } : {}),
       });
 
+      if (backgroundMode) {
+        console.log(JSON.stringify({ port, url, pid: process.pid }));
+        return;
+      }
+
       console.log(`\n🚀 difit server started on ${url}`);
       console.log(`📋 Reviewing: ${selection.targetCommitish}`);
 
@@ -360,16 +482,7 @@ program
     }
   });
 
-program.parse();
-
-// Check for untracked files and prompt user to add them for diff visibility
-async function readStdin(): Promise<string> {
-  const chunks: Buffer[] = [];
-  for await (const chunk of process.stdin) {
-    chunks.push(chunk as Buffer);
-  }
-  return Buffer.concat(chunks).toString('utf8');
-}
+void program.parseAsync();
 
 async function handleUntrackedFiles(git: SimpleGit, addAutomatically?: boolean): Promise<void> {
   const files = await findUntrackedFiles(git);

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -265,3 +265,11 @@ export async function waitForEnter(message: string): Promise<void> {
     rl.close();
   }
 }
+
+export async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}

--- a/src/client/App.test.tsx
+++ b/src/client/App.test.tsx
@@ -22,8 +22,10 @@ vi.mock('./hooks/useViewport', () => ({
 // Mock the useDiffComments hook
 vi.mock('./hooks/useDiffComments', () => ({
   useDiffComments: vi.fn(() => ({
+    hasLoadedComments: true,
     comments: [],
     threads: mockComments,
+    replaceThreads: mockReplaceThreads,
     addComment: vi.fn(),
     addThread: vi.fn(),
     removeComment: vi.fn(),
@@ -119,6 +121,7 @@ Object.defineProperty(window, 'EventSource', {
 });
 
 let mockComments: DiffCommentThread[] = [];
+const mockReplaceThreads = vi.fn();
 const mockClearAllComments = vi.fn();
 const mockApplyCommentImports = vi.fn(() => []);
 
@@ -169,10 +172,15 @@ beforeEach(() => {
   MockEventSource.clearInstances();
   mockViewedFiles = new Set<string>();
   mockHasLoadedInitialViewedFiles = true;
+  mockReplaceThreads.mockReset();
 });
 
 const mockDiffResponse: DiffResponse = {
   commit: 'abc123',
+  baseCommitish: 'HEAD^',
+  targetCommitish: 'HEAD',
+  requestedBaseCommitish: 'HEAD^',
+  requestedTargetCommitish: 'HEAD',
   files: [
     {
       path: 'test.ts',
@@ -335,30 +343,56 @@ describe('App Component - Clear Comments Functionality', () => {
       consoleLogSpy.mockRestore();
     });
 
-    it('applies imported comments after loading the diff response', async () => {
-      const responseWithImports: DiffResponse = {
-        ...mockDiffResponse,
-        commentImportId: 'import-bundle-1',
-        commentImports: [
-          {
-            type: 'thread',
-            filePath: 'test.ts',
-            position: { side: 'new', line: 10 },
-            body: 'Imported comment',
-          },
-        ],
-      };
+    it('hydrates comments from the server comment session on startup', async () => {
+      const serverThreads = [
+        createMockThread({
+          id: 'imported-thread',
+          filePath: 'test.ts',
+          line: 10,
+          body: 'Imported comment',
+        }),
+      ];
 
-      mockFetch(responseWithImports);
+      vi.mocked(global.fetch).mockImplementation((input) => {
+        const url = String(input);
+
+        if (url.startsWith('/api/comments-json')) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ threads: serverThreads }),
+          } as Response);
+        }
+
+        if (url.startsWith('/api/comments')) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ success: true }),
+          } as Response);
+        }
+
+        if (url === '/api/revisions') {
+          return Promise.resolve({
+            ok: true,
+            json: async () => null,
+          } as Response);
+        }
+
+        return Promise.resolve({
+          ok: true,
+          json: async () => mockDiffResponse,
+          blob: async () => ({ size: 1024 }),
+        } as Response);
+      });
 
       renderApp();
 
       await waitFor(() => {
-        expect(mockApplyCommentImports).toHaveBeenCalledWith(
-          responseWithImports.commentImports,
-          'import-bundle-1',
-        );
+        expect(mockReplaceThreads).toHaveBeenCalledWith(serverThreads);
       });
+
+      expect(vi.mocked(global.fetch)).toHaveBeenCalledWith(
+        '/api/comments-json?base=HEAD%5E&target=HEAD',
+      );
     });
   });
 });
@@ -433,17 +467,20 @@ describe('App Component - Comment sync', () => {
     const { rerender } = renderApp();
 
     await waitFor(() => {
-      const commentCalls = mockGlobalFetch.mock.calls.filter(([url]) => url === '/api/comments');
+      const commentCalls = mockGlobalFetch.mock.calls.filter(([url]) =>
+        String(url).startsWith('/api/comments?'),
+      );
       expect(commentCalls).toHaveLength(1);
 
-      const [, request] = commentCalls[0] as [string, RequestInit];
+      const [url, request] = commentCalls[0] as [string, RequestInit];
+      expect(url).toBe('/api/comments?base=HEAD%5E&target=HEAD');
       expect(request.method).toBe('POST');
       expect(JSON.parse(String(request.body))).toEqual({
         threads: [
           expect.objectContaining({
             id: 'test-1',
-            file: 'test.ts',
-            line: 10,
+            filePath: 'test.ts',
+            position: { side: 'new', line: 10 },
             messages: [
               expect.objectContaining({
                 id: 'test-1',
@@ -464,10 +501,13 @@ describe('App Component - Comment sync', () => {
     );
 
     await waitFor(() => {
-      const commentCalls = mockGlobalFetch.mock.calls.filter(([url]) => url === '/api/comments');
+      const commentCalls = mockGlobalFetch.mock.calls.filter(([url]) =>
+        String(url).startsWith('/api/comments?'),
+      );
       expect(commentCalls).toHaveLength(2);
 
-      const [, request] = commentCalls[1] as [string, RequestInit];
+      const [url, request] = commentCalls[1] as [string, RequestInit];
+      expect(url).toBe('/api/comments?base=HEAD%5E&target=HEAD');
       expect(request.method).toBe('POST');
       expect(JSON.parse(String(request.body))).toEqual({ threads: [] });
     });
@@ -475,25 +515,25 @@ describe('App Component - Comment sync', () => {
 
   it('sends an empty comment list on unload when no comments remain', async () => {
     mockComments = [];
+    const addEventListenerSpy = vi.spyOn(window, 'addEventListener');
 
     renderApp();
 
     await waitFor(() => {
-      expect(vi.mocked(global.fetch)).toHaveBeenCalledWith(
-        '/api/comments',
-        expect.objectContaining({
-          method: 'POST',
-          body: JSON.stringify({ threads: [] }),
-        }),
-      );
+      expect(addEventListenerSpy).toHaveBeenCalledWith('beforeunload', expect.any(Function));
     });
 
-    fireEvent(window, new Event('beforeunload'));
+    const beforeUnloadHandler = addEventListenerSpy.mock.calls.find(
+      ([eventName]) => eventName === 'beforeunload',
+    )?.[1] as (() => void) | undefined;
+    expect(beforeUnloadHandler).toBeDefined();
+    beforeUnloadHandler?.();
 
     expect(navigator.sendBeacon).toHaveBeenCalledWith(
-      '/api/comments',
+      '/api/comments?base=HEAD%5E&target=HEAD',
       JSON.stringify({ threads: [] }),
     );
+    addEventListenerSpy.mockRestore();
   });
 
   it('shows author badges in the comments modal when the diff has multiple authors', async () => {
@@ -809,7 +849,7 @@ describe('App Component - Revision-aware refetching', () => {
         } as Response);
       }
 
-      if (url.includes('/api/comments')) {
+      if (url.startsWith('/api/comments?')) {
         return Promise.resolve({
           ok: true,
           json: async () => ({ success: true }),

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -2,6 +2,7 @@ import { Columns, AlignLeft, Settings, PanelLeftClose, PanelLeft, Keyboard } fro
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 
 import {
+  type DiffCommentThread,
   type DiffResponse,
   type DiffSelection,
   type DiffViewMode,
@@ -11,6 +12,7 @@ import {
   type RevisionsResponse,
 } from '../types/diff';
 import { DEFAULT_DIFF_VIEW_MODE, normalizeDiffViewMode } from '../utils/diffMode';
+import { mergeCommentThreads } from '../utils/commentImports';
 import {
   createDiffSelection,
   diffSelectionsEqual,
@@ -150,14 +152,15 @@ function App() {
 
   // New diff-aware comment system
   const {
+    hasLoadedComments,
     threads,
+    replaceThreads,
     addThread,
     replyToThread,
     removeThread,
     removeMessage,
     updateMessage,
     clearAllComments,
-    applyCommentImports,
     generateThreadPrompt,
     generateAllCommentsPrompt,
   } = useDiffComments(
@@ -204,6 +207,70 @@ function App() {
     return map;
   }, [normalizedThreads]);
   const showMobileCommentsBar = isMobile && threads.length > 0;
+  const commentsContextKey = useMemo(() => {
+    if (!resolvedSelectionKey) {
+      return null;
+    }
+
+    return `${diffData?.repositoryId ?? 'default'}:${resolvedSelectionKey}`;
+  }, [diffData?.repositoryId, resolvedSelectionKey]);
+  const commentSessionQueryString = useMemo(() => {
+    if (!resolvedSelection) {
+      return null;
+    }
+
+    const params = new URLSearchParams({
+      base: resolvedSelection.baseCommitish,
+      target: resolvedSelection.targetCommitish,
+    });
+    if (resolvedSelection.baseMode === 'merge-base') {
+      params.set('baseMode', resolvedSelection.baseMode);
+    }
+
+    return params.toString();
+  }, [resolvedSelection]);
+  const getCommentApiUrl = useCallback(
+    (path: string) => {
+      if (!commentSessionQueryString) {
+        return path;
+      }
+      return `${path}?${commentSessionQueryString}`;
+    },
+    [commentSessionQueryString],
+  );
+  const [bootstrappedCommentsKey, setBootstrappedCommentsKey] = useState<string | null>(null);
+  const hasBootstrappedComments =
+    commentsContextKey !== null && commentsContextKey === bootstrappedCommentsKey;
+  const bootstrappingCommentsKeyRef = useRef<string | null>(null);
+  const skipNextCommentSyncRef = useRef(false);
+  const pendingBootstrapAfterLocalResetRef = useRef(false);
+
+  useEffect(() => {
+    if (commentsContextKey !== bootstrappedCommentsKey) {
+      skipNextCommentSyncRef.current = false;
+    }
+  }, [bootstrappedCommentsKey, commentsContextKey]);
+
+  const fetchServerThreads = useCallback(async (): Promise<DiffCommentThread[]> => {
+    const response = await fetch(getCommentApiUrl('/api/comments-json'));
+    if (!response.ok) {
+      throw new Error(`Failed to fetch comments: ${response.status} ${response.statusText}`);
+    }
+
+    const payload = (await response.json()) as { threads?: DiffCommentThread[] };
+    return Array.isArray(payload.threads) ? payload.threads : [];
+  }, [getCommentApiUrl]);
+
+  const syncThreadsToServer = useCallback(
+    async (nextThreads: DiffCommentThread[]) => {
+      await fetch(getCommentApiUrl('/api/comments'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ threads: nextThreads }),
+      });
+    },
+    [getCommentApiUrl],
+  );
 
   // Viewed files management
   const { viewedFiles, hasLoadedInitialViewedFiles, toggleFileViewed, clearViewedFiles } =
@@ -369,11 +436,28 @@ function App() {
     chunkIndex: number;
     lineIndex: number;
   } | null>(null);
+  const fetchDiffDataRef = useRef<((selection?: DiffSelection) => Promise<void>) | null>(null);
+  const handleWatchReload = useCallback(async () => {
+    await fetchDiffDataRef.current?.();
+  }, []);
+  const handleCommentsChanged = useCallback(async () => {
+    try {
+      const serverThreads = await fetchServerThreads();
+      skipNextCommentSyncRef.current = true;
+      replaceThreads(serverThreads);
+      if (commentsContextKey) {
+        setBootstrappedCommentsKey(commentsContextKey);
+      }
+    } catch (commentsError) {
+      console.error('Failed to refresh comments from server:', commentsError);
+    }
+  }, [commentsContextKey, fetchServerThreads, replaceThreads]);
 
   // File watch for reload functionality - initialize with callback
-  const { shouldReload, reload, watchState } = useFileWatch(async () => {
-    await fetchDiffData();
-  });
+  const { shouldReload, reload, watchState } = useFileWatch(
+    handleWatchReload,
+    handleCommentsChanged,
+  );
 
   const { cursor, isHelpOpen, setIsHelpOpen, setCursorPosition } = useKeyboardNavigation({
     files: navigableFiles,
@@ -537,6 +621,7 @@ function App() {
     },
     [ignoreWhitespace],
   );
+  fetchDiffDataRef.current = fetchDiffData;
 
   useEffect(() => {
     void fetchDiffData();
@@ -610,6 +695,7 @@ function App() {
   useEffect(() => {
     if (diffData?.clearComments && !hasCleanedRef.current) {
       hasCleanedRef.current = true;
+      pendingBootstrapAfterLocalResetRef.current = true;
       clearAllComments({ resetAppliedCommentImportIds: true });
       clearViewedFiles();
       console.log(
@@ -619,13 +705,71 @@ function App() {
   }, [diffData?.clearComments, clearAllComments, clearViewedFiles]);
 
   useEffect(() => {
-    if (!diffData?.commentImportId || !diffData.commentImports?.length) {
+    if (!commentsContextKey || !hasLoadedComments) {
       return;
     }
 
-    const warnings = applyCommentImports(diffData.commentImports, diffData.commentImportId);
-    warnings.forEach((warning) => console.warn(warning));
-  }, [applyCommentImports, diffData?.commentImportId, diffData?.commentImports]);
+    if (bootstrappedCommentsKey === commentsContextKey) {
+      return;
+    }
+
+    if (bootstrappingCommentsKeyRef.current === commentsContextKey) {
+      return;
+    }
+
+    if (pendingBootstrapAfterLocalResetRef.current) {
+      pendingBootstrapAfterLocalResetRef.current = false;
+      return;
+    }
+
+    bootstrappingCommentsKeyRef.current = commentsContextKey;
+    let cancelled = false;
+
+    const bootstrapComments = async () => {
+      try {
+        const serverThreads = await fetchServerThreads();
+        const mergedThreads = mergeCommentThreads(serverThreads, threads).threads;
+        if (cancelled) {
+          return;
+        }
+
+        skipNextCommentSyncRef.current = true;
+        replaceThreads(mergedThreads);
+
+        if (JSON.stringify(serverThreads) !== JSON.stringify(mergedThreads)) {
+          await syncThreadsToServer(mergedThreads);
+        }
+      } catch (commentsError) {
+        if (!cancelled) {
+          console.error('Failed to bootstrap comments from server:', commentsError);
+        }
+      } finally {
+        if (!cancelled) {
+          setBootstrappedCommentsKey(commentsContextKey);
+        }
+        if (bootstrappingCommentsKeyRef.current === commentsContextKey) {
+          bootstrappingCommentsKeyRef.current = null;
+        }
+      }
+    };
+
+    void bootstrapComments();
+
+    return () => {
+      cancelled = true;
+      if (bootstrappingCommentsKeyRef.current === commentsContextKey) {
+        bootstrappingCommentsKeyRef.current = null;
+      }
+    };
+  }, [
+    bootstrappedCommentsKey,
+    commentsContextKey,
+    fetchServerThreads,
+    hasLoadedComments,
+    replaceThreads,
+    syncThreadsToServer,
+    threads,
+  ]);
 
   // Trigger sparkle animation when all files are viewed
   useEffect(() => {
@@ -648,28 +792,36 @@ function App() {
 
   // Send comments to server whenever they change and before page unload
   useEffect(() => {
-    const data = JSON.stringify({ threads: normalizedThreads });
+    if (!hasBootstrappedComments) {
+      return;
+    }
 
-    fetch('/api/comments', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: data,
-    }).catch((error) => {
-      console.error('Failed to sync comments:', error);
-    });
+    const data = JSON.stringify({ threads });
+    const commentsApiUrl = getCommentApiUrl('/api/comments');
 
     // Also handle page unload
     const sendCommentsBeforeUnload = () => {
       // Use sendBeacon for reliable delivery during page unload, including empty states.
-      navigator.sendBeacon('/api/comments', data);
+      navigator.sendBeacon(commentsApiUrl, data);
     };
 
     window.addEventListener('beforeunload', sendCommentsBeforeUnload);
 
+    if (skipNextCommentSyncRef.current) {
+      skipNextCommentSyncRef.current = false;
+      return () => {
+        window.removeEventListener('beforeunload', sendCommentsBeforeUnload);
+      };
+    }
+
+    syncThreadsToServer(threads).catch((syncError) => {
+      console.error('Failed to sync comments:', syncError);
+    });
+
     return () => {
       window.removeEventListener('beforeunload', sendCommentsBeforeUnload);
     };
-  }, [normalizedThreads]);
+  }, [getCommentApiUrl, hasBootstrappedComments, syncThreadsToServer, threads]);
 
   // Establish SSE connection for tab close detection
   useEffect(() => {

--- a/src/client/hooks/useDiffComments.ts
+++ b/src/client/hooks/useDiffComments.ts
@@ -32,8 +32,10 @@ interface ReplyToThreadParams {
 }
 
 interface UseDiffCommentsReturn {
+  hasLoadedComments: boolean;
   comments: LegacyDiffComment[];
   threads: DiffCommentThread[];
+  replaceThreads: (threads: DiffCommentThread[]) => void;
   addComment: (params: AddThreadParams) => LegacyDiffComment;
   addThread: (params: AddThreadParams) => DiffCommentThread;
   removeComment: (commentId: string) => void;
@@ -90,6 +92,7 @@ export function useDiffComments(
   baseMode?: BaseMode,
 ): UseDiffCommentsReturn {
   const [threads, setThreads] = useState<DiffCommentThread[]>([]);
+  const [hasLoadedComments, setHasLoadedComments] = useState(false);
 
   const loadDiffContextData = useCallback(() => {
     if (!baseCommitish || !targetCommitish) {
@@ -126,7 +129,12 @@ export function useDiffComments(
   }, [baseCommitish, targetCommitish, baseMode]);
 
   useEffect(() => {
-    if (!baseCommitish || !targetCommitish) return;
+    if (!baseCommitish || !targetCommitish) {
+      // oxlint-disable-next-line react-hooks-js/set-state-in-effect -- intentional: clear diff-scoped state when selection is unavailable
+      setThreads([]);
+      setHasLoadedComments(false);
+      return;
+    }
 
     const loadedThreads =
       loadDiffContextData()?.threads ||
@@ -138,8 +146,8 @@ export function useDiffComments(
         repositoryId,
         baseMode,
       );
-    // oxlint-disable-next-line react-hooks-js/set-state-in-effect -- intentional: sync state from external storage on prop change
     setThreads(loadedThreads);
+    setHasLoadedComments(true);
   }, [
     baseCommitish,
     targetCommitish,
@@ -164,8 +172,16 @@ export function useDiffComments(
         baseMode,
       );
       setThreads(newThreads);
+      setHasLoadedComments(true);
     },
     [baseCommitish, targetCommitish, currentCommitHash, branchToHash, repositoryId, baseMode],
+  );
+
+  const replaceThreads = useCallback(
+    (newThreads: DiffCommentThread[]) => {
+      saveThreads(newThreads);
+    },
+    [saveThreads],
   );
 
   const addThread = useCallback(
@@ -431,8 +447,10 @@ export function useDiffComments(
     .filter((comment): comment is LegacyDiffComment => comment !== null);
 
   return {
+    hasLoadedComments,
     comments,
     threads,
+    replaceThreads,
     addComment,
     addThread,
     removeComment,

--- a/src/client/hooks/useFileWatch.ts
+++ b/src/client/hooks/useFileWatch.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-import { DiffMode, type ClientWatchState } from '../../types/watch.js';
+import { DiffMode, type ClientWatchState, type WatchEvent } from '../../types/watch.js';
 import { resolveEventSourceUrl } from '../utils/eventSourceUrl';
 
 interface FileWatchHook {
@@ -11,15 +11,10 @@ interface FileWatchHook {
   watchState: ClientWatchState;
 }
 
-interface WatchEvent {
-  type: 'reload' | 'error' | 'connected';
-  diffMode: DiffMode;
-  changeType: 'file' | 'commit' | 'staging';
-  timestamp: string;
-  message?: string;
-}
-
-export function useFileWatch(onReload?: () => Promise<void>): FileWatchHook {
+export function useFileWatch(
+  onReload?: () => Promise<void>,
+  onCommentsChanged?: () => Promise<void>,
+): FileWatchHook {
   const eventSourceRef = useRef<EventSource | null>(null);
   const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const reconnectAttemptsRef = useRef(0);
@@ -86,6 +81,12 @@ export function useFileWatch(onReload?: () => Promise<void>): FileWatchHook {
               console.error('File watch error:', data.message);
               setError(data.message || 'File watch error occurred');
               break;
+
+            case 'commentsChanged':
+              if (onCommentsChanged) {
+                void onCommentsChanged();
+              }
+              break;
           }
         } catch (parseError) {
           console.error('Error parsing watch event:', parseError);
@@ -130,7 +131,7 @@ export function useFileWatch(onReload?: () => Promise<void>): FileWatchHook {
       console.error('Failed to connect to file watch service:', connectionError);
       setError('Failed to connect to file watch service');
     }
-  }, [maxReconnectAttempts, reconnectDelay]);
+  }, [maxReconnectAttempts, onCommentsChanged, reconnectDelay]);
 
   const handleReload = useCallback(async () => {
     if (watchState.isReloading) {

--- a/src/server/file-watcher.ts
+++ b/src/server/file-watcher.ts
@@ -4,7 +4,7 @@ import { subscribe } from '@parcel/watcher';
 import { type Response } from 'express';
 import { simpleGit, type SimpleGit } from 'simple-git';
 
-import { DiffMode } from '../types/watch.js';
+import { DiffMode, type WatchEvent } from '../types/watch.js';
 
 interface FileWatcherConfig {
   watchPath: string;
@@ -251,13 +251,22 @@ export class FileWatcherService {
     }
   }
 
+  broadcast(event: WatchEvent): void {
+    if (this.clients.length === 0) {
+      return;
+    }
+    this.clients.forEach((client) => {
+      this.sendToClient(client, event);
+    });
+  }
+
   private broadcastChange(): void {
     if (this.clients.length === 0 || !this.config) {
       return;
     }
 
     const changeType = this.determineChangeType();
-    const event = {
+    const event: WatchEvent = {
       type: 'reload' as const,
       diffMode: this.config.diffMode,
       changeType,
@@ -265,9 +274,7 @@ export class FileWatcherService {
       message: `Changes detected in ${this.config.diffMode} mode`,
     };
 
-    this.clients.forEach((client) => {
-      this.sendToClient(client, event);
-    });
+    this.broadcast(event);
   }
 
   private sendToClient(client: Response, event: unknown): void {

--- a/src/server/server.test.ts
+++ b/src/server/server.test.ts
@@ -663,6 +663,273 @@ describe('Server Integration Tests', () => {
       expect(output).toContain('Total comments: 2');
     });
 
+    it('POST /api/comment-imports accepts valid comment imports', async () => {
+      const imports = [
+        {
+          type: 'thread',
+          filePath: 'src/example.ts',
+          position: { side: 'new', line: 10 },
+          body: 'Review comment',
+        },
+      ];
+
+      const response = await fetch(`http://localhost:${port}/api/comment-imports`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(imports),
+      });
+
+      expect(response.ok).toBe(true);
+      const data = (await response.json()) as any;
+      expect(data.success).toBe(true);
+      expect(data.importId).toEqual(expect.any(String));
+      expect(data.count).toBe(1);
+    });
+
+    it('POST /api/comment-imports accepts a single object', async () => {
+      const singleImport = {
+        type: 'thread',
+        filePath: 'src/example.ts',
+        position: { side: 'new', line: 5 },
+        body: 'Single object import',
+      };
+
+      const response = await fetch(`http://localhost:${port}/api/comment-imports`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(singleImport),
+      });
+
+      expect(response.ok).toBe(true);
+      const data = (await response.json()) as any;
+      expect(data.success).toBe(true);
+      expect(data.count).toBe(1);
+    });
+
+    it('POST /api/comment-imports rejects invalid data', async () => {
+      const response = await fetch(`http://localhost:${port}/api/comment-imports`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ invalid: true }),
+      });
+
+      expect(response.status).toBe(400);
+      const data = (await response.json()) as any;
+      expect(data).toHaveProperty('error');
+    });
+
+    it('GET /api/comments-json returns empty threads by default', async () => {
+      const response = await fetch(`http://localhost:${port}/api/comments-json`);
+
+      expect(response.ok).toBe(true);
+      const data = (await response.json()) as any;
+      expect(data).toHaveProperty('threads');
+      expect(data.threads).toEqual([]);
+    });
+
+    it('GET /api/comments-json returns threads after posting comments', async () => {
+      const comments = [{ file: 'test.js', line: 10, body: 'JSON test comment' }];
+
+      await fetch(`http://localhost:${port}/api/comments`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ comments }),
+      });
+
+      const response = await fetch(`http://localhost:${port}/api/comments-json`);
+
+      expect(response.ok).toBe(true);
+      const data = (await response.json()) as any;
+      expect(data.threads).toHaveLength(1);
+      expect(data.threads[0].messages[0].body).toBe('JSON test comment');
+    });
+
+    it('POST /api/comment-imports merges into server-side threads for comments-output', async () => {
+      const imports = [
+        {
+          type: 'thread',
+          filePath: 'src/example.ts',
+          position: { side: 'new', line: 42 },
+          body: 'Merged server-side comment',
+        },
+      ];
+
+      await fetch(`http://localhost:${port}/api/comment-imports`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(imports),
+      });
+
+      const outputResponse = await fetch(`http://localhost:${port}/api/comments-output`);
+      const output = await outputResponse.text();
+
+      expect(output).toContain('src/example.ts:L42');
+      expect(output).toContain('Merged server-side comment');
+    });
+
+    it('POST /api/comment-imports merges reply into existing thread', async () => {
+      // First add a thread
+      await fetch(`http://localhost:${port}/api/comment-imports`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify([
+          {
+            type: 'thread',
+            filePath: 'src/reply-test.ts',
+            position: { side: 'new', line: 5 },
+            body: 'Original comment',
+            author: 'User',
+          },
+        ]),
+      });
+
+      // Then add a reply
+      await fetch(`http://localhost:${port}/api/comment-imports`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify([
+          {
+            type: 'reply',
+            filePath: 'src/reply-test.ts',
+            position: { side: 'new', line: 5 },
+            body: 'Reply to comment',
+            author: 'AI',
+          },
+        ]),
+      });
+
+      const jsonResponse = await fetch(`http://localhost:${port}/api/comments-json`);
+      const data = (await jsonResponse.json()) as any;
+
+      const thread = data.threads.find((t: any) => t.filePath === 'src/reply-test.ts');
+      expect(thread).toBeDefined();
+      expect(thread.messages).toHaveLength(2);
+      expect(thread.messages[0].body).toBe('Original comment');
+      expect(thread.messages[1].body).toBe('Reply to comment');
+    });
+
+    it('POST /api/comment-imports deduplicates identical imports', async () => {
+      const imports = [
+        {
+          type: 'thread',
+          filePath: 'src/dedup.ts',
+          position: { side: 'new', line: 1 },
+          body: 'Unique comment',
+        },
+      ];
+
+      // Send the same import twice
+      await fetch(`http://localhost:${port}/api/comment-imports`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(imports),
+      });
+      await fetch(`http://localhost:${port}/api/comment-imports`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(imports),
+      });
+
+      const jsonResponse = await fetch(`http://localhost:${port}/api/comments-json`);
+      const data = (await jsonResponse.json()) as any;
+
+      const threads = data.threads.filter((t: any) => t.filePath === 'src/dedup.ts');
+      expect(threads).toHaveLength(1);
+    });
+
+    it('isolates comment sessions between different diff selections', async () => {
+      const importServer = await startServer({
+        selection: { targetCommitish: 'HEAD', baseCommitish: 'HEAD^' },
+        preferredPort: 9039,
+        commentImports: [
+          {
+            type: 'thread',
+            filePath: 'src/cli/comment.test.ts',
+            position: { side: 'new', line: 10 },
+            body: 'Startup comment',
+          },
+        ],
+      });
+      servers.push(importServer.server);
+
+      const parser = parserInstances.at(-1);
+      parser?.parseDiff.mockImplementation(async (selection: any) => ({
+        targetCommit: 'abc123',
+        baseCommit: 'def456',
+        baseCommitish: selection.baseCommitish === 'HEAD^' ? 'def4567' : selection.baseCommitish,
+        targetCommitish:
+          selection.targetCommitish === 'HEAD' ? 'abc1234' : selection.targetCommitish,
+        requestedBaseCommitish: selection.baseCommitish,
+        requestedTargetCommitish: selection.targetCommitish,
+        requestedBaseMode: selection.baseMode,
+        targetMessage: 'Test commit',
+        baseMessage: 'Previous commit',
+        files: [
+          {
+            path: 'src/cli/comment.test.ts',
+            additions: 10,
+            deletions: 5,
+            chunks: [],
+          },
+        ],
+        stats: { additions: 10, deletions: 5 },
+        isEmpty: false,
+      }));
+
+      await fetch(`http://localhost:${importServer.port}/api/comment-imports`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify([
+          {
+            type: 'thread',
+            filePath: 'src/cli/comment.test.ts',
+            position: { side: 'new', line: 20 },
+            body: 'API comment',
+          },
+        ]),
+      });
+
+      let response = await fetch(`http://localhost:${importServer.port}/api/comments-output`);
+      let output = await response.text();
+      expect(output).toContain('Startup comment');
+      expect(output).toContain('API comment');
+
+      await fetch(
+        `http://localhost:${importServer.port}/api/diff?base=feat%2F292-comment-read-write&target=codex%2Fcomment-session-state`,
+      );
+
+      response = await fetch(`http://localhost:${importServer.port}/api/comments-output`);
+      output = await response.text();
+      expect(output).toBe('');
+
+      await fetch(`http://localhost:${importServer.port}/api/comment-imports`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify([
+          {
+            type: 'thread',
+            filePath: 'src/cli/comment.test.ts',
+            position: { side: 'new', line: 30 },
+            body: 'Other diff comment',
+          },
+        ]),
+      });
+
+      response = await fetch(`http://localhost:${importServer.port}/api/comments-output`);
+      output = await response.text();
+      expect(output).toContain('Other diff comment');
+      expect(output).not.toContain('Startup comment');
+      expect(output).not.toContain('API comment');
+
+      await fetch(`http://localhost:${importServer.port}/api/diff?base=HEAD%5E&target=HEAD`);
+
+      response = await fetch(`http://localhost:${importServer.port}/api/comments-output`);
+      output = await response.text();
+      expect(output).toContain('Startup comment');
+      expect(output).toContain('API comment');
+      expect(output).not.toContain('Other diff comment');
+    });
+
     it.skip('GET /api/heartbeat returns SSE headers', async () => {
       // Skipped due to connection reset issues in test environment
       // SSE endpoint functionality is verified through manual testing

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -11,7 +11,11 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 import { type DiffMode } from '../types/watch.js';
 import { formatCommentsOutput } from '../utils/commentFormatting.js';
-import { serializeCommentImports } from '../utils/commentImports.js';
+import {
+  mergeCommentImports,
+  normalizeCommentImports,
+  serializeCommentImports,
+} from '../utils/commentImports.js';
 import { normalizeDiffViewMode } from '../utils/diffMode.js';
 import { resolveEditorOption } from '../utils/editorOptions.js';
 import { getFileExtension } from '../utils/fileUtils.js';
@@ -89,6 +93,29 @@ function setCachedDiffResponse(cache: Map<string, DiffResponse>, key: string, va
   }
 }
 
+interface CommentSessionState {
+  threads: DiffCommentThread[];
+  version: number;
+}
+
+function createResolvedCommentSelection(
+  responseDiffData: DiffResponse,
+  fallbackSelection: DiffSelection,
+  stdinDiff: boolean,
+): DiffSelection {
+  const baseCommitish =
+    responseDiffData.baseCommitish ?? (stdinDiff ? 'stdin' : fallbackSelection.baseCommitish);
+  const targetCommitish =
+    responseDiffData.targetCommitish ?? (stdinDiff ? 'stdin' : fallbackSelection.targetCommitish);
+  const baseMode = responseDiffData.requestedBaseMode ?? fallbackSelection.baseMode;
+
+  return createDiffSelection(baseCommitish, targetCommitish, baseMode);
+}
+
+function createCommentSessionKey(selection: DiffSelection): string {
+  return getDiffSelectionKey(selection);
+}
+
 export async function startServer(
   options: ServerOptions,
 ): Promise<{ port: number; url: string; isEmpty?: boolean; server?: Server }> {
@@ -163,6 +190,11 @@ export async function startServer(
 
   // Track current revisions for cache invalidation
   let currentSelection = initialSelection;
+  let currentCommentSelection = createResolvedCommentSelection(
+    initialDiffData,
+    initialSelection,
+    Boolean(options.stdinDiff),
+  );
 
   function parseRepositoryRelativePath(
     filepath: unknown,
@@ -185,6 +217,50 @@ export async function startServer(
     }
 
     return { ok: true, path: normalizedFilepath };
+  }
+
+  const commentSessions = new Map<string, CommentSessionState>();
+  const initialCommentThreads = mergeCommentImports([], initialCommentImports).threads;
+  if (initialCommentThreads.length > 0) {
+    commentSessions.set(createCommentSessionKey(currentCommentSelection), {
+      threads: initialCommentThreads,
+      version: 1,
+    });
+  }
+
+  function getCommentSelectionFromQuery(query: Record<string, unknown>): DiffSelection {
+    const hasBase = typeof query.base === 'string';
+    const hasTarget = typeof query.target === 'string';
+    const hasBaseMode = typeof query.baseMode === 'string';
+
+    if (!hasBase && !hasTarget && !hasBaseMode) {
+      return currentCommentSelection;
+    }
+
+    return createDiffSelection(
+      hasBase ? (query.base as string) : currentCommentSelection.baseCommitish,
+      hasTarget ? (query.target as string) : currentCommentSelection.targetCommitish,
+      hasBaseMode
+        ? parseBaseMode(query.baseMode)
+        : hasBase || hasTarget
+          ? undefined
+          : currentCommentSelection.baseMode,
+    );
+  }
+
+  function getOrCreateCommentSession(selection: DiffSelection): CommentSessionState {
+    const key = createCommentSessionKey(selection);
+    const existing = commentSessions.get(key);
+    if (existing) {
+      return existing;
+    }
+
+    const nextSession: CommentSessionState = {
+      threads: [],
+      version: 0,
+    };
+    commentSessions.set(key, nextSession);
+    return nextSession;
   }
 
   app.get('/api/diff', async (req, res) => {
@@ -222,6 +298,12 @@ export async function startServer(
         generatedStatusCache.clear();
       }
     }
+
+    currentCommentSelection = createResolvedCommentSelection(
+      responseDiffData,
+      requestedSelection,
+      Boolean(options.stdinDiff),
+    );
 
     const baseCommitish =
       responseDiffData.baseCommitish ?? (options.stdinDiff ? 'stdin' : undefined);
@@ -424,34 +506,68 @@ export async function startServer(
     }
   });
 
-  let finalThreads: CommentThread[] = [];
+  function normalizeLineValue(line: unknown): DiffCommentThread['position']['line'] {
+    if (Array.isArray(line) && line.length === 2) {
+      const start = line[0] as unknown;
+      const end = line[1] as unknown;
+      if (
+        typeof start === 'number' &&
+        typeof end === 'number' &&
+        Number.isInteger(start) &&
+        Number.isInteger(end) &&
+        start > 0 &&
+        end > 0 &&
+        start <= end
+      ) {
+        return { start, end };
+      }
+    }
 
-  function normalizeComment(comment: Comment): CommentThread {
+    if (typeof line === 'number' && Number.isInteger(line) && line > 0) {
+      return line;
+    }
+
+    return 1;
+  }
+
+  function normalizeComment(comment: Comment): DiffCommentThread {
+    const now = new Date().toISOString();
+    const timestamp = typeof comment.timestamp === 'string' ? comment.timestamp : now;
+    const threadId =
+      typeof comment.id === 'string' && comment.id.length > 0
+        ? comment.id
+        : createHash('sha256').update(JSON.stringify(comment)).digest('hex').slice(0, 12);
+    const filePath =
+      typeof comment.file === 'string' && comment.file.length > 0 ? comment.file : '<unknown file>';
+
     return {
-      id: comment.id,
-      file: comment.file,
-      line: comment.line,
-      side: comment.side,
-      createdAt: comment.timestamp,
-      updatedAt: comment.timestamp,
-      codeContent: comment.codeContent,
+      id: threadId,
+      filePath,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      position: {
+        side: comment.side ?? 'new',
+        line: normalizeLineValue(comment.line),
+      },
+      codeSnapshot:
+        typeof comment.codeContent === 'string'
+          ? {
+              content: comment.codeContent,
+            }
+          : undefined,
       messages: [
         {
-          id: comment.id,
+          id: threadId,
           body: comment.body,
           author: comment.author,
-          createdAt: comment.timestamp,
-          updatedAt: comment.timestamp,
+          createdAt: timestamp,
+          updatedAt: timestamp,
         },
       ],
     };
   }
 
-  function normalizeThreadPayload(thread: CommentThread | DiffCommentThread): CommentThread {
-    if ('file' in thread && 'line' in thread) {
-      return thread;
-    }
-
+  function toCommentThread(thread: DiffCommentThread): CommentThread {
     return {
       id: thread.id,
       file: thread.filePath,
@@ -467,7 +583,60 @@ export async function startServer(
     };
   }
 
-  function parseCommentsPayload(body: unknown): CommentThread[] {
+  function normalizeThreadPayload(thread: CommentThread | DiffCommentThread): DiffCommentThread {
+    if ('filePath' in thread && 'position' in thread) {
+      return thread;
+    }
+
+    const threadId =
+      typeof thread.id === 'string' && thread.id.length > 0
+        ? thread.id
+        : createHash('sha256').update(JSON.stringify(thread)).digest('hex').slice(0, 12);
+    const now = new Date().toISOString();
+    const messages =
+      Array.isArray(thread.messages) && thread.messages.length > 0
+        ? thread.messages.map((message, index) => ({
+            id:
+              typeof message.id === 'string' && message.id.length > 0
+                ? message.id
+                : `${threadId}:${index}`,
+            body: message.body,
+            author: message.author,
+            createdAt: message.createdAt || thread.createdAt || now,
+            updatedAt: message.updatedAt || message.createdAt || thread.updatedAt || now,
+          }))
+        : [
+            {
+              id: threadId,
+              body: '',
+              createdAt: thread.createdAt || now,
+              updatedAt: thread.updatedAt || thread.createdAt || now,
+            },
+          ];
+    const firstMessage = messages[0];
+    const lastMessage = messages[messages.length - 1];
+
+    return {
+      id: threadId,
+      filePath:
+        typeof thread.file === 'string' && thread.file.length > 0 ? thread.file : '<unknown file>',
+      createdAt: thread.createdAt || firstMessage?.createdAt || now,
+      updatedAt: thread.updatedAt || lastMessage?.updatedAt || thread.createdAt || now,
+      position: {
+        side: thread.side ?? 'new',
+        line: normalizeLineValue(thread.line),
+      },
+      codeSnapshot:
+        typeof thread.codeContent === 'string'
+          ? {
+              content: thread.codeContent,
+            }
+          : undefined,
+      messages,
+    };
+  }
+
+  function parseCommentsPayload(body: unknown): DiffCommentThread[] {
     const payload =
       typeof body === 'string'
         ? (JSON.parse(body) as {
@@ -490,9 +659,41 @@ export async function startServer(
     return [];
   }
 
+  function parseCommentImportsPayload(body: unknown): CommentImport[] {
+    if (typeof body === 'string') {
+      return normalizeCommentImports(JSON.parse(body));
+    }
+
+    return normalizeCommentImports(body);
+  }
+
+  function updateCommentSession(
+    selection: DiffSelection,
+    nextThreads: DiffCommentThread[],
+  ): boolean {
+    const session = getOrCreateCommentSession(selection);
+    const previous = JSON.stringify(session.threads);
+    const next = JSON.stringify(nextThreads);
+    session.threads = nextThreads;
+
+    if (previous === next) {
+      return false;
+    }
+
+    session.version += 1;
+    fileWatcher.broadcast({
+      type: 'commentsChanged',
+      version: session.version,
+      timestamp: new Date().toISOString(),
+    });
+    return true;
+  }
+
   app.post('/api/comments', (req, res) => {
     try {
-      finalThreads = parseCommentsPayload(req.body);
+      const selection = getCommentSelectionFromQuery(req.query as Record<string, unknown>);
+      const nextThreads = parseCommentsPayload(req.body);
+      updateCommentSession(selection, nextThreads);
       res.json({ success: true });
     } catch (error) {
       console.error('Error parsing comments:', error);
@@ -500,11 +701,46 @@ export async function startServer(
     }
   });
 
-  app.get('/api/comments-output', (_req, res) => {
+  app.post('/api/comment-imports', (req, res) => {
+    try {
+      const selection = getCommentSelectionFromQuery(req.query as Record<string, unknown>);
+      const session = getOrCreateCommentSession(selection);
+      const commentImports = parseCommentImportsPayload(req.body);
+      const importId = createHash('sha256')
+        .update(serializeCommentImports(commentImports))
+        .digest('hex');
+      const merged = mergeCommentImports(session.threads, commentImports);
+      const changed = updateCommentSession(selection, merged.threads);
+
+      res.json({
+        success: true,
+        changed,
+        count: commentImports.length,
+        importId,
+        warnings: merged.warnings,
+      });
+    } catch (error) {
+      console.error('Error parsing comment imports:', error);
+      res.status(400).json({ error: 'Invalid comment import data' });
+    }
+  });
+
+  app.get('/api/comments-json', (req, res) => {
+    const selection = getCommentSelectionFromQuery(req.query as Record<string, unknown>);
+    const session = getOrCreateCommentSession(selection);
+    res.json({
+      version: session.version,
+      threads: session.threads,
+    });
+  });
+
+  app.get('/api/comments-output', (req, res) => {
+    const selection = getCommentSelectionFromQuery(req.query as Record<string, unknown>);
+    const session = getOrCreateCommentSession(selection);
     res.type('text/plain');
 
-    if (finalThreads.length > 0) {
-      const output = formatCommentsOutput(finalThreads);
+    if (session.threads.length > 0) {
+      const output = formatCommentsOutput(session.threads.map(toCommentThread));
       res.send(output);
     } else {
       res.send('');
@@ -598,8 +834,9 @@ export async function startServer(
 
   // Function to output comments when server shuts down
   function outputFinalComments() {
-    if (finalThreads.length > 0) {
-      console.log(formatCommentsOutput(finalThreads));
+    const session = getOrCreateCommentSession(currentCommentSelection);
+    if (session.threads.length > 0) {
+      console.log(formatCommentsOutput(session.threads.map(toCommentThread)));
     }
   }
 

--- a/src/types/watch.ts
+++ b/src/types/watch.ts
@@ -6,12 +6,50 @@ export enum DiffMode {
   SPECIFIC = 'specific', // commit vs commit (no watching)
 }
 
+export type WatchChangeType = 'file' | 'commit' | 'staging';
+
+export interface ConnectedWatchEvent {
+  type: 'connected';
+  diffMode: DiffMode;
+  changeType: WatchChangeType;
+  timestamp: string;
+  message?: string;
+}
+
+export interface ReloadWatchEvent {
+  type: 'reload';
+  diffMode: DiffMode;
+  changeType: WatchChangeType;
+  timestamp: string;
+  message?: string;
+}
+
+export interface ErrorWatchEvent {
+  type: 'error';
+  diffMode: DiffMode;
+  changeType: WatchChangeType;
+  timestamp: string;
+  message?: string;
+}
+
+export interface CommentsChangedWatchEvent {
+  type: 'commentsChanged';
+  version: number;
+  timestamp: string;
+}
+
+export type WatchEvent =
+  | ConnectedWatchEvent
+  | ReloadWatchEvent
+  | ErrorWatchEvent
+  | CommentsChangedWatchEvent;
+
 export interface ClientWatchState {
   isWatchEnabled: boolean;
   diffMode: DiffMode;
   shouldReload: boolean;
   isReloading: boolean;
   lastChangeTime: Date | null;
-  lastChangeType: 'file' | 'commit' | 'staging' | null;
+  lastChangeType: WatchChangeType | null;
   connectionStatus: 'connected' | 'disconnected' | 'reconnecting';
 }

--- a/src/utils/commentImports.ts
+++ b/src/utils/commentImports.ts
@@ -149,7 +149,7 @@ function normalizeCommentImportEntry(value: unknown): CommentImport {
   return normalized as CommentImport;
 }
 
-function normalizeCommentImports(input: unknown): CommentImport[] {
+export function normalizeCommentImports(input: unknown): CommentImport[] {
   if (Array.isArray(input)) {
     return input.map((entry) => normalizeCommentImportEntry(entry));
   }
@@ -281,6 +281,168 @@ function createImportedReply(commentImport: ReplyCommentImport, now: string): Di
     createdAt,
     updatedAt,
   };
+}
+
+function cloneLineRange(line: DiffLineRange): DiffLineRange {
+  if (typeof line === 'number') {
+    return line;
+  }
+
+  return {
+    start: line.start,
+    end: line.end,
+  };
+}
+
+function clonePosition(position: DiffCommentPosition): DiffCommentPosition {
+  return {
+    side: position.side,
+    line: cloneLineRange(position.line),
+  };
+}
+
+function cloneCodeSnapshot(
+  snapshot: DiffCommentCodeSnapshot | undefined,
+): DiffCommentCodeSnapshot | undefined {
+  if (!snapshot) {
+    return undefined;
+  }
+
+  return {
+    content: snapshot.content,
+    language: snapshot.language,
+  };
+}
+
+function cloneMessage(message: DiffCommentMessage): DiffCommentMessage {
+  return {
+    id: message.id,
+    body: message.body,
+    author: message.author,
+    createdAt: message.createdAt,
+    updatedAt: message.updatedAt,
+  };
+}
+
+function cloneThread(thread: DiffCommentThread): DiffCommentThread {
+  return {
+    id: thread.id,
+    filePath: thread.filePath,
+    createdAt: thread.createdAt,
+    updatedAt: thread.updatedAt,
+    position: clonePosition(thread.position),
+    codeSnapshot: cloneCodeSnapshot(thread.codeSnapshot),
+    messages: thread.messages.map(cloneMessage),
+  };
+}
+
+function messagesMatch(left: DiffCommentMessage, right: DiffCommentMessage): boolean {
+  if (left.id === right.id) {
+    return true;
+  }
+
+  if (normalizeAuthor(left.author) !== normalizeAuthor(right.author)) {
+    return false;
+  }
+
+  return left.body === right.body && left.createdAt === right.createdAt;
+}
+
+function threadsMatch(left: DiffCommentThread, right: DiffCommentThread): boolean {
+  if (left.id === right.id) {
+    return true;
+  }
+
+  if (left.filePath !== right.filePath || !positionsMatch(left.position, right.position)) {
+    return false;
+  }
+
+  const leftRoot = left.messages[0];
+  const rightRoot = right.messages[0];
+  if (!leftRoot || !rightRoot) {
+    return false;
+  }
+
+  return messagesMatch(leftRoot, rightRoot);
+}
+
+function sortReplies(left: DiffCommentMessage, right: DiffCommentMessage): number {
+  const createdAtOrder = left.createdAt.localeCompare(right.createdAt);
+  if (createdAtOrder !== 0) {
+    return createdAtOrder;
+  }
+
+  return left.id.localeCompare(right.id);
+}
+
+function pickNewerMessage(
+  existingMessage: DiffCommentMessage,
+  incomingMessage: DiffCommentMessage,
+): DiffCommentMessage {
+  if (incomingMessage.updatedAt.localeCompare(existingMessage.updatedAt) >= 0) {
+    return cloneMessage(incomingMessage);
+  }
+
+  return cloneMessage(existingMessage);
+}
+
+function mergeThread(
+  existingThread: DiffCommentThread,
+  incomingThread: DiffCommentThread,
+): DiffCommentThread {
+  const mergedMessages = existingThread.messages.map(cloneMessage);
+
+  for (const incomingMessage of incomingThread.messages) {
+    const matchIndex = mergedMessages.findIndex((message) =>
+      messagesMatch(message, incomingMessage),
+    );
+    if (matchIndex >= 0) {
+      mergedMessages[matchIndex] = pickNewerMessage(mergedMessages[matchIndex], incomingMessage);
+      continue;
+    }
+
+    mergedMessages.push(cloneMessage(incomingMessage));
+  }
+
+  const [rootMessage, ...replyMessages] = mergedMessages;
+  const orderedMessages = rootMessage
+    ? [rootMessage, ...replyMessages.sort(sortReplies)]
+    : replyMessages.sort(sortReplies);
+  const updatedAt = orderedMessages.reduce(
+    (latest, message) => maxIsoTimestamp(latest, message.updatedAt),
+    maxIsoTimestamp(existingThread.updatedAt, incomingThread.updatedAt),
+  );
+
+  return {
+    ...cloneThread(existingThread),
+    createdAt:
+      existingThread.createdAt.localeCompare(incomingThread.createdAt) <= 0
+        ? existingThread.createdAt
+        : incomingThread.createdAt,
+    updatedAt,
+    position: clonePosition(existingThread.position),
+    codeSnapshot: cloneCodeSnapshot(incomingThread.codeSnapshot ?? existingThread.codeSnapshot),
+    messages: orderedMessages,
+  };
+}
+
+export function mergeCommentThreads(
+  existingThreads: DiffCommentThread[],
+  incomingThreads: DiffCommentThread[],
+): MergeCommentImportsResult {
+  const threads = existingThreads.map(cloneThread);
+
+  for (const incomingThread of incomingThreads) {
+    const existingIndex = threads.findIndex((thread) => threadsMatch(thread, incomingThread));
+    if (existingIndex < 0) {
+      threads.push(cloneThread(incomingThread));
+      continue;
+    }
+
+    threads[existingIndex] = mergeThread(threads[existingIndex], incomingThread);
+  }
+
+  return { threads, warnings: [] };
 }
 
 function serializeLineRange(line: DiffLineRange): number | { start: number; end: number } {


### PR DESCRIPTION
## Summary
- Restore the comment session sync flow across the server, client, and file watcher
- Bring back CLI comment import and retrieval commands along with the supporting parsing utilities
- Re-enable comment session handling for revision-aware diffs and update the README option tables in all four locales

## Testing
- `pnpm run check` passed
- `pnpm test` passed
- `pnpm build` passed