### PR TITLE
fix: commit drag selection on mouse release anywhere, not only on the comment button

### DIFF
--- a/src/client/components/CommentButton.tsx
+++ b/src/client/components/CommentButton.tsx
@@ -3,12 +3,11 @@ import React from 'react';
 
 interface CommentButtonProps {
   onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => void;
-  onMouseUp: (e: React.MouseEvent<HTMLButtonElement>) => void;
   title?: string;
 }
 
 export const CommentButton: React.FC<CommentButtonProps> = React.memo(
-  ({ onMouseDown, onMouseUp, title = 'Add a comment' }) => {
+  ({ onMouseDown, title = 'Add a comment' }) => {
     return (
       <button
         className="absolute -right-2 top-1/2 -translate-y-1/2 w-7 h-7 flex items-center justify-center rounded transition-all duration-150 hover:scale-110 z-10"
@@ -27,7 +26,6 @@ export const CommentButton: React.FC<CommentButtonProps> = React.memo(
           e.currentTarget.style.borderColor = 'var(--color-yellow-btn-border)';
         }}
         onMouseDown={onMouseDown}
-        onMouseUp={onMouseUp}
         title={title}
       >
         <MessageSquare className="w-4 h-4" />

--- a/src/client/components/DiffChunk.tsx
+++ b/src/client/components/DiffChunk.tsx
@@ -48,7 +48,11 @@ interface DiffChunkProps {
     lineIndex: number,
     side: 'left' | 'right',
   ) => void;
-  commentTrigger?: { fileIndex: number; chunkIndex: number; lineIndex: number } | null;
+  commentTrigger?: {
+    fileIndex: number;
+    chunkIndex: number;
+    lineIndex: number;
+  } | null;
   onCommentTriggerHandled?: () => void;
   filename?: string;
   onOpenInEditor?: (filePath: string, lineNumber: number) => void;
@@ -77,6 +81,7 @@ export const DiffChunk = memo(function DiffChunk({
 }: DiffChunkProps) {
   const [startLine, setStartLine] = useState<number | null>(null);
   const [endLine, setEndLine] = useState<number | null>(null);
+  const [dragSide, setDragSide] = useState<DiffSide | null>(null);
   const [isDragging, setIsDragging] = useState(false);
   const [commentingLine, setCommentingLine] = useState<{
     side: DiffSide;
@@ -99,23 +104,6 @@ export const DiffChunk = memo(function DiffChunk({
     }
   }, [commentTrigger, chunk.lines, onCommentTriggerHandled]);
 
-  // Global mouse up handler for drag selection
-  useEffect(() => {
-    if (isDragging) {
-      const handleGlobalMouseUp = () => {
-        setIsDragging(false);
-        setStartLine(null);
-        setEndLine(null);
-      };
-
-      document.addEventListener('mouseup', handleGlobalMouseUp);
-      return () => {
-        document.removeEventListener('mouseup', handleGlobalMouseUp);
-      };
-    }
-    return undefined;
-  }, [isDragging]);
-
   const handleAddComment = useCallback(
     (side: DiffSide, lineNumber: LineNumber) => {
       if (commentingLine?.side === side && commentingLine?.lineNumber === lineNumber) {
@@ -126,6 +114,40 @@ export const DiffChunk = memo(function DiffChunk({
     },
     [commentingLine],
   );
+
+  // Global mouse up handler for drag selection: commit the selection wherever
+  // the mouse is released, not only on the comment button itself
+  useEffect(() => {
+    if (!isDragging) {
+      return undefined;
+    }
+
+    const handleGlobalMouseUp = () => {
+      // Defer so the click event fired after mouseup doesn't immediately
+      // close the newly opened (still empty) comment form
+      setTimeout(() => {
+        if (startLine && dragSide) {
+          const actualEndLine = endLine ?? startLine;
+          if (startLine === actualEndLine) {
+            handleAddComment(dragSide, startLine);
+          } else {
+            const min = Math.min(startLine, actualEndLine);
+            const max = Math.max(startLine, actualEndLine);
+            handleAddComment(dragSide, [min, max]);
+          }
+        }
+        setIsDragging(false);
+        setStartLine(null);
+        setEndLine(null);
+        setDragSide(null);
+      }, 0);
+    };
+
+    document.addEventListener('mouseup', handleGlobalMouseUp);
+    return () => {
+      document.removeEventListener('mouseup', handleGlobalMouseUp);
+    };
+  }, [isDragging, startLine, endLine, dragSide, handleAddComment]);
 
   const handleCancelComment = useCallback(() => {
     setCommentingLine(null);
@@ -377,32 +399,9 @@ export const DiffChunk = memo(function DiffChunk({
                     if (lineNumber) {
                       setStartLine(lineNumber);
                       setEndLine(lineNumber);
+                      setDragSide(line.type === 'delete' ? 'old' : 'new');
                       setIsDragging(true);
                     }
-                  }}
-                  onCommentButtonMouseUp={(e) => {
-                    e.stopPropagation();
-                    const lineNumber = line.newLineNumber || line.oldLineNumber;
-                    const side: DiffSide = line.type === 'delete' ? 'old' : 'new';
-                    if (!lineNumber || !startLine) {
-                      setIsDragging(false);
-                      setStartLine(null);
-                      setEndLine(null);
-                      return;
-                    }
-
-                    const actualEndLine = endLine || lineNumber;
-                    if (startLine === actualEndLine) {
-                      handleAddComment(side, lineNumber);
-                    } else {
-                      const min = Math.min(startLine, actualEndLine);
-                      const max = Math.max(startLine, actualEndLine);
-                      handleAddComment(side, [min, max]);
-                    }
-
-                    setIsDragging(false);
-                    setStartLine(null);
-                    setEndLine(null);
                   }}
                   onOpenInEditor={
                     onOpenInEditor &&

--- a/src/client/components/DiffLineRow.tsx
+++ b/src/client/components/DiffLineRow.tsx
@@ -19,7 +19,6 @@ interface DiffLineRowProps {
   onMouseLeave: () => void;
   onMouseMove: () => void;
   onCommentButtonMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => void;
-  onCommentButtonMouseUp: (e: React.MouseEvent<HTMLButtonElement>) => void;
   onOpenInEditor?: () => void;
   syntaxTheme?: AppearanceSettings['syntaxTheme'];
   onClick?: () => void;
@@ -54,7 +53,6 @@ export const DiffLineRow: React.FC<DiffLineRowProps> = React.memo(
     onMouseLeave,
     onMouseMove,
     onCommentButtonMouseDown,
-    onCommentButtonMouseUp,
     onOpenInEditor,
     syntaxTheme,
     onClick,
@@ -83,10 +81,7 @@ export const DiffLineRow: React.FC<DiffLineRowProps> = React.memo(
           {showLineActions && (
             <>
               {onOpenInEditor && <OpenInEditorButton onClick={onOpenInEditor} />}
-              <CommentButton
-                onMouseDown={onCommentButtonMouseDown}
-                onMouseUp={onCommentButtonMouseUp}
-              />
+              <CommentButton onMouseDown={onCommentButtonMouseDown} />
             </>
           )}
         </td>

--- a/src/client/components/SideBySideDiffChunk.tsx
+++ b/src/client/components/SideBySideDiffChunk.tsx
@@ -49,7 +49,11 @@ interface SideBySideDiffChunkProps {
     lineIndex: number,
     side: 'left' | 'right',
   ) => void;
-  commentTrigger?: { fileIndex: number; chunkIndex: number; lineIndex: number } | null;
+  commentTrigger?: {
+    fileIndex: number;
+    chunkIndex: number;
+    lineIndex: number;
+  } | null;
   onCommentTriggerHandled?: () => void;
   filename?: string;
   onOpenInEditor?: (filePath: string, lineNumber: number) => void;
@@ -131,23 +135,6 @@ export function SideBySideDiffChunk({
     }
   }, [commentTrigger, chunk.lines, onCommentTriggerHandled]);
 
-  // Global mouse up handler for drag selection
-  useEffect(() => {
-    if (isDragging) {
-      const handleGlobalMouseUp = () => {
-        setIsDragging(false);
-        setStartLine(null);
-        setEndLine(null);
-      };
-
-      document.addEventListener('mouseup', handleGlobalMouseUp);
-      return () => {
-        document.removeEventListener('mouseup', handleGlobalMouseUp);
-      };
-    }
-    return undefined;
-  }, [isDragging]);
-
   const handleAddComment = useCallback(
     (side: DiffSide, lineNumber: LineNumber) => {
       if (commentingLine?.side === side && commentingLine?.lineNumber === lineNumber) {
@@ -158,6 +145,40 @@ export function SideBySideDiffChunk({
     },
     [commentingLine],
   );
+
+  // Global mouse up handler for drag selection: commit the selection wherever
+  // the mouse is released, not only on the comment button itself
+  useEffect(() => {
+    if (!isDragging) {
+      return undefined;
+    }
+
+    const handleGlobalMouseUp = () => {
+      // Defer so the click event fired after mouseup doesn't immediately
+      // close the newly opened (still empty) comment form
+      setTimeout(() => {
+        if (startLine) {
+          const actualEndLine =
+            endLine && endLine.side === startLine.side ? endLine.lineNumber : startLine.lineNumber;
+          if (startLine.lineNumber === actualEndLine) {
+            handleAddComment(startLine.side, startLine.lineNumber);
+          } else {
+            const min = Math.min(startLine.lineNumber, actualEndLine);
+            const max = Math.max(startLine.lineNumber, actualEndLine);
+            handleAddComment(startLine.side, [min, max]);
+          }
+        }
+        setIsDragging(false);
+        setStartLine(null);
+        setEndLine(null);
+      }, 0);
+    };
+
+    document.addEventListener('mouseup', handleGlobalMouseUp);
+    return () => {
+      document.removeEventListener('mouseup', handleGlobalMouseUp);
+    };
+  }, [isDragging, startLine, endLine, handleAddComment]);
 
   const handleCancelComment = useCallback(() => {
     setCommentingLine(null);
@@ -454,9 +475,15 @@ export function SideBySideDiffChunk({
                       target.closest('td:nth-child(3)') || target.closest('td:nth-child(4)');
 
                     if (isInOldSide && sideLine.oldLineNumber) {
-                      setHoveredLine({ side: 'old', lineNumber: sideLine.oldLineNumber });
+                      setHoveredLine({
+                        side: 'old',
+                        lineNumber: sideLine.oldLineNumber,
+                      });
                     } else if (isInNewSide && sideLine.newLineNumber) {
-                      setHoveredLine({ side: 'new', lineNumber: sideLine.newLineNumber });
+                      setHoveredLine({
+                        side: 'new',
+                        lineNumber: sideLine.newLineNumber,
+                      });
                     }
                   }}
                   onMouseMove={(e) => {
@@ -473,23 +500,35 @@ export function SideBySideDiffChunk({
                         hoveredLine?.side !== 'old' ||
                         hoveredLine?.lineNumber !== sideLine.oldLineNumber
                       ) {
-                        setHoveredLine({ side: 'old', lineNumber: sideLine.oldLineNumber });
+                        setHoveredLine({
+                          side: 'old',
+                          lineNumber: sideLine.oldLineNumber,
+                        });
                       }
                     } else if (isInNewSide && sideLine.newLineNumber) {
                       if (
                         hoveredLine?.side !== 'new' ||
                         hoveredLine?.lineNumber !== sideLine.newLineNumber
                       ) {
-                        setHoveredLine({ side: 'new', lineNumber: sideLine.newLineNumber });
+                        setHoveredLine({
+                          side: 'new',
+                          lineNumber: sideLine.newLineNumber,
+                        });
                       }
                     }
 
                     // Handle dragging
                     if (isDragging && startLine) {
                       if (startLine.side === 'old' && sideLine.oldLineNumber) {
-                        setEndLine({ side: 'old', lineNumber: sideLine.oldLineNumber });
+                        setEndLine({
+                          side: 'old',
+                          lineNumber: sideLine.oldLineNumber,
+                        });
                       } else if (startLine.side === 'new' && sideLine.newLineNumber) {
-                        setEndLine({ side: 'new', lineNumber: sideLine.newLineNumber });
+                        setEndLine({
+                          side: 'new',
+                          lineNumber: sideLine.newLineNumber,
+                        });
                       }
                     }
                   }}
@@ -520,38 +559,16 @@ export function SideBySideDiffChunk({
                             onMouseDown={(e) => {
                               e.stopPropagation();
                               if (sideLine.oldLineNumber) {
-                                setStartLine({ side: 'old', lineNumber: sideLine.oldLineNumber });
-                                setEndLine({ side: 'old', lineNumber: sideLine.oldLineNumber });
+                                setStartLine({
+                                  side: 'old',
+                                  lineNumber: sideLine.oldLineNumber,
+                                });
+                                setEndLine({
+                                  side: 'old',
+                                  lineNumber: sideLine.oldLineNumber,
+                                });
                                 setIsDragging(true);
                               }
-                            }}
-                            onMouseUp={(e) => {
-                              e.stopPropagation();
-                              if (!sideLine.oldLineNumber || !startLine) {
-                                setIsDragging(false);
-                                setStartLine(null);
-                                setEndLine(null);
-                                return;
-                              }
-
-                              const actualEndLine =
-                                endLine && endLine.side === 'old'
-                                  ? endLine.lineNumber
-                                  : sideLine.oldLineNumber;
-                              if (
-                                startLine.side !== 'old' ||
-                                startLine.lineNumber === actualEndLine
-                              ) {
-                                handleAddComment('old', sideLine.oldLineNumber);
-                              } else {
-                                const min = Math.min(startLine.lineNumber, actualEndLine);
-                                const max = Math.max(startLine.lineNumber, actualEndLine);
-                                handleAddComment('old', [min, max]);
-                              }
-
-                              setIsDragging(false);
-                              setStartLine(null);
-                              setEndLine(null);
                             }}
                           />
                         </>
@@ -605,38 +622,16 @@ export function SideBySideDiffChunk({
                             onMouseDown={(e) => {
                               e.stopPropagation();
                               if (sideLine.newLineNumber) {
-                                setStartLine({ side: 'new', lineNumber: sideLine.newLineNumber });
-                                setEndLine({ side: 'new', lineNumber: sideLine.newLineNumber });
+                                setStartLine({
+                                  side: 'new',
+                                  lineNumber: sideLine.newLineNumber,
+                                });
+                                setEndLine({
+                                  side: 'new',
+                                  lineNumber: sideLine.newLineNumber,
+                                });
                                 setIsDragging(true);
                               }
-                            }}
-                            onMouseUp={(e) => {
-                              e.stopPropagation();
-                              if (!sideLine.newLineNumber || !startLine) {
-                                setIsDragging(false);
-                                setStartLine(null);
-                                setEndLine(null);
-                                return;
-                              }
-
-                              const actualEndLine =
-                                endLine && endLine.side === 'new'
-                                  ? endLine.lineNumber
-                                  : sideLine.newLineNumber;
-                              if (
-                                startLine.side !== 'new' ||
-                                startLine.lineNumber === actualEndLine
-                              ) {
-                                handleAddComment('new', sideLine.newLineNumber);
-                              } else {
-                                const min = Math.min(startLine.lineNumber, actualEndLine);
-                                const max = Math.max(startLine.lineNumber, actualEndLine);
-                                handleAddComment('new', [min, max]);
-                              }
-
-                              setIsDragging(false);
-                              setStartLine(null);
-                              setEndLine(null);
                             }}
                           />
                         </>


### PR DESCRIPTION
## Summary

Fixes #410

Dragging the comment button to select a range of lines only opened the comment form if the mouse was released while still over the button itself. The commit logic lived in the button's own `onMouseUp`, while the document-level `mouseup` listener simply discarded the selection.

This PR moves the selection-commit logic into the document-level `mouseup` handler, so releasing the mouse anywhere commits the selection and opens the comment form. Applied to both unified (`DiffChunk`) and side-by-side (`SideBySideDiffChunk`) views.

## Changes

- `DiffChunk.tsx`: commit the drag selection in the global `mouseup` handler. The selection side is now captured at drag start (`dragSide`) instead of being derived from the release line. The commit is deferred with `setTimeout(0)` so the `click` event fired right after `mouseup` doesn't immediately close the newly opened empty form (via `handleGlobalClick` in `App.tsx`).
- `SideBySideDiffChunk.tsx`: same change; `startLine` already carries the side.
- `CommentButton.tsx` / `DiffLineRow.tsx`: removed the now-unused `onMouseUp` prop.

## Testing

- Verified in the browser (Playwright) for both unified and split views:
  - drag from the comment button and release over the code area → form opens with the range selected
  - single click on the button still opens the form
- `pnpm run check`, `pnpm run format`, and the full test suite (679 passed) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)