### PR TITLE
Preserve imported comments when starting with --clean

### DIFF
--- a/src/client/App.test.tsx
+++ b/src/client/App.test.tsx
@@ -394,6 +394,74 @@ describe('App Component - Clear Comments Functionality', () => {
         '/api/comments-json?base=HEAD%5E&target=HEAD',
       );
     });
+
+    it('preserves server-provided comments after clearing local comments on startup', async () => {
+      mockComments = [
+        createMockThread({
+          id: 'stale-local-thread',
+          filePath: 'test.ts',
+          line: 5,
+          body: 'Stale local comment',
+        }),
+      ];
+      const serverThreads = [
+        createMockThread({
+          id: 'imported-thread',
+          filePath: 'test.ts',
+          line: 10,
+          body: 'Imported comment',
+        }),
+      ];
+      const responseWithClearFlag: DiffResponse = {
+        ...mockDiffResponse,
+        clearComments: true,
+      };
+
+      vi.mocked(global.fetch).mockImplementation((input) => {
+        const url = String(input);
+
+        if (url.startsWith('/api/comments-json')) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ threads: serverThreads }),
+          } as Response);
+        }
+
+        if (url.startsWith('/api/comments')) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ success: true }),
+          } as Response);
+        }
+
+        if (url === '/api/revisions') {
+          return Promise.resolve({
+            ok: true,
+            json: async () => null,
+          } as Response);
+        }
+
+        return Promise.resolve({
+          ok: true,
+          json: async () => responseWithClearFlag,
+          blob: async () => ({ size: 1024 }),
+        } as Response);
+      });
+
+      renderApp();
+
+      await waitFor(() => {
+        expect(mockClearAllComments).toHaveBeenCalledWith({
+          resetAppliedCommentImportIds: true,
+        });
+      });
+
+      await waitFor(() => {
+        expect(mockReplaceThreads).toHaveBeenCalledWith(serverThreads);
+      });
+
+      expect(mockReplaceThreads).not.toHaveBeenCalledWith([...serverThreads, ...mockComments]);
+    });
   });
 });
 

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -722,10 +722,8 @@ function App() {
       return;
     }
 
-    if (pendingBootstrapAfterLocalResetRef.current) {
-      pendingBootstrapAfterLocalResetRef.current = false;
-      return;
-    }
+    const shouldReplaceFromServer = pendingBootstrapAfterLocalResetRef.current;
+    pendingBootstrapAfterLocalResetRef.current = false;
 
     bootstrappingCommentsKeyRef.current = commentsContextKey;
     let cancelled = false;
@@ -733,16 +731,21 @@ function App() {
     const bootstrapComments = async () => {
       try {
         const serverThreads = await fetchServerThreads();
-        const mergedThreads = mergeCommentThreads(serverThreads, threads).threads;
+        const nextThreads = shouldReplaceFromServer
+          ? serverThreads
+          : mergeCommentThreads(serverThreads, threads).threads;
         if (cancelled) {
           return;
         }
 
         skipNextCommentSyncRef.current = true;
-        replaceThreads(mergedThreads);
+        replaceThreads(nextThreads);
 
-        if (JSON.stringify(serverThreads) !== JSON.stringify(mergedThreads)) {
-          await syncThreadsToServer(mergedThreads);
+        if (
+          !shouldReplaceFromServer &&
+          JSON.stringify(serverThreads) !== JSON.stringify(nextThreads)
+        ) {
+          await syncThreadsToServer(nextThreads);
         }
       } catch (commentsError) {
         if (!cancelled) {


### PR DESCRIPTION
Resolved #353 

## Summary
- Fix the startup bootstrap path so `--clean` clears stale local comments without discarding server-provided `--comment` imports.
- Keep the server comment session intact during the post-clean hydration step instead of merging it with pre-clean local state.
- Add a regression test that covers the clean + imported comment combination.

## Testing
- `pnpm vitest run src/client/App.test.tsx`
- `pnpm run check`
- `pnpm run format`
- `pnpm test`
- `pnpm run build`
- Verified the behavior in Chrome against a local `difit` session