### PR TITLE
Add project badges to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,8 @@
 
 <p align="center">
   <a href="https://www.npmjs.com/package/difit"><img src="https://img.shields.io/npm/v/difit.svg" alt="npm version"></a>
-  <a href="https://www.npmjs.com/package/difit"><img src="https://img.shields.io/npm/dm/difit.svg" alt="npm downloads"></a>
   <a href="https://github.com/yoshiko-pg/difit/actions/workflows/ci.yml"><img src="https://github.com/yoshiko-pg/difit/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://github.com/yoshiko-pg/difit/blob/main/LICENSE"><img src="https://img.shields.io/npm/l/difit.svg" alt="license"></a>
-  <a href="https://github.com/yoshiko-pg/difit/stargazers"><img src="https://img.shields.io/github/stars/yoshiko-pg/difit?style=social" alt="GitHub stars"></a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 <p align="center">
   <a href="https://www.npmjs.com/package/difit"><img src="https://img.shields.io/npm/v/difit.svg" alt="npm version"></a>
   <a href="https://github.com/yoshiko-pg/difit/actions/workflows/pr.yml"><img src="https://github.com/yoshiko-pg/difit/actions/workflows/pr.yml/badge.svg" alt="CI"></a>
-  <a href="https://github.com/yoshiko-pg/difit/blob/main/LICENSE"><img src="https://img.shields.io/npm/l/difit.svg" alt="license"></a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <a href="https://www.npmjs.com/package/difit"><img src="https://img.shields.io/npm/v/difit.svg" alt="npm version"></a>
-  <a href="https://github.com/yoshiko-pg/difit/actions/workflows/ci.yml"><img src="https://github.com/yoshiko-pg/difit/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/yoshiko-pg/difit/actions/workflows/pr.yml"><img src="https://github.com/yoshiko-pg/difit/actions/workflows/pr.yml/badge.svg" alt="CI"></a>
   <a href="https://github.com/yoshiko-pg/difit/blob/main/LICENSE"><img src="https://img.shields.io/npm/l/difit.svg" alt="license"></a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@
 </h1>
 
 <p align="center">
+  <a href="https://www.npmjs.com/package/difit"><img src="https://img.shields.io/npm/v/difit.svg" alt="npm version"></a>
+  <a href="https://www.npmjs.com/package/difit"><img src="https://img.shields.io/npm/dm/difit.svg" alt="npm downloads"></a>
+  <a href="https://github.com/yoshiko-pg/difit/actions/workflows/ci.yml"><img src="https://github.com/yoshiko-pg/difit/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/yoshiko-pg/difit/blob/main/LICENSE"><img src="https://img.shields.io/npm/l/difit.svg" alt="license"></a>
+  <a href="https://github.com/yoshiko-pg/difit/stargazers"><img src="https://img.shields.io/github/stars/yoshiko-pg/difit?style=social" alt="GitHub stars"></a>
+</p>
+
+<p align="center">
   English | <a href="./README.ja.md">日本語</a> | <a href="./README.zh.md">简体中文</a> | <a href="./README.ko.md">한국어</a>
 </p>
 


### PR DESCRIPTION
## Summary
- Add centered badges for npm version, npm downloads, CI status, license, and GitHub stars to the top of the README
- Keep the badges visually grouped under the logo and above the language selector

## Testing
- Not run (not requested)