### PR TITLE
Show total diff line counts in the file sidebar

### DIFF
--- a/src/client/components/FileList.test.tsx
+++ b/src/client/components/FileList.test.tsx
@@ -6,11 +6,14 @@ import type { DiffFile } from '../../types/diff';
 
 import { FileList } from './FileList';
 
-const createFile = (path: string): DiffFile => ({
+const createFile = (
+  path: string,
+  totals: { additions?: number; deletions?: number } = {},
+): DiffFile => ({
   path,
   status: 'modified',
-  additions: 1,
-  deletions: 1,
+  additions: totals.additions ?? 1,
+  deletions: totals.deletions ?? 1,
   chunks: [],
 });
 
@@ -31,6 +34,27 @@ function getLabel(title: string): HTMLElement {
 }
 
 describe('FileList', () => {
+  it('renders total additions and deletions beside the file count', () => {
+    render(
+      <FileList
+        files={[
+          createFile('README.md', { additions: 3, deletions: 1 }),
+          createFile('src/client/App.tsx', { additions: 2, deletions: 4 }),
+        ]}
+        onScrollToFile={vi.fn()}
+        comments={[]}
+        reviewedFiles={new Set()}
+        onToggleReviewed={vi.fn()}
+        selectedFileIndex={null}
+      />,
+    );
+
+    expect(screen.getByText('Files changed (2)')).toBeInTheDocument();
+    expect(screen.getByLabelText('5 additions and 5 deletions')).toBeInTheDocument();
+    expect(screen.getByText('+5')).toBeInTheDocument();
+    expect(screen.getByText('-5')).toBeInTheDocument();
+  });
+
   it('includes the row gap in nested tree indentation', () => {
     render(
       <FileList

--- a/src/client/components/FileList.tsx
+++ b/src/client/components/FileList.tsx
@@ -193,6 +193,17 @@ export const FileList = memo(function FileList({
     });
     return indices;
   }, [files]);
+  const diffTotals = useMemo(
+    () =>
+      files.reduce(
+        (totals, file) => ({
+          additions: totals.additions + file.additions,
+          deletions: totals.deletions + file.deletions,
+        }),
+        { additions: 0, deletions: 0 },
+      ),
+    [files],
+  );
   const reviewedDirectoryPaths = useMemo(
     () => getReviewedDirectoryPaths(fileTree, reviewedFiles),
     [fileTree, reviewedFiles],
@@ -424,9 +435,19 @@ export const FileList = memo(function FileList({
     <div className="h-full flex flex-col">
       <div className="px-4 py-3 border-b border-github-border bg-github-bg-tertiary">
         <div className="flex items-center justify-between mb-3">
-          <h3 className="text-sm font-semibold text-github-text-primary m-0">
-            Files changed ({files.length})
-          </h3>
+          <div className="flex min-w-0 items-baseline gap-2">
+            <h3 className="text-sm font-semibold text-github-text-primary m-0">
+              Files changed ({files.length})
+            </h3>
+            <span
+              className="text-xs font-medium whitespace-nowrap"
+              title="Total additions and deletions"
+              aria-label={`${diffTotals.additions} additions and ${diffTotals.deletions} deletions`}
+            >
+              <span className="text-github-accent">+{diffTotals.additions}</span>{' '}
+              <span className="text-github-danger">-{diffTotals.deletions}</span>
+            </span>
+          </div>
           <button
             onClick={toggleAllDirectories}
             className="p-1 hover:bg-github-bg-primary rounded transition-colors"

--- a/src/client/components/FileList.tsx
+++ b/src/client/components/FileList.tsx
@@ -435,30 +435,30 @@ export const FileList = memo(function FileList({
     <div className="h-full flex flex-col">
       <div className="px-4 py-3 border-b border-github-border bg-github-bg-tertiary">
         <div className="flex items-center justify-between mb-3">
-          <div className="flex min-w-0 items-baseline gap-2">
-            <h3 className="text-sm font-semibold text-github-text-primary m-0">
-              Files changed ({files.length})
-            </h3>
+          <h3 className="text-sm font-semibold text-github-text-primary m-0">
+            Files changed ({files.length})
+          </h3>
+          <div className="ml-auto flex items-center gap-2">
             <span
-              className="text-xs font-medium whitespace-nowrap"
+              className="text-right text-xs font-medium whitespace-nowrap"
               title="Total additions and deletions"
               aria-label={`${diffTotals.additions} additions and ${diffTotals.deletions} deletions`}
             >
               <span className="text-github-accent">+{diffTotals.additions}</span>{' '}
               <span className="text-github-danger">-{diffTotals.deletions}</span>
             </span>
+            <button
+              onClick={toggleAllDirectories}
+              className="p-1 hover:bg-github-bg-primary rounded transition-colors"
+              title={isAllExpanded ? 'Collapse all' : 'Expand all'}
+            >
+              {isAllExpanded ? (
+                <ChevronsDownUp size={16} className="text-github-text-secondary" />
+              ) : (
+                <ChevronsUpDown size={16} className="text-github-text-secondary" />
+              )}
+            </button>
           </div>
-          <button
-            onClick={toggleAllDirectories}
-            className="p-1 hover:bg-github-bg-primary rounded transition-colors"
-            title={isAllExpanded ? 'Collapse all' : 'Expand all'}
-          >
-            {isAllExpanded ? (
-              <ChevronsDownUp size={16} className="text-github-text-secondary" />
-            ) : (
-              <ChevronsUpDown size={16} className="text-github-text-secondary" />
-            )}
-          </button>
         </div>
         <div className="relative">
           <Search

--- a/src/client/components/FileList.tsx
+++ b/src/client/components/FileList.tsx
@@ -440,11 +440,11 @@ export const FileList = memo(function FileList({
           </h3>
           <div className="ml-auto flex items-center gap-2">
             <span
-              className="text-right text-xs font-medium whitespace-nowrap"
+              className="inline-flex gap-1 text-right text-xs font-medium whitespace-nowrap"
               title="Total additions and deletions"
               aria-label={`${diffTotals.additions} additions and ${diffTotals.deletions} deletions`}
             >
-              <span className="text-github-accent">+{diffTotals.additions}</span>{' '}
+              <span className="text-github-accent">+{diffTotals.additions}</span>
               <span className="text-github-danger">-{diffTotals.deletions}</span>
             </span>
             <button


### PR DESCRIPTION
## Summary
- Add aggregated `+` and `-` line totals next to the sidebar file count.
- Right-align the totals alongside the existing expand/collapse control.
- Cover the new header display with a component test.

## Testing
- Added a unit test for the sidebar header totals.
- Ran formatting, lint/type checks, and the full test suite locally.