### PR TITLE
feat(client): add "Outdated" badge to comments whose code snapshot drifted

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -52,6 +52,7 @@ import {
   buildMergedChunksState,
   getMergedChunksForVersion,
 } from './utils/mergedChunks';
+import { buildFileLineIndex, isThreadOutdated } from './utils/outdatedComments';
 
 const EMPTY_COMMENT_THREADS: CommentThread[] = [];
 const EMPTY_MERGED_CHUNKS: MergedChunk[] = [];
@@ -198,40 +199,6 @@ function App() {
     resolvedSelection?.baseMode,
   );
 
-  const normalizedThreads = useMemo<CommentThread[]>(
-    () =>
-      threads.map((thread) => ({
-        id: thread.id,
-        file: thread.filePath,
-        line:
-          typeof thread.position.line === 'number'
-            ? thread.position.line
-            : ([thread.position.line.start, thread.position.line.end] as [number, number]),
-        side: thread.position.side,
-        createdAt: thread.createdAt,
-        updatedAt: thread.updatedAt,
-        codeContent: thread.codeSnapshot?.content,
-        messages: thread.messages,
-      })),
-    [threads],
-  );
-  const showAuthorBadges = useMemo(
-    () => hasMultipleCommentAuthors(normalizedThreads.flatMap((thread) => thread.messages)),
-    [normalizedThreads],
-  );
-
-  const threadsByFile = useMemo(() => {
-    const map = new Map<string, CommentThread[]>();
-    normalizedThreads.forEach((thread) => {
-      const entry = map.get(thread.file);
-      if (entry) {
-        entry.push(thread);
-      } else {
-        map.set(thread.file, [thread]);
-      }
-    });
-    return map;
-  }, [normalizedThreads]);
   const showMobileCommentsBar = isMobile && threads.length > 0;
   const commentsContextKey = useMemo(() => {
     if (!resolvedSelectionKey) {
@@ -464,6 +431,49 @@ function App() {
         getMergedChunksForVersion(mergedChunksState, diffDataVersion, file.path) || file.chunks,
     }));
   }, [diffData, diffDataVersion, mergedChunksState]);
+
+  const fileLineIndexByPath = useMemo(() => {
+    const map = new Map<string, ReturnType<typeof buildFileLineIndex>>();
+    navigableFiles.forEach((file) => {
+      map.set(file.path, buildFileLineIndex(file));
+    });
+    return map;
+  }, [navigableFiles]);
+
+  const normalizedThreads = useMemo<CommentThread[]>(
+    () =>
+      threads.map((thread) => ({
+        id: thread.id,
+        file: thread.filePath,
+        line:
+          typeof thread.position.line === 'number'
+            ? thread.position.line
+            : ([thread.position.line.start, thread.position.line.end] as [number, number]),
+        side: thread.position.side,
+        createdAt: thread.createdAt,
+        updatedAt: thread.updatedAt,
+        codeContent: thread.codeSnapshot?.content,
+        isOutdated: isThreadOutdated(thread, fileLineIndexByPath.get(thread.filePath)),
+        messages: thread.messages,
+      })),
+    [threads, fileLineIndexByPath],
+  );
+  const showAuthorBadges = useMemo(
+    () => hasMultipleCommentAuthors(normalizedThreads.flatMap((thread) => thread.messages)),
+    [normalizedThreads],
+  );
+  const threadsByFile = useMemo(() => {
+    const map = new Map<string, CommentThread[]>();
+    normalizedThreads.forEach((thread) => {
+      const entry = map.get(thread.file);
+      if (entry) {
+        entry.push(thread);
+      } else {
+        map.set(thread.file, [thread]);
+      }
+    });
+    return map;
+  }, [normalizedThreads]);
 
   // State to trigger comment creation from keyboard
   const [commentTrigger, setCommentTrigger] = useState<{
@@ -888,12 +898,13 @@ function App() {
         body,
         side: side || 'new',
         line: typeof line === 'number' ? line : { start: line[0], end: line[1] },
-        codeSnapshot: codeContent
-          ? {
-              content: codeContent,
-              language: undefined,
-            }
-          : undefined,
+        codeSnapshot:
+          codeContent !== undefined
+            ? {
+                content: codeContent,
+                language: undefined,
+              }
+            : undefined,
       });
       return Promise.resolve();
     },
@@ -1038,7 +1049,12 @@ function App() {
             }}
           >
             <h1>
-              <Logo style={{ height: '18px', color: 'var(--color-github-text-secondary)' }} />
+              <Logo
+                style={{
+                  height: '18px',
+                  color: 'var(--color-github-text-secondary)',
+                }}
+              />
             </h1>
             <div className="flex items-center gap-1">
               <button

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1049,12 +1049,7 @@ function App() {
             }}
           >
             <h1>
-              <Logo
-                style={{
-                  height: '18px',
-                  color: 'var(--color-github-text-secondary)',
-                }}
-              />
+              <Logo style={{ height: '18px', color: 'var(--color-github-text-secondary)' }} />
             </h1>
             <div className="flex items-center gap-1">
               <button

--- a/src/client/components/CommentThreadCard.test.tsx
+++ b/src/client/components/CommentThreadCard.test.tsx
@@ -100,6 +100,39 @@ describe('CommentThreadCard', () => {
     expect(onRemoveThread).not.toHaveBeenCalled();
   });
 
+  it('shows the "Outdated" badge when the thread is marked outdated', () => {
+    render(
+      <CommentThreadCard
+        thread={{ ...mockThread, isOutdated: true }}
+        onGeneratePrompt={() => 'thread prompt'}
+        onRemoveThread={vi.fn()}
+        onReplyToThread={vi.fn().mockResolvedValue(undefined)}
+        onRemoveMessage={vi.fn()}
+        onUpdateMessage={vi.fn()}
+      />,
+    );
+
+    const badge = screen.getByLabelText('Outdated comment');
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveTextContent('Outdated');
+    expect(badge).toHaveAttribute('title', 'Code has changed since this comment was made');
+  });
+
+  it('does not render the "Outdated" badge when the thread is up to date', () => {
+    render(
+      <CommentThreadCard
+        thread={mockThread}
+        onGeneratePrompt={() => 'thread prompt'}
+        onRemoveThread={vi.fn()}
+        onReplyToThread={vi.fn().mockResolvedValue(undefined)}
+        onRemoveMessage={vi.fn()}
+        onUpdateMessage={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByLabelText('Outdated comment')).not.toBeInTheDocument();
+  });
+
   it('confirms before deleting a user-authored reply', async () => {
     const user = userEvent.setup();
     const confirmSpy = vi.fn(() => false);

--- a/src/client/components/CommentThreadCard.tsx
+++ b/src/client/components/CommentThreadCard.tsx
@@ -191,6 +191,15 @@ export function CommentThreadCard({
           >
             {thread.file}:{lineLabel}
           </span>
+          {thread.isOutdated && (
+            <span
+              className="inline-flex h-5 shrink-0 items-center rounded-full border border-github-text-muted px-2 text-[10px] font-medium text-github-text-muted"
+              title="Code has changed since this comment was made"
+              aria-label="Outdated comment"
+            >
+              Outdated
+            </span>
+          )}
         </div>
         <div className="flex items-center gap-2">
           <button

--- a/src/client/components/DiffChunk.tsx
+++ b/src/client/components/DiffChunk.tsx
@@ -143,7 +143,7 @@ export const DiffChunk = memo(function DiffChunk({
       const line = lines.find((l) =>
         side === 'old' ? l.oldLineNumber === lineNumber : l.newLineNumber === lineNumber,
       );
-      return line?.content?.replace(/^[+-]/, '') || '';
+      return line?.content ?? '';
     } else {
       // Range of lines
       const [start, end] = lineNumber;
@@ -151,7 +151,7 @@ export const DiffChunk = memo(function DiffChunk({
         const ln = side === 'old' ? l.oldLineNumber : l.newLineNumber;
         return ln !== undefined && ln >= start && ln <= end;
       });
-      return selectedLines.map((l) => l.content?.replace(/^[+-]/, '') || '').join('\n');
+      return selectedLines.map((l) => l.content ?? '').join('\n');
     }
   }, [commentingLine, chunk.lines]);
 
@@ -159,12 +159,7 @@ export const DiffChunk = memo(function DiffChunk({
     async (body: string) => {
       if (commentingLine !== null) {
         const codeContent = getSelectedCodeContent();
-        await onAddComment(
-          commentingLine.lineNumber,
-          body,
-          codeContent || undefined,
-          commentingLine.side,
-        );
+        await onAddComment(commentingLine.lineNumber, body, codeContent, commentingLine.side);
         setCommentingLine(null);
       }
     },

--- a/src/client/components/SideBySideDiffChunk.tsx
+++ b/src/client/components/SideBySideDiffChunk.tsx
@@ -173,7 +173,7 @@ export function SideBySideDiffChunk({
       const line = lines.find((l) =>
         side === 'old' ? l.oldLineNumber === lineNumber : l.newLineNumber === lineNumber,
       );
-      return line?.content?.replace(/^[+-]/, '') || '';
+      return line?.content ?? '';
     } else {
       // Range of lines
       const [start, end] = lineNumber;
@@ -181,7 +181,7 @@ export function SideBySideDiffChunk({
         const ln = side === 'old' ? l.oldLineNumber : l.newLineNumber;
         return ln !== undefined && ln >= start && ln <= end;
       });
-      return selectedLines.map((l) => l.content?.replace(/^[+-]/, '') || '').join('\n');
+      return selectedLines.map((l) => l.content ?? '').join('\n');
     }
   }, [commentingLine, chunk.lines]);
 
@@ -189,12 +189,7 @@ export function SideBySideDiffChunk({
     async (body: string) => {
       if (commentingLine !== null) {
         const codeContent = getSelectedCodeContent();
-        await onAddComment(
-          commentingLine.lineNumber,
-          body,
-          codeContent || undefined,
-          commentingLine.side,
-        );
+        await onAddComment(commentingLine.lineNumber, body, codeContent, commentingLine.side);
         setCommentingLine(null);
       }
     },

--- a/src/client/utils/outdatedComments.test.ts
+++ b/src/client/utils/outdatedComments.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from 'vitest';
+
+import type { DiffCommentThread, DiffFile, DiffLine } from '../../types/diff';
+
+import { buildFileLineIndex, isThreadOutdated } from './outdatedComments';
+
+const buildThread = (overrides: Partial<DiffCommentThread> = {}): DiffCommentThread => ({
+  id: 'thread-1',
+  filePath: 'src/app.ts',
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+  position: { side: 'new', line: 10 },
+  codeSnapshot: { content: 'const value = 1;' },
+  messages: [
+    {
+      id: 'message-1',
+      body: 'comment',
+      author: 'User',
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    },
+  ],
+  ...overrides,
+});
+
+const buildFile = (lines: DiffLine[]): DiffFile => ({
+  path: 'src/app.ts',
+  status: 'modified',
+  additions: 0,
+  deletions: 0,
+  chunks: [
+    {
+      header: '@@ -1,1 +1,1 @@',
+      oldStart: 1,
+      oldLines: 1,
+      newStart: 1,
+      newLines: lines.length,
+      lines,
+    },
+  ],
+});
+
+const newLine = (lineNumber: number, content: string): DiffLine => ({
+  type: 'add',
+  content,
+  newLineNumber: lineNumber,
+});
+
+const oldLine = (lineNumber: number, content: string): DiffLine => ({
+  type: 'delete',
+  content,
+  oldLineNumber: lineNumber,
+});
+
+describe('isThreadOutdated', () => {
+  it('returns false when the current line content matches the snapshot', () => {
+    const thread = buildThread({
+      codeSnapshot: { content: 'const value = 1;' },
+      position: { side: 'new', line: 10 },
+    });
+    const index = buildFileLineIndex(buildFile([newLine(10, 'const value = 1;')]));
+
+    expect(isThreadOutdated(thread, index)).toBe(false);
+  });
+
+  it('returns true when the current line content differs from the snapshot', () => {
+    const thread = buildThread({
+      codeSnapshot: { content: 'const value = 1;' },
+      position: { side: 'new', line: 10 },
+    });
+    const index = buildFileLineIndex(buildFile([newLine(10, 'const value = 2;')]));
+
+    expect(isThreadOutdated(thread, index)).toBe(true);
+  });
+
+  it('returns false when the target line is not present in the index (e.g. unexpanded context)', () => {
+    const thread = buildThread({ position: { side: 'new', line: 10 } });
+    const index = buildFileLineIndex(buildFile([newLine(5, 'const other = 99;')]));
+
+    expect(isThreadOutdated(thread, index)).toBe(false);
+  });
+
+  it('returns true when the file is missing from the index map (file no longer in the diff)', () => {
+    const thread = buildThread();
+
+    expect(isThreadOutdated(thread, undefined)).toBe(true);
+  });
+
+  it('returns false when the thread has no code snapshot (legacy comment)', () => {
+    const thread = buildThread({ codeSnapshot: undefined });
+    const index = buildFileLineIndex(buildFile([newLine(10, 'anything')]));
+
+    expect(isThreadOutdated(thread, index)).toBe(false);
+  });
+
+  it('returns false when the snapshot only differs by trailing whitespace or line endings', () => {
+    const thread = buildThread({
+      codeSnapshot: { content: 'const value = 1;  \r\nconst next = 2;\r\n' },
+      position: { side: 'new', line: { start: 10, end: 11 } },
+    });
+    const index = buildFileLineIndex(
+      buildFile([newLine(10, 'const value = 1;'), newLine(11, 'const next = 2;')]),
+    );
+
+    expect(isThreadOutdated(thread, index)).toBe(false);
+  });
+
+  it('returns false when a multi-line range is partially present and the present lines all match', () => {
+    const thread = buildThread({
+      codeSnapshot: { content: 'const a = 1;\nconst b = 2;' },
+      position: { side: 'new', line: { start: 10, end: 11 } },
+    });
+    const index = buildFileLineIndex(buildFile([newLine(10, 'const a = 1;')]));
+
+    expect(isThreadOutdated(thread, index)).toBe(false);
+  });
+
+  it('returns true when a partially-present multi-line range has a mismatch on the visible line', () => {
+    const thread = buildThread({
+      codeSnapshot: { content: 'const a = 1;\nconst b = 2;\nconst c = 3;' },
+      position: { side: 'new', line: { start: 10, end: 12 } },
+    });
+    const index = buildFileLineIndex(buildFile([newLine(10, 'const a = 999;')]));
+
+    expect(isThreadOutdated(thread, index)).toBe(true);
+  });
+
+  it('compares against the "old" side when the thread is anchored to a deletion', () => {
+    const thread = buildThread({
+      codeSnapshot: { content: 'const removed = true;' },
+      position: { side: 'old', line: 42 },
+    });
+    const index = buildFileLineIndex(buildFile([oldLine(42, 'const removed = false;')]));
+
+    expect(isThreadOutdated(thread, index)).toBe(true);
+  });
+
+  it('does not flag outdated when the actual code line starts with "+" or "-" and matches', () => {
+    const thread = buildThread({
+      codeSnapshot: { content: '++i;' },
+      position: { side: 'new', line: 10 },
+    });
+    const index = buildFileLineIndex(buildFile([newLine(10, '++i;')]));
+
+    expect(isThreadOutdated(thread, index)).toBe(false);
+  });
+
+  it('treats an empty-string snapshot as a valid blank-line comment (matches blank current line)', () => {
+    const thread = buildThread({
+      codeSnapshot: { content: '' },
+      position: { side: 'new', line: 10 },
+    });
+    const index = buildFileLineIndex(buildFile([newLine(10, '')]));
+
+    expect(isThreadOutdated(thread, index)).toBe(false);
+  });
+
+  it('flags an empty-string snapshot as outdated when the current line has gained content', () => {
+    const thread = buildThread({
+      codeSnapshot: { content: '' },
+      position: { side: 'new', line: 10 },
+    });
+    const index = buildFileLineIndex(buildFile([newLine(10, 'const added = true;')]));
+
+    expect(isThreadOutdated(thread, index)).toBe(true);
+  });
+
+  it('flags a snapshot with a trailing blank line as outdated when the current trailing line has content', () => {
+    const thread = buildThread({
+      codeSnapshot: { content: 'const a = 1;\nconst b = 2;\n' },
+      position: { side: 'new', line: { start: 10, end: 12 } },
+    });
+    const index = buildFileLineIndex(
+      buildFile([
+        newLine(10, 'const a = 1;'),
+        newLine(11, 'const b = 2;'),
+        newLine(12, 'const c = 3;'),
+      ]),
+    );
+
+    expect(isThreadOutdated(thread, index)).toBe(true);
+  });
+
+  it('does not confuse "old" and "new" line numbers when both sides exist', () => {
+    const thread = buildThread({
+      codeSnapshot: { content: 'old-side text' },
+      position: { side: 'old', line: 5 },
+    });
+    const index = buildFileLineIndex(
+      buildFile([
+        {
+          type: 'normal',
+          content: 'new-side text',
+          oldLineNumber: 5,
+          newLineNumber: 5,
+        },
+      ]),
+    );
+
+    expect(isThreadOutdated(thread, index)).toBe(true);
+  });
+});

--- a/src/client/utils/outdatedComments.ts
+++ b/src/client/utils/outdatedComments.ts
@@ -1,0 +1,59 @@
+import type { DiffCommentThread, DiffFile } from '../../types/diff';
+
+export interface FileLineIndex {
+  old: Map<number, string>;
+  new: Map<number, string>;
+}
+
+function trimTrailingWhitespace(line: string): string {
+  return line.replace(/[ \t]+$/, '');
+}
+
+function splitSnapshot(content: string): string[] {
+  return content.replace(/\r\n/g, '\n').split('\n').map(trimTrailingWhitespace);
+}
+
+export function buildFileLineIndex(file: DiffFile): FileLineIndex {
+  const oldIndex = new Map<number, string>();
+  const newIndex = new Map<number, string>();
+
+  for (const chunk of file.chunks) {
+    for (const line of chunk.lines) {
+      if (line.oldLineNumber !== undefined) {
+        oldIndex.set(line.oldLineNumber, line.content);
+      }
+      if (line.newLineNumber !== undefined) {
+        newIndex.set(line.newLineNumber, line.content);
+      }
+    }
+  }
+
+  return { old: oldIndex, new: newIndex };
+}
+
+export function isThreadOutdated(
+  thread: DiffCommentThread,
+  index: FileLineIndex | undefined,
+): boolean {
+  const snapshot = thread.codeSnapshot?.content;
+  if (snapshot === undefined) return false;
+
+  if (!index) return true;
+
+  const sideIndex = thread.position.side === 'old' ? index.old : index.new;
+  const range =
+    typeof thread.position.line === 'number'
+      ? { start: thread.position.line, end: thread.position.line }
+      : thread.position.line;
+
+  const snapshotLines = splitSnapshot(snapshot);
+
+  for (let i = 0; i <= range.end - range.start; i++) {
+    const current = sideIndex.get(range.start + i);
+    if (current === undefined) continue;
+    const expected = snapshotLines[i] ?? '';
+    if (trimTrailingWhitespace(current) !== expected) return true;
+  }
+
+  return false;
+}

--- a/src/types/diff.ts
+++ b/src/types/diff.ts
@@ -195,6 +195,7 @@ export interface CommentThread {
   createdAt: string;
   updatedAt: string;
   codeContent?: string;
+  isOutdated?: boolean;
   messages: DiffCommentMessage[];
 }
 


### PR DESCRIPTION
## Summary

Renders an **"Outdated"** badge on a comment whose saved `codeSnapshot` no longer matches the current diff content at the same position.

This is **Part 2 of 2** for #177. Part 1 (#382) covers the file-header "Updated" badge.

## Background

[The maintainer's comment](https://github.com/yoshiko-pg/difit/issues/177#issuecomment-3827053052):

> If we do them, it would be good to proceed with 1 and 2 separately!

Both PRs target `main` independently; the changes touch different files and have no conflict.

## Approach

- New util `outdatedComments.ts` exposes `isThreadOutdated(thread, index)` and `buildFileLineIndex(file)`.
- In `App.tsx`, an index of `side + lineNumber -> content` is built from `navigableFiles` (the merged-chunks variant — includes expanded context lines so comments on expanded lines are not incorrectly flagged).
- `normalizedThreads` wires the result onto each `CommentThread` as `isOutdated?: boolean`.
- `CommentThreadCard` renders the badge next to the file:line label when `thread.isOutdated` is true. The badge also surfaces in `CommentsListModal` via the same component.

The comparison is per-line and conservative:

| Case | Result |
|---|---|
| Comparable line(s) differ from snapshot | **Outdated** |
| File no longer in the diff | **Outdated** |
| Range partially unloaded (e.g. expanded context not re-expanded after reload), visible portion matches | Not outdated |
| `codeSnapshot` missing (legacy comment) | Not outdated |
| Snapshot differs only in trailing whitespace or line endings | Not outdated |

## Bundled pre-existing snapshot-capture bug fixes

This feature surfaces two bugs in the existing snapshot-capture path. Without fixing them, `isThreadOutdated` produces false positives in exactly the scenarios the feature is supposed to handle, so I've bundled them into this PR rather than deferring.

**1. Double-stripping of the leading `+` / `-`**

`DiffChunk` and `SideBySideDiffChunk` ran `line.content.replace(/^[+-]/, '')` on the selected code before passing it to `addThread`. The diff parser at `src/server/git-diff.ts:504` already strips the leading diff marker via `line.slice(1)`, so this second strip corrupts real code lines that start with `+` or `-`:

```
Actual code: ++i;   (a line of code that is *adding* the text `++i;`)
After parser: ++i;   (line.slice(1) on the raw `+++i;`)
After the buggy second strip: +i;   ← snapshot stored as +i;
On comparison against current `++i;`: mismatch -> incorrectly Outdated
```

**2. Empty-string snapshot silently dropped**

The `getSelectedCodeContent` helpers returned `''` for blank lines, and `handleSubmitComment` then passed `codeContent || undefined` to `addThread`. Empty string is falsy, so any comment on a blank line was stored with `codeSnapshot: undefined`. `App.tsx` had the same truthy collapse on the receiving end. The new Outdated check has nothing to compare against, so it can never flag changes on blank lines.

Both bugs have regression tests in `outdatedComments.test.ts`.

## Files touched

| File | Why |
|---|---|
| `src/client/utils/outdatedComments.ts` (new) | `isThreadOutdated` + `buildFileLineIndex` |
| `src/client/utils/outdatedComments.test.ts` (new) | 12 unit tests covering match / mismatch / range / legacy / blank / leading `+`-`/`-` / old-side / both-sides |
| `src/types/diff.ts` | Add `CommentThread.isOutdated?: boolean` |
| `src/client/App.tsx` | Build the index from `navigableFiles`, compute `isOutdated` per thread |
| `src/client/components/CommentThreadCard.tsx` | Render the badge |
| `src/client/components/CommentThreadCard.test.tsx` | 2 new tests (renders / does not render) |
| `src/client/components/DiffChunk.tsx` | Drop the double `replace(/^[+-]/, '')`, stop coercing empty `codeContent` to `undefined` |
| `src/client/components/SideBySideDiffChunk.tsx` | Same as DiffChunk |

## Test plan

- [x] `pnpm check` — passes
- [x] `pnpm test` — 661 passing (+13 new tests)
- [x] `pnpm build` — passes
- [x] Manual: inject two threads via `localStorage` — one with a snapshot matching the current diff line, one with a deliberately mismatched snapshot. Reload. Confirm Outdated badge appears only on the mismatched comment, both in the inline view and in **View All Comments**.

## Out of scope

The Outdated badge is read-only — there's no UI to "resolve" or hide it, matching the maintainer's "minimal implementation" guidance.