### PR TITLE
feat(client): rename "Changed" badge to "Updated"

### DIFF
--- a/src/client/components/DiffViewerHeader.test.tsx
+++ b/src/client/components/DiffViewerHeader.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom';
+
+import type { DiffFile } from '../../types/diff';
+
+import { DiffViewerHeader } from './DiffViewerHeader';
+
+const file: DiffFile = {
+  path: 'src/app.ts',
+  status: 'modified',
+  additions: 1,
+  deletions: 1,
+  chunks: [],
+};
+
+const baseProps = {
+  file,
+  isCollapsed: false,
+  isReviewed: false,
+  onToggleCollapsed: vi.fn(),
+  onToggleAllCollapsed: vi.fn(),
+  onToggleReviewed: vi.fn(),
+};
+
+describe('DiffViewerHeader', () => {
+  it('shows the "Updated" badge when the file changed since last viewed', () => {
+    render(<DiffViewerHeader {...baseProps} isChangedSinceViewed />);
+
+    const badge = screen.getByLabelText('Updated since you last viewed this file');
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveTextContent('Updated');
+    expect(badge).toHaveAttribute('title', 'Updated since you last viewed this file');
+  });
+
+  it('hides the "Updated" badge once the file is marked as reviewed', () => {
+    render(<DiffViewerHeader {...baseProps} isChangedSinceViewed isReviewed />);
+
+    expect(
+      screen.queryByLabelText('Updated since you last viewed this file'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('hides the "Updated" badge when the file is unchanged since last viewed', () => {
+    render(<DiffViewerHeader {...baseProps} isChangedSinceViewed={false} />);
+
+    expect(
+      screen.queryByLabelText('Updated since you last viewed this file'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/client/components/DiffViewerHeader.tsx
+++ b/src/client/components/DiffViewerHeader.tsx
@@ -105,10 +105,10 @@ export const DiffViewerHeader = ({
         {isChangedSinceViewed && !isReviewed && (
           <span
             className="inline-flex h-6 items-center rounded-full border border-github-warning px-2.5 text-xs font-medium text-github-warning"
-            title="Changed since you last viewed this file"
-            aria-label="Changed since you last viewed this file"
+            title="Updated since you last viewed this file"
+            aria-label="Updated since you last viewed this file"
           >
-            Changed
+            Updated
           </span>
         )}
         <div className="flex items-center gap-2 text-xs">


### PR DESCRIPTION
## Summary

Renames the file header badge shown when a file's contents have changed since the user last viewed it: `Changed` → `Updated`.

This is **Part 1 of 2** for #177. Part 2 (the "Outdated" badge for comments whose code snapshot has drifted) will be submitted as a separate PR per the maintainer's guidance.

## Background

#177 proposes two related improvements:

1. Reset the "viewed" status when the diff changes
2. Mark comments as "Outdated" when their code snapshot no longer matches

In [the maintainer's comment](https://github.com/yoshiko-pg/difit/issues/177#issuecomment-3827053052):

> I think both are good ideas!
> It would be clearer if option 1 had a label like "Updated" and option 2 had "Outdated."
> It would be best if there are no options in the settings, just the minimal implementation.
> If we do them, it would be good to proceed with 1 and 2 separately!

The "Changed" badge for option 1 is already implemented (`DiffViewerHeader.tsx:105`), so this PR limits itself to the label rename plus tests, matching the minimal-implementation request.

## Changes

- `src/client/components/DiffViewerHeader.tsx`: update the badge's visible text, `title`, and `aria-label` from `Changed` → `Updated`
- `src/client/components/DiffViewerHeader.test.tsx` (new): cover the three display conditions of the badge

## Out of scope (intentional)

- **Auto-resetting `viewed` status** when the diff changes — the badge already surfaces this state, so any auto-reset behavior should be a separate decision. Happy to follow up if desired.
- **"Outdated" comment badge** (#177 option 2) — will be a separate PR.

## Test plan

- [x] `pnpm check` — passes
- [x] `pnpm test` — 648 passing (+3 new tests in `DiffViewerHeader.test.tsx`)
- [x] `pnpm build` — passes
- [x] Manual: badge renders as "Updated" when file changes after marking viewed; disappears once reviewed