### PR TITLE
Move changed-since-viewed indicator to the file header

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1219,7 +1219,6 @@ function App() {
                   onFileSelected={isMobile ? handleMobileFileSelected : undefined}
                   comments={normalizedThreads}
                   reviewedFiles={viewedFiles}
-                  changedSinceViewedFiles={changedSinceViewedFiles}
                   onToggleReviewed={toggleFileReviewed}
                   selectedFileIndex={cursor?.fileIndex ?? null}
                 />
@@ -1286,6 +1285,7 @@ function App() {
                       showAuthorBadges={showAuthorBadges}
                       diffMode={diffMode}
                       reviewedFiles={viewedFiles}
+                      isChangedSinceViewed={changedSinceViewedFiles.has(file.path)}
                       onToggleReviewed={toggleFileReviewed}
                       collapsedFiles={collapsedFiles}
                       onToggleCollapsed={toggleFileCollapsed}

--- a/src/client/components/DiffViewer.test.tsx
+++ b/src/client/components/DiffViewer.test.tsx
@@ -182,6 +182,26 @@ describe('DiffViewer', () => {
 
       expect(screen.getByText('+10')).toBeInTheDocument();
     });
+
+    it('shows the changed-since-viewed indicator in the file header', () => {
+      render(<DiffViewer {...defaultProps} isChangedSinceViewed />);
+
+      expect(screen.getByLabelText('Changed since you last viewed this file')).toBeInTheDocument();
+    });
+
+    it('hides the changed-since-viewed indicator when the file is reviewed', () => {
+      render(
+        <DiffViewer
+          {...defaultProps}
+          reviewedFiles={new Set([mockFile.path])}
+          isChangedSinceViewed
+        />,
+      );
+
+      expect(
+        screen.queryByLabelText('Changed since you last viewed this file'),
+      ).not.toBeInTheDocument();
+    });
   });
 
   describe('Collapse functionality', () => {

--- a/src/client/components/DiffViewer.test.tsx
+++ b/src/client/components/DiffViewer.test.tsx
@@ -186,7 +186,9 @@ describe('DiffViewer', () => {
     it('shows the changed-since-viewed indicator in the file header', () => {
       render(<DiffViewer {...defaultProps} isChangedSinceViewed />);
 
-      expect(screen.getByLabelText('Changed since you last viewed this file')).toBeInTheDocument();
+      const indicator = screen.getByLabelText('Changed since you last viewed this file');
+      expect(indicator).toBeInTheDocument();
+      expect(indicator).toHaveTextContent('Changed');
     });
 
     it('hides the changed-since-viewed indicator when the file is reviewed', () => {

--- a/src/client/components/DiffViewer.tsx
+++ b/src/client/components/DiffViewer.tsx
@@ -21,6 +21,7 @@ interface DiffViewerProps {
   showAuthorBadges?: boolean;
   diffMode: DiffViewMode;
   reviewedFiles: Set<string>;
+  isChangedSinceViewed?: boolean;
   onToggleReviewed: (path: string) => void;
   collapsedFiles: Set<string>;
   onToggleCollapsed: (path: string) => void;
@@ -171,6 +172,7 @@ export const DiffViewer = memo(function DiffViewer({
   showAuthorBadges = false,
   diffMode,
   reviewedFiles,
+  isChangedSinceViewed = false,
   onToggleReviewed,
   collapsedFiles,
   onToggleCollapsed,
@@ -344,6 +346,7 @@ export const DiffViewer = memo(function DiffViewer({
         file={file}
         isCollapsed={isCollapsed}
         isReviewed={reviewedFiles.has(file.path)}
+        isChangedSinceViewed={isChangedSinceViewed}
         onToggleCollapsed={onToggleCollapsed}
         onToggleAllCollapsed={onToggleAllCollapsed}
         onToggleReviewed={onToggleReviewed}

--- a/src/client/components/DiffViewerHeader.tsx
+++ b/src/client/components/DiffViewerHeader.tsx
@@ -104,11 +104,11 @@ export const DiffViewerHeader = ({
       <div className="flex items-center gap-3">
         {isChangedSinceViewed && !isReviewed && (
           <span
-            className="flex items-center"
+            className="inline-flex h-6 items-center rounded-full border border-github-warning px-2.5 text-xs font-medium text-github-warning"
             title="Changed since you last viewed this file"
             aria-label="Changed since you last viewed this file"
           >
-            <span className="block w-2 h-2 rounded-full bg-github-warning" />
+            Changed
           </span>
         )}
         <div className="flex items-center gap-2 text-xs">

--- a/src/client/components/DiffViewerHeader.tsx
+++ b/src/client/components/DiffViewerHeader.tsx
@@ -18,6 +18,7 @@ interface DiffViewerHeaderProps {
   file: DiffFile;
   isCollapsed: boolean;
   isReviewed: boolean;
+  isChangedSinceViewed?: boolean;
   onToggleCollapsed: (path: string) => void;
   onToggleAllCollapsed: (shouldCollapse: boolean) => void;
   onToggleReviewed: (path: string) => void;
@@ -40,6 +41,7 @@ export const DiffViewerHeader = ({
   file,
   isCollapsed,
   isReviewed,
+  isChangedSinceViewed = false,
   onToggleCollapsed,
   onToggleAllCollapsed,
   onToggleReviewed,
@@ -100,6 +102,15 @@ export const DiffViewerHeader = ({
       </div>
 
       <div className="flex items-center gap-3">
+        {isChangedSinceViewed && !isReviewed && (
+          <span
+            className="flex items-center"
+            title="Changed since you last viewed this file"
+            aria-label="Changed since you last viewed this file"
+          >
+            <span className="block w-2 h-2 rounded-full bg-github-warning" />
+          </span>
+        )}
         <div className="flex items-center gap-2 text-xs">
           <span className="font-medium px-1 py-0.5 rounded text-github-accent bg-green-100/10">
             +{file.additions}

--- a/src/client/components/FileList.tsx
+++ b/src/client/components/FileList.tsx
@@ -25,12 +25,6 @@ interface FileListProps {
   onFileSelected?: () => void;
   comments: CommentThread[];
   reviewedFiles: Set<string>;
-  /**
-   * File paths that were marked viewed in a prior comparison range but whose
-   * current diff differs from the prior view. Surfaces a "changed since you
-   * viewed" hint for incremental reviews.
-   */
-  changedSinceViewedFiles?: Set<string>;
   onToggleReviewed: (path: string) => void;
   selectedFileIndex: number | null;
 }
@@ -164,7 +158,6 @@ export const FileList = memo(function FileList({
   onFileSelected,
   comments,
   reviewedFiles,
-  changedSinceViewedFiles,
   onToggleReviewed,
   selectedFileIndex,
 }: FileListProps) {
@@ -379,8 +372,6 @@ export const FileList = memo(function FileList({
       const file = node.file;
       const commentCount = commentCountMap.get(file.path) ?? 0;
       const isReviewed = reviewedFiles.has(file.path);
-      const isChangedSinceViewed =
-        !isReviewed && (changedSinceViewedFiles?.has(file.path) ?? false);
       const fileIndex = fileIndexMap.get(file.path) ?? -1;
       const isSelected = selectedFileIndex !== null && selectedFileIndex === fileIndex;
 
@@ -416,15 +407,6 @@ export const FileList = memo(function FileList({
           >
             {node.name}
           </span>
-          {isChangedSinceViewed && (
-            <span
-              className="flex items-center"
-              title="Changed since you last viewed this file"
-              aria-label="Changed since you last viewed this file"
-            >
-              <span className="block w-2 h-2 rounded-full bg-github-warning" />
-            </span>
-          )}
           {commentCount > 0 && (
             <span className="text-github-warning text-sm font-medium ml-auto flex items-center gap-1">
               <MessageSquare size={14} />


### PR DESCRIPTION
## Summary
- Move the incremental review indicator from the file tree into the diff file header, next to the line-count badges.
- Render it as a yellow `Changed` chip instead of a dot, while preserving the existing tooltip and hiding it when the file is already viewed.
- Update `DiffViewer` props and tests to cover the new header placement and reviewed-state behavior.

<img width="1497" height="364" alt="image" src="https://github.com/user-attachments/assets/b908138d-3184-4f3e-9f4b-7509e90582bd" />


## Testing
- `pnpm vitest run src/client/components/DiffViewer.test.tsx`
- `pnpm run check`
- Local Chrome verification confirmed the `Changed` chip appears in the file header for a file whose diff changed after being viewed.

---

ref. https://github.com/yoshiko-pg/difit/pull/336