### PR TITLE
feat: Add Svelte syntax highlighting support

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -193,7 +193,7 @@ npx skills add yoshiko-pg/difit
 
 ## 🎨 シンタックスハイライト対応言語
 
-- **JavaScript/TypeScript**：`.js`, `.jsx`, `.ts`, `.tsx`
+- **JavaScript/TypeScript**：`.js`, `.jsx`, `.ts`, `.tsx`, `.svelte`
 - **Web技術**：HTML, CSS, JSON, XML, Markdown
 - **シェルスクリプト**：`.sh`, `.bash`, `.zsh`, `.fish`
 - **バックエンド言語**：PHP, SQL, Ruby, Java, Scala, Perl, Elixir, Haskell, Clojure

--- a/README.ko.md
+++ b/README.ko.md
@@ -193,7 +193,7 @@ npx skills add yoshiko-pg/difit
 
 ## 🎨 구문 강조 언어
 
-- **JavaScript/TypeScript**: `.js`, `.jsx`, `.ts`, `.tsx`
+- **JavaScript/TypeScript**: `.js`, `.jsx`, `.ts`, `.tsx`, `.svelte`
 - **웹 기술**: HTML, CSS, JSON, XML, Markdown
 - **셸 스크립트**: `.sh`, `.bash`, `.zsh`, `.fish`
 - **백엔드 언어**: PHP, SQL, Ruby, Java, Scala, Perl, Elixir, Haskell, Clojure

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ After code edits or automated review, the agent can start the difit server with 
 
 ## 🎨 Syntax Highlighting Languages
 
-- **JavaScript/TypeScript**: `.js`, `.jsx`, `.ts`, `.tsx`
+- **JavaScript/TypeScript**: `.js`, `.jsx`, `.ts`, `.tsx`, `.svelte`
 - **Web Technologies**: HTML, CSS, JSON, XML, Markdown
 - **Shell Scripts**: `.sh`, `.bash`, `.zsh`, `.fish`
 - **Backend Languages**: PHP, SQL, Ruby, Java, Scala, Perl, Elixir, Haskell, Clojure

--- a/README.zh.md
+++ b/README.zh.md
@@ -193,7 +193,7 @@ npx skills add yoshiko-pg/difit
 
 ## 🎨 语法高亮语言
 
-- **JavaScript/TypeScript**：`.js`, `.jsx`, `.ts`, `.tsx`
+- **JavaScript/TypeScript**：`.js`, `.jsx`, `.ts`, `.tsx`, `.svelte`
 - **Web 技术**：HTML, CSS, JSON, XML, Markdown
 - **Shell 脚本**：`.sh`, `.bash`, `.zsh`, `.fish`
 - **后端语言**：PHP, SQL, Ruby, Java, Scala, Perl, Elixir, Haskell, Clojure

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "mermaid": "^11.13.0",
     "open": "^11.0.0",
     "prism-react-renderer": "^2.4.1",
+    "prism-svelte": "^0.5.0",
     "prismjs": "^1.30.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       prism-react-renderer:
         specifier: ^2.4.1
         version: 2.4.1(react@19.2.7)
+      prism-svelte:
+        specifier: ^0.5.0
+        version: 0.5.0
       prismjs:
         specifier: ^1.30.0
         version: 1.30.0
@@ -3389,6 +3392,9 @@ packages:
     resolution: {integrity: sha512-ey8Ls/+Di31eqzUxC46h8MksNuGx/n0AAC8uKpwFau4RPDYLuE3EXTp8N8G2vX2N7UC/+IXeNUnlWBGGcAG+Ig==}
     peerDependencies:
       react: '>=16.0.0'
+
+  prism-svelte@0.5.0:
+    resolution: {integrity: sha512-db91Bf3pRGKDPz1lAqLFSJXeW13mulUJxhycysFpfXV5MIK7RgWWK2E5aPAa71s8TCzQUXxF5JOV42/iOs6QkA==}
 
   prismjs@1.30.0:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
@@ -7495,6 +7501,8 @@ snapshots:
       '@types/prismjs': 1.26.5
       clsx: 2.1.1
       react: 19.2.7
+
+  prism-svelte@0.5.0: {}
 
   prismjs@1.30.0: {}
 

--- a/src/client/utils/languageLoader.ts
+++ b/src/client/utils/languageLoader.ts
@@ -35,6 +35,9 @@ export function loadPrismLanguage(lang: string): Promise<void> {
       nix: () => import('prismjs/components/prism-nix.js'),
       haskell: () => import('prismjs/components/prism-haskell.js'),
       clojure: () => import('prismjs/components/prism-clojure.js'),
+      // Svelte grammar ships as a third-party plugin (not in prismjs core);
+      // it extends markup and embeds js/css, all available by default.
+      svelte: () => import('prism-svelte'),
     };
 
     const importFn = languageImports[lang];

--- a/src/types/prism-components.d.ts
+++ b/src/types/prism-components.d.ts
@@ -3,3 +3,9 @@ declare module 'prismjs/components/*' {
   const value: unknown;
   export = value;
 }
+
+// Third-party Prism grammar plugin (registers Prism.languages.svelte on import).
+declare module 'prism-svelte' {
+  const value: unknown;
+  export = value;
+}


### PR DESCRIPTION
Hi @yoshiko-pg san! 👋

This PR adds syntax highlighting support for Svelte files.

`.svelte` files were already detected as the `svelte` Prism language, but there was no matching loader in `languageLoader.ts`, so they fell back to plain text.
PrismJS core doesn't ship a Svelte grammar either, so this wires up the third-party `prism-svelte` plugin to fill the gap.

## Changes

### Svelte Support
- Add `prism-svelte` dependency (Svelte grammar isn't in prismjs core)
- Add Svelte language loader in `languageLoader.ts`
- Add a module type declaration for `prism-svelte`
- Update README docs in all 4 languages (EN, JA, KO, ZH)

One loader entry covers both per-line highlighting and whole-file SFC tokenization, since both paths go through `loadPrismLanguage`.

## Supported Extensions

- Svelte (.svelte)

## Screenshot

<img width="879" height="749" alt="Screenshot 2026-06-29 at 22 52 45" src="https://github.com/user-attachments/assets/c69213d1-3ad8-4398-83b3-d5f34f6b8586" />


Thanks!