### PR TITLE
fix(comments): keep concurrent agent comment writes from being lost or hidden

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -269,6 +269,8 @@ function App() {
     commentsContextKey !== null && commentsContextKey === bootstrappedCommentsKey;
   const bootstrappingCommentsKeyRef = useRef<string | null>(null);
   const skipNextCommentSyncRef = useRef(false);
+  // Last server comment version seen; echoed back as baseVersion so the server can detect concurrent writes.
+  const serverCommentVersionRef = useRef<number | null>(null);
   const pendingBootstrapAfterLocalResetRef = useRef(false);
 
   useEffect(() => {
@@ -283,19 +285,45 @@ function App() {
       throw new Error(`Failed to fetch comments: ${response.status} ${response.statusText}`);
     }
 
-    const payload = (await response.json()) as { threads?: DiffCommentThread[] };
+    const payload = (await response.json()) as {
+      version?: number;
+      threads?: DiffCommentThread[];
+    };
+    if (typeof payload.version === 'number') {
+      serverCommentVersionRef.current = payload.version;
+    }
     return Array.isArray(payload.threads) ? payload.threads : [];
   }, [getCommentApiUrl]);
 
   const syncThreadsToServer = useCallback(
     async (nextThreads: DiffCommentThread[]) => {
-      await fetch(getCommentApiUrl('/api/comments'), {
+      const response = await fetch(getCommentApiUrl('/api/comments'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ threads: nextThreads }),
+        body: JSON.stringify({
+          threads: nextThreads,
+          baseVersion: serverCommentVersionRef.current ?? undefined,
+        }),
       });
+      if (!response.ok) {
+        return;
+      }
+
+      const result = (await response.json()) as {
+        version?: number;
+        merged?: boolean;
+        threads?: DiffCommentThread[];
+      };
+      if (typeof result.version === 'number') {
+        serverCommentVersionRef.current = result.version;
+      }
+      // Server merged in a concurrent change; adopt it so we don't push a stale set back.
+      if (result.merged && Array.isArray(result.threads)) {
+        skipNextCommentSyncRef.current = true;
+        replaceThreads(result.threads);
+      }
     },
-    [getCommentApiUrl],
+    [getCommentApiUrl, replaceThreads],
   );
 
   // Viewed files management
@@ -829,7 +857,10 @@ function App() {
       return;
     }
 
-    const data = JSON.stringify({ threads });
+    const data = JSON.stringify({
+      threads,
+      baseVersion: serverCommentVersionRef.current ?? undefined,
+    });
     const commentsApiUrl = getCommentApiUrl('/api/comments');
 
     // Also handle page unload

--- a/src/server/server.test.ts
+++ b/src/server/server.test.ts
@@ -128,8 +128,13 @@ describe('Server Integration Tests', () => {
         });
 
         expect(response.status).toBe(200);
-        const apiResult = await response.json();
-        expect(apiResult).toEqual({ success: true });
+        const apiResult = (await response.json()) as {
+          success: boolean;
+          merged: boolean;
+          version: number;
+        };
+        expect(apiResult).toMatchObject({ success: true, merged: false });
+        expect(typeof apiResult.version).toBe('number');
 
         // Verify the formatted output
         const outputResponse = await fetch(`http://localhost:${result.port}/api/comments-output`);
@@ -181,6 +186,109 @@ describe('Server Integration Tests', () => {
 
         expect(output).toContain('<unknown file>:L10');
         expect(output).toContain('Comment without file');
+      } finally {
+        if (result.server) {
+          await new Promise<void>((resolve) => {
+            result.server!.close(() => resolve());
+          });
+        }
+      }
+    });
+
+    const isoNow = '2024-01-01T00:00:00Z';
+    const makeThread = (id: string, filePath: string, line: number, body: string) => ({
+      id,
+      filePath,
+      createdAt: isoNow,
+      updatedAt: isoNow,
+      position: { side: 'new' as const, line },
+      messages: [{ id, body, createdAt: isoNow, updatedAt: isoNow }],
+    });
+
+    const postThreads = (port: number, threads: unknown[], baseVersion?: number) =>
+      fetch(`http://localhost:${port}/api/comments`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ threads, baseVersion }),
+      });
+
+    const getSession = async (port: number) => {
+      const res = await fetch(`http://localhost:${port}/api/comments-json`);
+      return (await res.json()) as {
+        version: number;
+        threads: Array<{ id: string; filePath: string }>;
+      };
+    };
+
+    it('merges concurrent agent additions instead of clobbering on a stale push', async () => {
+      const port = await getAvailablePort(4966);
+      const result = await startServer({ preferredPort: port, openBrowser: false });
+
+      try {
+        // Browser establishes a thread; it now knows version 1.
+        await postThreads(result.port, [makeThread('t1', 'src/a.ts', 10, 'human thread')]);
+        const afterFirst = await getSession(result.port);
+        expect(afterFirst.version).toBe(1);
+
+        // An agent adds a second thread out of band (e.g. `difit comment add`).
+        const agentImport: CommentImport[] = [
+          {
+            type: 'thread',
+            id: 'agent-1',
+            filePath: 'src/b.ts',
+            position: { side: 'new', line: 20 },
+            body: 'agent finding',
+            author: 'Agent',
+          },
+        ];
+        await fetch(`http://localhost:${result.port}/api/comment-imports`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(agentImport),
+        });
+
+        // The browser, unaware of the agent's thread, pushes its stale set
+        // tagged with the version it last observed (1).
+        const staleResponse = await postThreads(
+          result.port,
+          [makeThread('t1', 'src/a.ts', 10, 'human thread')],
+          1,
+        );
+        const staleResult = (await staleResponse.json()) as { merged: boolean };
+        expect(staleResult.merged).toBe(true);
+
+        // The agent's thread must survive the stale push.
+        const final = await getSession(result.port);
+        expect(final.threads).toHaveLength(2);
+        expect(final.threads.some((thread) => thread.id === 't1')).toBe(true);
+        expect(final.threads.some((thread) => thread.id === 'agent-1')).toBe(true);
+      } finally {
+        if (result.server) {
+          await new Promise<void>((resolve) => {
+            result.server!.close(() => resolve());
+          });
+        }
+      }
+    });
+
+    it('replaces (honoring deletions) when the push version matches', async () => {
+      const port = await getAvailablePort(4966);
+      const result = await startServer({ preferredPort: port, openBrowser: false });
+
+      try {
+        await postThreads(result.port, [makeThread('t1', 'src/a.ts', 10, 'human thread')]);
+        const afterFirst = await getSession(result.port);
+        expect(afterFirst.version).toBe(1);
+        expect(afterFirst.threads).toHaveLength(1);
+
+        // Same version means no concurrent writer, so an empty set is a real
+        // deletion and must be honored (not merged back).
+        const response = await postThreads(result.port, [], afterFirst.version);
+        const body = (await response.json()) as { merged: boolean };
+        expect(body.merged).toBe(false);
+
+        const final = await getSession(result.port);
+        expect(final.threads).toHaveLength(0);
       } finally {
         if (result.server) {
           await new Promise<void>((resolve) => {

--- a/src/server/server.test.ts
+++ b/src/server/server.test.ts
@@ -297,6 +297,41 @@ describe('Server Integration Tests', () => {
         }
       }
     });
+
+    it('bumps the version when a reply is imported (so the change is broadcast)', async () => {
+      const port = await getAvailablePort(4966);
+      const result = await startServer({ preferredPort: port, openBrowser: false });
+
+      try {
+        await postThreads(result.port, [makeThread('t1', 'src/a.ts', 10, 'human thread')]);
+        const before = await getSession(result.port);
+
+        // A reply via comment-imports must register as a change — otherwise the
+        // server skips the commentsChanged broadcast and open browsers go stale.
+        await fetch(`http://localhost:${result.port}/api/comment-imports`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify([
+            {
+              type: 'reply',
+              filePath: 'src/a.ts',
+              position: { side: 'new', line: 10 },
+              body: 'agent reply',
+              author: 'Agent',
+            },
+          ] satisfies CommentImport[]),
+        });
+
+        const after = await getSession(result.port);
+        expect(after.version).toBeGreaterThan(before.version);
+      } finally {
+        if (result.server) {
+          await new Promise<void>((resolve) => {
+            result.server!.close(() => resolve());
+          });
+        }
+      }
+    });
   });
 
   let servers: any[] = [];

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -13,6 +13,7 @@ import { type DiffMode } from '../types/watch.js';
 import { formatCommentsOutput } from '../utils/commentFormatting.js';
 import {
   mergeCommentImports,
+  mergeCommentThreads,
   normalizeCommentImports,
   serializeCommentImports,
 } from '../utils/commentImports.js';
@@ -682,6 +683,13 @@ export async function startServer(
     return [];
   }
 
+  // Version the client based its push on (omitted by older clients).
+  function parseBaseVersion(payload: unknown): number | undefined {
+    if (!payload || typeof payload !== 'object') return undefined;
+    const value = (payload as { baseVersion?: unknown }).baseVersion;
+    return typeof value === 'number' && Number.isInteger(value) && value >= 0 ? value : undefined;
+  }
+
   function parseCommentImportsPayload(body: unknown): CommentImport[] {
     if (typeof body === 'string') {
       return normalizeCommentImports(JSON.parse(body));
@@ -715,9 +723,27 @@ export async function startServer(
   app.post('/api/comments', (req, res) => {
     try {
       const selection = getCommentSelectionFromQuery(req.query as Record<string, unknown>);
-      const nextThreads = parseCommentsPayload(req.body);
-      updateCommentSession(selection, nextThreads);
-      res.json({ success: true });
+      const body: unknown =
+        typeof req.body === 'string' ? (JSON.parse(req.body) as unknown) : req.body;
+      const nextThreads = parseCommentsPayload(body);
+      const baseVersion = parseBaseVersion(body);
+      const session = getOrCreateCommentSession(selection);
+
+      // Stale baseVersion means another writer (e.g. an agent) changed comments since the
+      // client's last read, so merge rather than overwrite. A matching/absent version replaces.
+      const isStale = typeof baseVersion === 'number' && baseVersion !== session.version;
+      const resolvedThreads = isStale
+        ? mergeCommentThreads(session.threads, nextThreads).threads
+        : nextThreads;
+
+      updateCommentSession(selection, resolvedThreads);
+
+      res.json({
+        success: true,
+        merged: isStale,
+        version: session.version,
+        threads: session.threads,
+      });
     } catch (error) {
       console.error('Error parsing comments:', error);
       res.status(400).json({ error: 'Invalid comment data' });

--- a/src/utils/commentImports.ts
+++ b/src/utils/commentImports.ts
@@ -481,7 +481,10 @@ export function mergeCommentImports(
   existingThreads: DiffCommentThread[],
   commentImports: CommentImport[],
 ): MergeCommentImportsResult {
-  const threads = [...existingThreads];
+  // Clone (don't shallow-copy) so appending a reply doesn't mutate the caller's
+  // thread objects in place — otherwise the server can't detect the change and
+  // skips the commentsChanged broadcast, leaving open browsers stale.
+  const threads = existingThreads.map(cloneThread);
   const warnings: string[] = [];
 
   for (const commentImport of commentImports) {


### PR DESCRIPTION
## Motivation

difit's comment store lives server-side and is pushed to open browsers over the `/api/watch` SSE channel, which makes it a natural surface for an agent (`difit comment add`) and a human reviewer to collaborate in real time. Two issues broke that loop whenever writes happened concurrently:

1. **The browser clobbered concurrent writes.** The browser keeps comment threads in local state and syncs the **entire** set to `POST /api/comments` on every local change; the handler replaced the server session wholesale (`session.threads = nextThreads`). In the happy path the browser re-pulls on `commentsChanged` before it pushes, but when a local edit races an out-of-band write — the browser pushes before its SSE pull lands, or the SSE connection dropped — the push overwrites the concurrent write. The agent's comment lands on the server, then the next browser push erases it.

2. **Imported replies never broadcast.** A reply added via `comment-imports` (`mergeCommentImports`) mutated the existing thread object **in place** (the array was shallow-copied), so `updateCommentSession` saw no difference between previous and next state, skipped the version bump, and never emitted `commentsChanged`. Open browsers didn't see agent replies until some other event triggered a refetch.

## Changes

- **Stale-push merge** — the client records the session `version` from `GET /api/comments-json` and the `POST /api/comments` response and sends it back as `baseVersion`. If it matches (no concurrent writer) the server replaces as before, so **deletions are still honored**; if it's stale, the server **merges** via the existing `mergeCommentThreads` instead of overwriting. Missing `baseVersion` keeps the legacy replace behavior. On a merged response the client adopts the merged result so the UI converges.
- **Reply broadcast** — `mergeCommentImports` now clones the threads (matching `mergeCommentThreads`) instead of shallow-copying, so an appended reply is a real change: the version bumps and `commentsChanged` fires.

No new endpoints, schema, or dependencies — both reuse the existing version counter, SSE channel, pull endpoint, and merge utilities.

**Known limitation:** during the narrow stale-push conflict window, a *deletion* on the stale side won't propagate (the merge is additive). Losing a not-yet-synced deletion is far less damaging than losing a concurrent addition, and deletions work normally when versions match (the common case). Fully resolving deletes under conflict would need tombstones or granular per-op endpoints — out of scope here.

## Tests / verification

- New server tests: a stale `baseVersion` push preserves a concurrently-added thread; a matching-version push still replaces (honoring deletions); an imported reply bumps the session version (so it broadcasts).
- `pnpm check`, `pnpm test`, `pnpm build`, and `pnpm format` all pass.

## UI changes

None (behavioral / server change only).
