### PR TITLE
fix: exclude site data from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
   },
   "files": [
     "dist",
+    "!dist/client/site-data",
+    "!dist/site",
     "README.md"
   ],
   "type": "module",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+import { rmSync } from 'fs';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { resolve } from 'path';
@@ -5,7 +6,15 @@ import { resolve } from 'path';
 const apiTarget = process.env.VITE_DIFIT_API_URL || 'http://localhost:4966';
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    {
+      name: 'remove-site-data-from-client-build',
+      closeBundle() {
+        rmSync(resolve(__dirname, 'dist/client/site-data'), { recursive: true, force: true });
+      },
+    },
+  ],
   root: 'src/client',
   publicDir: '../../public',
   build: {


### PR DESCRIPTION
## Summary
- remove generated site-data from the regular client build output
- exclude dist/client/site-data and dist/site from npm package files

## Root cause
The regular Vite client build copied the shared public directory into dist/client, so GitHub Pages demo data under public/site-data could be published with the CLI package.

## Validation
- pnpm run build
- pnpm run build:site
- pnpm run check
- pnpm run format
- pnpm test
- npm pack --dry-run confirms site-data and dist/site are excluded

Closes #407