### PR TITLE
feat(client): improve keyboard file navigation

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -543,38 +543,60 @@ function App() {
     handleCommentsChanged,
   );
 
-  const { cursor, isHelpOpen, setIsHelpOpen, setCursorPosition } = useKeyboardNavigation({
-    files: navigableFiles,
-    comments: normalizedThreads,
-    viewMode: diffMode,
-    reviewedFiles: viewedFiles,
-    onToggleReviewed: toggleFileReviewed,
-    onCreateComment: () => {
-      if (cursor) {
-        setCommentTrigger({
-          fileIndex: cursor.fileIndex,
-          chunkIndex: cursor.chunkIndex,
-          lineIndex: cursor.lineIndex,
-        });
+  // Track which file the mouse is over so `v` works without a cursor
+  const hoveredFileIndexRef = useRef<number | null>(null);
+  const getHoveredFileIndex = useCallback(() => hoveredFileIndexRef.current, []);
+
+  const { cursor, isHelpOpen, setIsHelpOpen, setCursorPosition, focusNextUnviewedFile } =
+    useKeyboardNavigation({
+      files: navigableFiles,
+      comments: normalizedThreads,
+      viewMode: diffMode,
+      reviewedFiles: viewedFiles,
+      onToggleReviewed: toggleFileReviewed,
+      getHoveredFileIndex,
+      onCreateComment: () => {
+        if (cursor) {
+          setCommentTrigger({
+            fileIndex: cursor.fileIndex,
+            chunkIndex: cursor.chunkIndex,
+            lineIndex: cursor.lineIndex,
+          });
+        }
+      },
+      onCopyAllComments: () => {
+        if (threads.length > 0) {
+          void handleCopyAllComments();
+        }
+      },
+      onDeleteAllComments: () => {
+        if (threads.length > 0 && confirm('Delete all comments?')) {
+          clearAllComments();
+        }
+      },
+      onShowCommentsList: () => {
+        setIsCommentsListOpen(true);
+      },
+      onRefresh: () => {
+        reload();
+      },
+    });
+
+  // Viewed button in the diff header: after marking a file as viewed, move
+  // keyboard focus to the next unviewed file so review can continue seamlessly
+  const handleViewedButtonToggle = useCallback(
+    (filePath: string) => {
+      const wasViewed = viewedFiles.has(filePath);
+      void toggleFileReviewed(filePath);
+      if (!wasViewed && diffData) {
+        const fileIndex = diffData.files.findIndex((f) => f.path === filePath);
+        if (fileIndex !== -1) {
+          focusNextUnviewedFile(fileIndex, { scroll: false });
+        }
       }
     },
-    onCopyAllComments: () => {
-      if (threads.length > 0) {
-        void handleCopyAllComments();
-      }
-    },
-    onDeleteAllComments: () => {
-      if (threads.length > 0 && confirm('Delete all comments?')) {
-        clearAllComments();
-      }
-    },
-    onShowCommentsList: () => {
-      setIsCommentsListOpen(true);
-    },
-    onRefresh: () => {
-      reload();
-    },
-  });
+    [viewedFiles, toggleFileReviewed, diffData, focusNextUnviewedFile],
+  );
 
   useEffect(() => {
     if (!diffData || !cursor) return;
@@ -1363,6 +1385,14 @@ function App() {
                   data-rendered={isRendered ? 'true' : 'false'}
                   ref={(node) => registerLazyFileContainer(file.path, node)}
                   className="mb-6"
+                  onMouseEnter={() => {
+                    hoveredFileIndexRef.current = fileIndex;
+                  }}
+                  onMouseLeave={() => {
+                    if (hoveredFileIndexRef.current === fileIndex) {
+                      hoveredFileIndexRef.current = null;
+                    }
+                  }}
                 >
                   {isRendered ? (
                     <DiffViewer
@@ -1372,7 +1402,7 @@ function App() {
                       diffMode={diffMode}
                       reviewedFiles={viewedFiles}
                       isChangedSinceViewed={changedSinceViewedFiles.has(file.path)}
-                      onToggleReviewed={toggleFileReviewed}
+                      onToggleReviewed={handleViewedButtonToggle}
                       collapsedFiles={collapsedFiles}
                       onToggleCollapsed={toggleFileCollapsed}
                       onToggleAllCollapsed={toggleAllFilesCollapsed}
@@ -1387,6 +1417,7 @@ function App() {
                       baseCommitish={diffData.baseCommitish}
                       targetCommitish={diffData.targetCommitish}
                       cursor={cursor?.fileIndex === fileIndex ? cursor : null}
+                      isFocused={cursor?.fileIndex === fileIndex}
                       fileIndex={fileIndex}
                       onLineClick={handleLineClick}
                       commentTrigger={

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -547,7 +547,7 @@ function App() {
   const hoveredFileIndexRef = useRef<number | null>(null);
   const getHoveredFileIndex = useCallback(() => hoveredFileIndexRef.current, []);
 
-  const { cursor, isHelpOpen, setIsHelpOpen, setCursorPosition, focusNextUnviewedFile } =
+  const { cursor, isHelpOpen, setIsHelpOpen, setCursorPosition, rememberFilePosition } =
     useKeyboardNavigation({
       files: navigableFiles,
       comments: normalizedThreads,
@@ -582,20 +582,20 @@ function App() {
       },
     });
 
-  // Viewed button in the diff header: after marking a file as viewed, move
-  // keyboard focus to the next unviewed file so review can continue seamlessly
+  // Viewed button in the diff header: silently remember the toggled file as
+  // the navigation position, so keyboard navigation resumes from it without
+  // showing any keyboard UI for a mouse interaction
   const handleViewedButtonToggle = useCallback(
     (filePath: string) => {
-      const wasViewed = viewedFiles.has(filePath);
       void toggleFileReviewed(filePath);
-      if (!wasViewed && diffData) {
+      if (diffData) {
         const fileIndex = diffData.files.findIndex((f) => f.path === filePath);
         if (fileIndex !== -1) {
-          focusNextUnviewedFile(fileIndex, { scroll: false });
+          rememberFilePosition(fileIndex);
         }
       }
     },
-    [viewedFiles, toggleFileReviewed, diffData, focusNextUnviewedFile],
+    [toggleFileReviewed, diffData, rememberFilePosition],
   );
 
   useEffect(() => {

--- a/src/client/components/DiffViewer.tsx
+++ b/src/client/components/DiffViewer.tsx
@@ -46,6 +46,7 @@ interface DiffViewerProps {
   baseCommitish?: string;
   targetCommitish?: string;
   cursor?: CursorPosition | null;
+  isFocused?: boolean;
   fileIndex?: number;
   mergedChunks: MergedChunk[];
   expandLines: (
@@ -67,7 +68,11 @@ interface DiffViewerProps {
     lineIndex: number,
     side: 'left' | 'right',
   ) => void;
-  commentTrigger?: { fileIndex: number; chunkIndex: number; lineIndex: number } | null;
+  commentTrigger?: {
+    fileIndex: number;
+    chunkIndex: number;
+    lineIndex: number;
+  } | null;
   onCommentTriggerHandled?: () => void;
   diffVersion?: number;
 }
@@ -192,6 +197,7 @@ export const DiffViewer = memo(function DiffViewer({
   baseCommitish,
   targetCommitish,
   cursor = null,
+  isFocused = false,
   fileIndex = 0,
   onLineClick,
   commentTrigger,
@@ -362,6 +368,7 @@ export const DiffViewer = memo(function DiffViewer({
       <DiffViewerHeader
         file={file}
         isCollapsed={isCollapsed}
+        isFocused={isFocused}
         isReviewed={reviewedFiles.has(file.path)}
         isChangedSinceViewed={isChangedSinceViewed}
         onToggleCollapsed={onToggleCollapsed}

--- a/src/client/components/DiffViewerHeader.tsx
+++ b/src/client/components/DiffViewerHeader.tsx
@@ -17,6 +17,7 @@ import { copyTextToClipboard } from '../utils/clipboard';
 interface DiffViewerHeaderProps {
   file: DiffFile;
   isCollapsed: boolean;
+  isFocused?: boolean;
   isReviewed: boolean;
   isChangedSinceViewed?: boolean;
   onToggleCollapsed: (path: string) => void;
@@ -40,6 +41,7 @@ const getFileIcon = (status: DiffFile['status']) => {
 export const DiffViewerHeader = ({
   file,
   isCollapsed,
+  isFocused = false,
   isReviewed,
   isChangedSinceViewed = false,
   onToggleCollapsed,
@@ -49,7 +51,11 @@ export const DiffViewerHeader = ({
   const [isCopied, setIsCopied] = useState(false);
 
   return (
-    <div className="bg-github-bg-secondary border-t-2 border-t-github-accent border-b border-github-border px-5 py-4 flex items-center justify-between flex-wrap gap-3 sticky top-0 z-10">
+    <div
+      className={`bg-github-bg-secondary border-t-2 border-t-github-accent border-b border-github-border px-5 py-4 flex items-center justify-between flex-wrap gap-3 sticky top-0 z-10 ${
+        isFocused ? 'keyboard-focused-file-header' : ''
+      }`}
+    >
       <div className="flex items-center gap-2 flex-1 min-w-0">
         <button
           onClick={(e) => {

--- a/src/client/components/HelpModal.tsx
+++ b/src/client/components/HelpModal.tsx
@@ -243,7 +243,21 @@ export function HelpModal({ isOpen, onClose }: HelpModalProps) {
                   v
                 </kbd>
                 <span className="text-github-text-secondary">
-                  Toggle viewed state of current file
+                  Toggle viewed state of current (or hovered) file
+                </span>
+              </div>
+              <div className="flex justify-between text-sm">
+                <div className="flex items-center gap-1">
+                  <kbd className="px-2 py-1 bg-github-bg-tertiary border border-github-border rounded text-github-text-primary font-mono">
+                    Shift
+                  </kbd>
+                  <span className="text-github-text-muted">+</span>
+                  <kbd className="px-2 py-1 bg-github-bg-tertiary border border-github-border rounded text-github-text-primary font-mono">
+                    V
+                  </kbd>
+                </div>
+                <span className="text-github-text-secondary">
+                  Mark file as viewed and go to next unviewed file
                 </span>
               </div>
               <div className="flex justify-between text-sm">

--- a/src/client/components/HelpModal.tsx
+++ b/src/client/components/HelpModal.tsx
@@ -246,7 +246,7 @@ export function HelpModal({ isOpen, onClose }: HelpModalProps) {
                   Toggle viewed state of current (or hovered) file
                 </span>
               </div>
-              <div className="flex justify-between text-sm">
+              <div className="flex justify-between gap-4 text-sm">
                 <div className="flex items-center gap-1">
                   <kbd className="px-2 py-1 bg-github-bg-tertiary border border-github-border rounded text-github-text-primary font-mono">
                     Shift
@@ -256,7 +256,7 @@ export function HelpModal({ isOpen, onClose }: HelpModalProps) {
                     V
                   </kbd>
                 </div>
-                <span className="text-github-text-secondary">
+                <span className="text-github-text-secondary text-right">
                   Mark file as viewed and go to next unviewed file
                 </span>
               </div>

--- a/src/client/hooks/keyboardNavigation/types.ts
+++ b/src/client/hooks/keyboardNavigation/types.ts
@@ -44,6 +44,7 @@ export interface UseKeyboardNavigationProps {
   onShowCommentsList?: () => void;
   onRefresh?: () => void;
   isModalOpen?: boolean;
+  getHoveredFileIndex?: () => number | null;
 }
 
 /**
@@ -54,6 +55,7 @@ export interface UseKeyboardNavigationReturn {
   isHelpOpen: boolean;
   setIsHelpOpen: (open: boolean) => void;
   setCursorPosition: (position: CursorPosition | null) => void;
+  focusNextUnviewedFile: (afterIndex: number, options?: { scroll?: boolean }) => void;
 }
 
 /**

--- a/src/client/hooks/keyboardNavigation/types.ts
+++ b/src/client/hooks/keyboardNavigation/types.ts
@@ -55,7 +55,7 @@ export interface UseKeyboardNavigationReturn {
   isHelpOpen: boolean;
   setIsHelpOpen: (open: boolean) => void;
   setCursorPosition: (position: CursorPosition | null) => void;
-  focusNextUnviewedFile: (afterIndex: number, options?: { scroll?: boolean }) => void;
+  rememberFilePosition: (fileIndex: number) => void;
 }
 
 /**

--- a/src/client/hooks/useKeyboardNavigation.test.tsx
+++ b/src/client/hooks/useKeyboardNavigation.test.tsx
@@ -821,7 +821,9 @@ describe('useKeyboardNavigation', () => {
       expect(result.current.cursor?.fileIndex).toBe(1);
     });
 
-    it('should move cursor to next unviewed file with focusNextUnviewedFile', () => {
+    it('should remember a file position without showing the cursor', async () => {
+      const user = userEvent.setup();
+
       const { result } = renderHook(
         () =>
           useKeyboardNavigation({
@@ -835,12 +837,15 @@ describe('useKeyboardNavigation', () => {
       );
 
       act(() => {
-        result.current.focusNextUnviewedFile(0, { scroll: false });
+        result.current.rememberFilePosition(0);
       });
 
+      // No visible cursor appears for a mouse interaction
+      expect(result.current.cursor).toBeNull();
+
+      // But keyboard navigation resumes from the remembered file
+      await user.keyboard('{\\]}');
       expect(result.current.cursor?.fileIndex).toBe(1);
-      expect(result.current.cursor?.chunkIndex).toBe(0);
-      expect(result.current.cursor?.lineIndex).toBe(0);
     });
   });
 

--- a/src/client/hooks/useKeyboardNavigation.test.tsx
+++ b/src/client/hooks/useKeyboardNavigation.test.tsx
@@ -73,8 +73,18 @@ const mockFiles: DiffFile[] = [
         lines: [
           { type: 'delete', oldLineNumber: 1, content: '- old line' },
           { type: 'add', newLineNumber: 1, content: '+ new line' },
-          { type: 'normal', oldLineNumber: 2, newLineNumber: 2, content: '  unchanged' },
-          { type: 'normal', oldLineNumber: 3, newLineNumber: 3, content: '  another unchanged' },
+          {
+            type: 'normal',
+            oldLineNumber: 2,
+            newLineNumber: 2,
+            content: '  unchanged',
+          },
+          {
+            type: 'normal',
+            oldLineNumber: 3,
+            newLineNumber: 3,
+            content: '  another unchanged',
+          },
         ],
         header: '@@ -1,3 +1,4 @@',
       },
@@ -92,7 +102,12 @@ const mockFiles: DiffFile[] = [
         newStart: 1,
         newLines: 2,
         lines: [
-          { type: 'normal', oldLineNumber: 1, newLineNumber: 1, content: '  first line' },
+          {
+            type: 'normal',
+            oldLineNumber: 1,
+            newLineNumber: 1,
+            content: '  first line',
+          },
           { type: 'add', newLineNumber: 2, content: '+ added line' },
         ],
         header: '@@ -1,2 +1,2 @@',
@@ -599,6 +614,59 @@ describe('useKeyboardNavigation', () => {
       expect(onToggleReviewed).toHaveBeenCalledWith('file1.js');
     });
 
+    it('should toggle reviewed state of hovered file when there is no cursor', async () => {
+      const user = userEvent.setup();
+      const onToggleReviewed = vi.fn();
+
+      renderHook(
+        () =>
+          useKeyboardNavigation({
+            files: mockFiles,
+            comments: [],
+            viewMode: 'unified',
+            onToggleReviewed,
+            reviewedFiles: new Set<string>(),
+            getHoveredFileIndex: () => 1,
+          }),
+        { wrapper },
+      );
+
+      await user.keyboard('v');
+
+      expect(onToggleReviewed).toHaveBeenCalledWith('file2.js');
+    });
+
+    it('should prefer cursor file over hovered file', async () => {
+      const user = userEvent.setup();
+      const onToggleReviewed = vi.fn();
+
+      const { result } = renderHook(
+        () =>
+          useKeyboardNavigation({
+            files: mockFiles,
+            comments: [],
+            viewMode: 'unified',
+            onToggleReviewed,
+            reviewedFiles: new Set<string>(),
+            getHoveredFileIndex: () => 1,
+          }),
+        { wrapper },
+      );
+
+      act(() => {
+        result.current.setCursorPosition({
+          fileIndex: 0,
+          chunkIndex: 0,
+          lineIndex: 0,
+          side: 'left',
+        });
+      });
+
+      await user.keyboard('v');
+
+      expect(onToggleReviewed).toHaveBeenCalledWith('file1.js');
+    });
+
     it('should not toggle reviewed state when no file is selected', async () => {
       const user = userEvent.setup();
       const onToggleReviewed = vi.fn();
@@ -618,6 +686,161 @@ describe('useKeyboardNavigation', () => {
       await user.keyboard('v');
 
       expect(onToggleReviewed).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Mark Viewed and Advance (Shift+V)', () => {
+    it('should mark current file as viewed and move cursor to next unviewed file', async () => {
+      const user = userEvent.setup();
+      const onToggleReviewed = vi.fn();
+
+      const { result } = renderHook(
+        () =>
+          useKeyboardNavigation({
+            files: mockFiles,
+            comments: [],
+            viewMode: 'unified',
+            onToggleReviewed,
+            reviewedFiles: new Set<string>(),
+          }),
+        { wrapper },
+      );
+
+      act(() => {
+        result.current.setCursorPosition({
+          fileIndex: 0,
+          chunkIndex: 0,
+          lineIndex: 0,
+          side: 'left',
+        });
+      });
+
+      await user.keyboard('{Shift>}v{/Shift}');
+
+      expect(onToggleReviewed).toHaveBeenCalledWith('file1.js');
+      expect(result.current.cursor?.fileIndex).toBe(1);
+    });
+
+    it('should not mark again when the current file is already viewed', async () => {
+      const user = userEvent.setup();
+      const onToggleReviewed = vi.fn();
+
+      const { result } = renderHook(
+        () =>
+          useKeyboardNavigation({
+            files: mockFiles,
+            comments: [],
+            viewMode: 'unified',
+            onToggleReviewed,
+            reviewedFiles: new Set<string>(['file1.js']),
+          }),
+        { wrapper },
+      );
+
+      act(() => {
+        result.current.setCursorPosition({
+          fileIndex: 0,
+          chunkIndex: 0,
+          lineIndex: 0,
+          side: 'left',
+        });
+      });
+
+      await user.keyboard('{Shift>}v{/Shift}');
+
+      expect(onToggleReviewed).not.toHaveBeenCalled();
+      expect(result.current.cursor?.fileIndex).toBe(1);
+    });
+
+    it('should keep cursor when all other files are already viewed', async () => {
+      const user = userEvent.setup();
+      const onToggleReviewed = vi.fn();
+
+      const { result } = renderHook(
+        () =>
+          useKeyboardNavigation({
+            files: mockFiles,
+            comments: [],
+            viewMode: 'unified',
+            onToggleReviewed,
+            reviewedFiles: new Set<string>(['file2.js']),
+          }),
+        { wrapper },
+      );
+
+      act(() => {
+        result.current.setCursorPosition({
+          fileIndex: 0,
+          chunkIndex: 0,
+          lineIndex: 0,
+          side: 'left',
+        });
+      });
+
+      await user.keyboard('{Shift>}v{/Shift}');
+
+      expect(onToggleReviewed).toHaveBeenCalledWith('file1.js');
+      expect(result.current.cursor?.fileIndex).toBe(0);
+    });
+  });
+
+  describe('Cursor Memory', () => {
+    it('should resume file navigation from the last cursor after it is cleared', async () => {
+      const user = userEvent.setup();
+
+      const { result } = renderHook(
+        () =>
+          useKeyboardNavigation({
+            files: mockFiles,
+            comments: [],
+            viewMode: 'unified',
+            onToggleReviewed: vi.fn(),
+            reviewedFiles: new Set<string>(),
+          }),
+        { wrapper },
+      );
+
+      // Navigate to a position, then clear the cursor (as a mouse click does)
+      act(() => {
+        result.current.setCursorPosition({
+          fileIndex: 0,
+          chunkIndex: 0,
+          lineIndex: 2,
+          side: 'right',
+        });
+      });
+      act(() => {
+        result.current.setCursorPosition(null);
+      });
+
+      expect(result.current.cursor).toBeNull();
+
+      await user.keyboard('{\\]}');
+
+      // Should move to the file after the remembered position, not wrap to the end
+      expect(result.current.cursor?.fileIndex).toBe(1);
+    });
+
+    it('should move cursor to next unviewed file with focusNextUnviewedFile', () => {
+      const { result } = renderHook(
+        () =>
+          useKeyboardNavigation({
+            files: mockFiles,
+            comments: [],
+            viewMode: 'unified',
+            onToggleReviewed: vi.fn(),
+            reviewedFiles: new Set<string>(),
+          }),
+        { wrapper },
+      );
+
+      act(() => {
+        result.current.focusNextUnviewedFile(0, { scroll: false });
+      });
+
+      expect(result.current.cursor?.fileIndex).toBe(1);
+      expect(result.current.cursor?.chunkIndex).toBe(0);
+      expect(result.current.cursor?.lineIndex).toBe(0);
     });
   });
 

--- a/src/client/hooks/useKeyboardNavigation.ts
+++ b/src/client/hooks/useKeyboardNavigation.ts
@@ -421,7 +421,7 @@ export function useKeyboardNavigation({
   // Move the cursor to the first unviewed file after the given index,
   // wrapping around but never landing back on the starting file
   const focusNextUnviewedFile = useCallback(
-    (afterIndex: number, options?: { scroll?: boolean }) => {
+    (afterIndex: number) => {
       const totalFiles = files.length;
       for (let offset = 1; offset < totalFiles; offset++) {
         const fileIndex = (afterIndex + offset) % totalFiles;
@@ -439,13 +439,33 @@ export function useKeyboardNavigation({
           files,
         );
         setCursor(position);
-        if (options?.scroll !== false) {
-          scrollToElement(getElementId(position, viewMode));
-        }
+        scrollToElement(getElementId(position, viewMode));
         return;
       }
     },
     [files, reviewedFiles, viewMode, scrollToElement],
+  );
+
+  // Update only the remembered navigation position, without showing the
+  // keyboard cursor. Used by mouse interactions (e.g. the Viewed button) so
+  // keyboard navigation resumes from that file while mouse-only usage never
+  // surfaces keyboard UI.
+  const rememberFilePosition = useCallback(
+    (fileIndex: number) => {
+      const file = files[fileIndex];
+      if (!file || !file.chunks[0]?.lines[0]) return;
+
+      lastCursorRef.current = fixSide(
+        {
+          fileIndex,
+          chunkIndex: 0,
+          lineIndex: 0,
+          side: viewMode === 'split' ? 'left' : 'right',
+        },
+        files,
+      );
+    },
+    [files, viewMode],
   );
 
   // File review toggle - targets the cursor file, or the hovered file when
@@ -575,6 +595,6 @@ export function useKeyboardNavigation({
     isHelpOpen,
     setIsHelpOpen,
     setCursorPosition,
-    focusNextUnviewedFile,
+    rememberFilePosition,
   };
 }

--- a/src/client/hooks/useKeyboardNavigation.ts
+++ b/src/client/hooks/useKeyboardNavigation.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 
 import { DEFAULT_DIFF_VIEW_MODE } from '../../utils/diffMode';
@@ -34,9 +34,19 @@ export function useKeyboardNavigation({
   onDeleteAllComments,
   onShowCommentsList,
   onRefresh,
+  getHoveredFileIndex,
 }: UseKeyboardNavigationProps): UseKeyboardNavigationReturn {
   const [cursor, setCursor] = useState<CursorPosition | null>(null);
   const [isHelpOpen, setIsHelpOpen] = useState(false);
+
+  // Remember the last cursor so navigation resumes from it after the cursor
+  // is cleared (e.g. by a mouse click) instead of restarting from the top
+  const lastCursorRef = useRef<CursorPosition | null>(null);
+  useEffect(() => {
+    if (cursor) {
+      lastCursorRef.current = cursor;
+    }
+  }, [cursor]);
 
   // Create scroll function
   const scrollToElement = useMemo(() => createScrollToElement(), []);
@@ -68,7 +78,7 @@ export function useKeyboardNavigation({
         return { position: null, scrollTarget: null };
       }
 
-      const startPosition = getStartPosition(cursor);
+      const startPosition = getStartPosition(cursor ?? lastCursorRef.current);
       return findNextMatchingPosition(startPosition, direction, filter, files, viewMode);
     },
     [cursor, files, viewMode],
@@ -188,7 +198,11 @@ export function useKeyboardNavigation({
             const chunk = file.chunks[chunkIdx];
             if (!chunk) continue;
             for (let lineIdx = 0; lineIdx < chunk.lines.length; lineIdx++) {
-              const testPos = { ...newCursor, chunkIndex: chunkIdx, lineIndex: lineIdx };
+              const testPos = {
+                ...newCursor,
+                chunkIndex: chunkIdx,
+                lineIndex: lineIdx,
+              };
               if (hasContentOnSide(testPos, files)) {
                 newCursor = testPos;
                 break;
@@ -203,7 +217,11 @@ export function useKeyboardNavigation({
               const chunk = file.chunks[chunkIdx];
               if (!chunk) continue;
               for (let lineIdx = chunk.lines.length - 1; lineIdx >= 0; lineIdx--) {
-                const testPos = { ...newCursor, chunkIndex: chunkIdx, lineIndex: lineIdx };
+                const testPos = {
+                  ...newCursor,
+                  chunkIndex: chunkIdx,
+                  lineIndex: lineIdx,
+                };
                 if (hasContentOnSide(testPos, files)) {
                   newCursor = testPos;
                   break;
@@ -245,7 +263,12 @@ export function useKeyboardNavigation({
           const sides = viewMode === 'split' ? (['left', 'right'] as const) : (['right'] as const);
 
           for (const side of sides) {
-            const position: CursorPosition = { fileIndex, chunkIndex, lineIndex, side };
+            const position: CursorPosition = {
+              fileIndex,
+              chunkIndex,
+              lineIndex,
+              side,
+            };
 
             // Skip positions without content in split mode
             if (viewMode === 'split' && !hasContentOnSide(position, files)) {
@@ -395,19 +418,70 @@ export function useKeyboardNavigation({
     [switchSide, viewMode],
   );
 
-  // File review toggle
+  // Move the cursor to the first unviewed file after the given index,
+  // wrapping around but never landing back on the starting file
+  const focusNextUnviewedFile = useCallback(
+    (afterIndex: number, options?: { scroll?: boolean }) => {
+      const totalFiles = files.length;
+      for (let offset = 1; offset < totalFiles; offset++) {
+        const fileIndex = (afterIndex + offset) % totalFiles;
+        const file = files[fileIndex];
+        if (!file || !file.chunks[0]?.lines[0]) continue;
+        if (reviewedFiles.has(file.path)) continue;
+
+        const position = fixSide(
+          {
+            fileIndex,
+            chunkIndex: 0,
+            lineIndex: 0,
+            side: viewMode === 'split' ? 'left' : 'right',
+          },
+          files,
+        );
+        setCursor(position);
+        if (options?.scroll !== false) {
+          scrollToElement(getElementId(position, viewMode));
+        }
+        return;
+      }
+    },
+    [files, reviewedFiles, viewMode, scrollToElement],
+  );
+
+  // File review toggle - targets the cursor file, or the hovered file when
+  // there is no cursor (e.g. after a mouse click cleared it)
   useHotkeys(
     'v',
     () => {
-      if (cursor) {
-        const file = files[cursor.fileIndex];
+      const fileIndex = cursor?.fileIndex ?? getHoveredFileIndex?.() ?? null;
+      if (fileIndex !== null) {
+        const file = files[fileIndex];
         if (file) {
           onToggleReviewed(file.path);
         }
       }
     },
     hotkeyOptions,
-    [cursor, files, onToggleReviewed],
+    [cursor, files, onToggleReviewed, getHoveredFileIndex],
+  );
+
+  // Mark current file as viewed (collapse) and move to the next unviewed file
+  useHotkeys(
+    'shift+v',
+    () => {
+      const fileIndex =
+        cursor?.fileIndex ?? getHoveredFileIndex?.() ?? lastCursorRef.current?.fileIndex ?? null;
+      if (fileIndex === null) return;
+      const file = files[fileIndex];
+      if (!file) return;
+
+      if (!reviewedFiles.has(file.path)) {
+        onToggleReviewed(file.path);
+      }
+      focusNextUnviewedFile(fileIndex);
+    },
+    hotkeyOptions,
+    [cursor, files, reviewedFiles, onToggleReviewed, getHoveredFileIndex, focusNextUnviewedFile],
   );
 
   // Refresh
@@ -501,5 +575,6 @@ export function useKeyboardNavigation({
     isHelpOpen,
     setIsHelpOpen,
     setCursorPosition,
+    focusNextUnviewedFile,
   };
 }

--- a/src/client/styles/global.css
+++ b/src/client/styles/global.css
@@ -145,9 +145,12 @@ tr.keyboard-cursor td:not(:first-child):not(:last-child)::before {
    the file that currently holds the cursor, so the focused file stays visible
    even when its diff is collapsed */
 .keyboard-focused-file-header {
+  /* #3fb950: brighter green than --color-github-accent so the focused header
+     stands out from the accent-colored top border every file header has */
+  background-image: linear-gradient(rgba(63, 185, 80, 0.1), rgba(63, 185, 80, 0.1));
   box-shadow:
-    inset 3px 0 0 0 rgba(255, 253, 84, 0.7),
-    inset 0 0 0 1px rgba(255, 253, 84, 0.35);
+    inset 3px 0 0 0 #3fb950,
+    inset 0 0 0 1px rgba(63, 185, 80, 0.45);
 }
 
 /* Keyboard navigation cursor styles for split mode (td level) */

--- a/src/client/styles/global.css
+++ b/src/client/styles/global.css
@@ -141,6 +141,15 @@ tr.keyboard-cursor td:not(:first-child):not(:last-child)::before {
     inset 0 -1px 0 0 rgba(255, 253, 84, 0.4);
 }
 
+/* Focused-file indicator for keyboard navigation: highlights the header of
+   the file that currently holds the cursor, so the focused file stays visible
+   even when its diff is collapsed */
+.keyboard-focused-file-header {
+  box-shadow:
+    inset 3px 0 0 0 rgba(255, 253, 84, 0.7),
+    inset 0 0 0 1px rgba(255, 253, 84, 0.35);
+}
+
 /* Keyboard navigation cursor styles for split mode (td level) */
 td.keyboard-cursor {
   position: relative;


### PR DESCRIPTION
Addresses all five suggestions from #378.

## What changed

1. **Focused-file indicator** — the header of the file holding the cursor now gets a green highlight (3px left bar + subtle ring/tint in `#3fb950`, brighter than the accent top border every header has). Since the header always renders, the focused file stays visible even when its diff is collapsed.
2. **Navigation resumes after a click** — clicking anywhere used to clear the cursor, so the next `[` / `]` wrapped to the end/start of the file list. The last cursor position is now remembered (`lastCursorRef`) and navigation resumes from it. The visual cursor still clears on click as before.
3. **`Shift+V`** — marks the current file as viewed (collapsing it) and moves the cursor to the next unviewed file. If the file is already viewed, it just moves on. Added to the help modal.
4. **Viewed button keeps your place** — clicking the Viewed button silently remembers that file as the navigation position (no keyboard UI appears for a mouse interaction), so a subsequent `]` / `j` / `n` resumes from there instead of losing focus.
5. **`v` works on hover** — when there is no cursor (e.g. after a mouse click cleared it), `v` toggles the hovered file. An active keyboard cursor still takes priority, so keyboard users aren't affected by wherever the mouse happens to rest.

## Notes for review

- `focusNextUnviewedFile` (used by `Shift+V`) skips viewed files, wraps around, and never lands back on the starting file.
- The Viewed-button flow deliberately does not scroll or show the cursor, so it doesn't interfere with the collapse scroll-anchoring behavior from #164 / #402.
- Hover tracking uses a ref (`hoveredFileIndexRef`) via mouse enter/leave on each file container — no extra re-renders.
- New unit tests cover cursor memory, `Shift+V` (including already-viewed and no-remaining-files cases), hover-`v`, cursor priority, and `rememberFilePosition`.

Closes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)