### PR TITLE
fix: selection highlight covers the whole screen in Safari (unified mode)

### DIFF
--- a/src/client/components/DiffChunk.tsx
+++ b/src/client/components/DiffChunk.tsx
@@ -204,15 +204,14 @@ export const DiffChunk = memo(function DiffChunk({
       const min = Math.min(startLine, endLine);
       const max = Math.max(startLine, endLine);
       if (lineNumber >= min && lineNumber <= max) {
-        let classes =
-          'after:bg-blue-100 after:absolute after:inset-0 after:opacity-30 after:border-l-4 after:border-blue-500 after:pointer-events-none';
+        let classes = 'drag-selected';
         // Add top border for first line
         if (lineNumber === min) {
-          classes += ' after:border-t-2';
+          classes += ' drag-selected-first';
         }
         // Add bottom border for last line
         if (lineNumber === max) {
-          classes += ' after:border-b-2';
+          classes += ' drag-selected-last';
         }
         return classes;
       }
@@ -227,7 +226,7 @@ export const DiffChunk = memo(function DiffChunk({
         ? commentingLine.lineNumber[1]
         : commentingLine.lineNumber;
       if (lineNumber >= start && lineNumber <= end) {
-        return 'after:bg-diff-selected-bg after:absolute after:inset-0 after:border-l-5 after:border-l-diff-selected-border after:pointer-events-none';
+        return 'comment-selected';
       }
     }
 

--- a/src/client/styles/global.css
+++ b/src/client/styles/global.css
@@ -157,6 +157,51 @@ td.keyboard-cursor::before {
   z-index: 1;
 }
 
+/* WebKit ignores position:relative on <tr>, so the selection overlays below are
+   anchored to each td instead of the row, like the keyboard-cursor styles above */
+tr.comment-selected td {
+  position: relative;
+}
+
+tr.comment-selected td::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-color: var(--color-diff-selected-bg);
+  pointer-events: none;
+}
+
+tr.comment-selected td:first-child::after {
+  border-left: 5px solid var(--color-diff-selected-border);
+}
+
+tr.drag-selected td {
+  position: relative;
+}
+
+/* Colors match the Tailwind blue-100 / blue-500 utilities used in split mode */
+tr.drag-selected td::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-color: #dbeafe;
+  opacity: 0.3;
+  border: 0 solid #3b82f6;
+  pointer-events: none;
+}
+
+tr.drag-selected td:first-child::after {
+  border-left-width: 4px;
+}
+
+tr.drag-selected-first td::after {
+  border-top-width: 2px;
+}
+
+tr.drag-selected-last td::after {
+  border-bottom-width: 2px;
+}
+
 /* Word highlighting styles */
 .word-token {
   cursor: pointer;


### PR DESCRIPTION
fix this issue:
- #415 
## Problem

In Safari (WebKit), selecting lines for a comment in unified mode renders the highlight overlay over the entire viewport instead of the selected rows. Each selected line adds another full-screen layer. (Video will be attached later)

Split mode and Chrome / Firefox are not affected.

## Cause

The selection classes (`after:absolute after:inset-0 ...`) were applied to the `<tr>`, relying on the row's `position: relative`. WebKit ignores `position: relative` on `<tr>`, so the overlay resolved against the app root and stretched over the whole screen.

## Fix

Move the overlay styles to `global.css` and anchor them to each `<td>`, following the same approach as the existing keyboard-cursor styles (`tr.keyboard-cursor td::before`).



https://github.com/user-attachments/assets/ec07c64d-7a6a-4c64-87e1-0fbbcd2131c0


https://github.com/user-attachments/assets/2c0988af-e119-4728-99d4-ca670fbcc97a

