### PR TITLE
feat: add ability to mark an entire folder as reviewed from the file tree

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -299,6 +299,7 @@ function App() {
     changedSinceViewedFiles,
     hasLoadedInitialViewedFiles,
     toggleFileViewed,
+    setFilesViewed,
     clearViewedFiles,
   } = useViewedFiles(
     resolvedSelection?.baseCommitish,
@@ -377,6 +378,31 @@ function App() {
       toggleFileViewed,
       viewedFiles,
     ],
+  );
+
+  const toggleFolderReviewed = useCallback(
+    async (folderPath: string, reviewed: boolean) => {
+      if (!diffData) return;
+
+      const folderFiles = diffData.files.filter((file) => file.path.startsWith(`${folderPath}/`));
+      if (folderFiles.length === 0) return;
+
+      await setFilesViewed(folderFiles, reviewed);
+
+      // Keep the collapse state of every file in the folder in sync with its viewed state
+      setCollapsedFiles((prev) => {
+        const newSet = new Set(prev);
+        folderFiles.forEach((file) => {
+          if (reviewed) {
+            newSet.add(file.path);
+          } else {
+            newSet.delete(file.path);
+          }
+        });
+        return newSet;
+      });
+    },
+    [diffData, setFilesViewed],
   );
 
   const toggleFileCollapsed = useCallback((filePath: string) => {
@@ -1306,6 +1332,7 @@ function App() {
                   comments={normalizedThreads}
                   reviewedFiles={viewedFiles}
                   onToggleReviewed={toggleFileReviewed}
+                  onToggleFolderReviewed={toggleFolderReviewed}
                   selectedFileIndex={cursor?.fileIndex ?? null}
                 />
               </div>

--- a/src/client/components/FileList.test.tsx
+++ b/src/client/components/FileList.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import '@testing-library/jest-dom';
 
@@ -39,6 +39,7 @@ describe('FileList', () => {
         comments={[]}
         reviewedFiles={new Set()}
         onToggleReviewed={vi.fn()}
+        onToggleFolderReviewed={vi.fn()}
         selectedFileIndex={null}
       />,
     );
@@ -60,6 +61,7 @@ describe('FileList', () => {
       onScrollToFile: vi.fn(),
       comments: [],
       onToggleReviewed: vi.fn(),
+      onToggleFolderReviewed: vi.fn(),
       selectedFileIndex: null,
     };
     const { rerender } = render(
@@ -86,5 +88,51 @@ describe('FileList', () => {
     expect(getTreeRow('cli')).toHaveClass('opacity-70');
     expect(getLabel('client')).toHaveClass('line-through');
     expect(getTreeRow('client')).toHaveClass('opacity-70');
+  });
+
+  it('marks all files in a folder as reviewed via the directory checkbox', () => {
+    const onToggleFolderReviewed = vi.fn();
+    render(
+      <FileList
+        files={[
+          createFile('src/cli/index.ts'),
+          createFile('src/client/App.tsx'),
+          createFile('README.md'),
+        ]}
+        onScrollToFile={vi.fn()}
+        comments={[]}
+        reviewedFiles={new Set()}
+        onToggleReviewed={vi.fn()}
+        onToggleFolderReviewed={onToggleFolderReviewed}
+        selectedFileIndex={null}
+      />,
+    );
+
+    const checkbox = within(getTreeRow('src')).getByRole('checkbox');
+    expect(checkbox).toHaveAttribute('aria-checked', 'false');
+
+    fireEvent.click(checkbox);
+    expect(onToggleFolderReviewed).toHaveBeenCalledWith('src', true);
+  });
+
+  it('unmarks all files in a fully reviewed folder via the directory checkbox', () => {
+    const onToggleFolderReviewed = vi.fn();
+    render(
+      <FileList
+        files={[createFile('src/cli/index.ts'), createFile('src/client/App.tsx')]}
+        onScrollToFile={vi.fn()}
+        comments={[]}
+        reviewedFiles={new Set(['src/cli/index.ts', 'src/client/App.tsx'])}
+        onToggleReviewed={vi.fn()}
+        onToggleFolderReviewed={onToggleFolderReviewed}
+        selectedFileIndex={null}
+      />,
+    );
+
+    const checkbox = within(getTreeRow('src')).getByRole('checkbox');
+    expect(checkbox).toHaveAttribute('aria-checked', 'true');
+
+    fireEvent.click(checkbox);
+    expect(onToggleFolderReviewed).toHaveBeenCalledWith('src', false);
   });
 });

--- a/src/client/components/FileList.tsx
+++ b/src/client/components/FileList.tsx
@@ -369,7 +369,7 @@ export const FileList = memo(function FileList({
                   <Folder size={16} className="text-github-text-secondary" />
                 )}
               </span>
-              <span className="hidden items-center group-hover:flex">
+              <span className="hidden items-center pl-[2px] group-hover:flex">
                 <Checkbox
                   checked={isReviewed}
                   onChange={() => {

--- a/src/client/components/FileList.tsx
+++ b/src/client/components/FileList.tsx
@@ -26,6 +26,7 @@ interface FileListProps {
   comments: CommentThread[];
   reviewedFiles: Set<string>;
   onToggleReviewed: (path: string) => void;
+  onToggleFolderReviewed: (path: string, reviewed: boolean) => void;
   selectedFileIndex: number | null;
 }
 
@@ -159,6 +160,7 @@ export const FileList = memo(function FileList({
   comments,
   reviewedFiles,
   onToggleReviewed,
+  onToggleFolderReviewed,
   selectedFileIndex,
 }: FileListProps) {
   const fileTree = useMemo(() => buildFileTree(files), [files]);
@@ -360,6 +362,14 @@ export const FileList = memo(function FileList({
               onClick={(event) => handleDirectoryClick(event, node.path)}
             >
               {isExpanded ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+              <Checkbox
+                checked={isReviewed}
+                onChange={() => {
+                  onToggleFolderReviewed(node.path, !isReviewed);
+                }}
+                title={isReviewed ? 'Mark all files as not reviewed' : 'Mark all files as reviewed'}
+                className="z-10"
+              />
               {isExpanded ? (
                 <FolderOpen size={16} className="text-github-text-secondary" />
               ) : (

--- a/src/client/components/FileList.tsx
+++ b/src/client/components/FileList.tsx
@@ -346,7 +346,7 @@ export const FileList = memo(function FileList({
         >
           {node.name && (
             <div
-              className={`${shouldUseStickyDirectoryHeaders ? 'sticky ' : ''}flex h-9 items-center gap-2 bg-github-bg-secondary px-4 hover:bg-github-bg-tertiary cursor-pointer ${
+              className={`${shouldUseStickyDirectoryHeaders ? 'sticky ' : ''}group flex h-9 items-center gap-2 bg-github-bg-secondary px-4 hover:bg-github-bg-tertiary cursor-pointer ${
                 isReviewed ? 'opacity-70' : ''
               }`}
               data-dir-header="true"
@@ -362,19 +362,25 @@ export const FileList = memo(function FileList({
               onClick={(event) => handleDirectoryClick(event, node.path)}
             >
               {isExpanded ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
-              <Checkbox
-                checked={isReviewed}
-                onChange={() => {
-                  onToggleFolderReviewed(node.path, !isReviewed);
-                }}
-                title={isReviewed ? 'Mark all files as not reviewed' : 'Mark all files as reviewed'}
-                className="z-10"
-              />
-              {isExpanded ? (
-                <FolderOpen size={16} className="text-github-text-secondary" />
-              ) : (
-                <Folder size={16} className="text-github-text-secondary" />
-              )}
+              <span className="flex items-center group-hover:hidden">
+                {isExpanded ? (
+                  <FolderOpen size={16} className="text-github-text-secondary" />
+                ) : (
+                  <Folder size={16} className="text-github-text-secondary" />
+                )}
+              </span>
+              <span className="hidden items-center group-hover:flex">
+                <Checkbox
+                  checked={isReviewed}
+                  onChange={() => {
+                    onToggleFolderReviewed(node.path, !isReviewed);
+                  }}
+                  title={
+                    isReviewed ? 'Mark all files as not reviewed' : 'Mark all files as reviewed'
+                  }
+                  className="z-10"
+                />
+              </span>
               <span
                 className={`text-sm text-github-text-primary font-medium flex-1 overflow-hidden text-ellipsis whitespace-nowrap ${
                   isReviewed ? 'line-through text-github-text-muted' : ''

--- a/src/client/hooks/useViewedFiles.test.ts
+++ b/src/client/hooks/useViewedFiles.test.ts
@@ -261,6 +261,112 @@ describe('useViewedFiles', () => {
     });
   });
 
+  describe('setFilesViewed', () => {
+    it('marks multiple files as viewed at once', async () => {
+      const files = [createMockDiffFile('src/dir/a.ts'), createMockDiffFile('src/dir/b.ts')];
+      const { result } = renderHook(() =>
+        useViewedFiles('main', 'feature-branch', 'abc', undefined, files, 'repo-1'),
+      );
+
+      await waitFor(() => {
+        expect(result.current.hasLoadedInitialViewedFiles).toBe(true);
+      });
+
+      await act(async () => {
+        await result.current.setFilesViewed(files, true);
+      });
+
+      expect(result.current.viewedFiles.has('src/dir/a.ts')).toBe(true);
+      expect(result.current.viewedFiles.has('src/dir/b.ts')).toBe(true);
+      expect(mockRecordViewedHashes).toHaveBeenCalledTimes(1);
+      const entries = mockRecordViewedHashes.mock.calls[0]![1];
+      expect(entries).toHaveLength(2);
+    });
+
+    it('skips files that are already viewed when marking', async () => {
+      const files = [createMockDiffFile('src/dir/a.ts'), createMockDiffFile('src/dir/b.ts')];
+      mockGetViewedFiles.mockReturnValue([
+        {
+          filePath: 'src/dir/a.ts',
+          viewedAt: '2024-01-01T00:00:00Z',
+          diffContentHash: 'existing-hash',
+        },
+      ]);
+      const { result } = renderHook(() =>
+        useViewedFiles('main', 'feature-branch', 'abc', undefined, files, 'repo-1'),
+      );
+
+      await waitFor(() => {
+        expect(result.current.hasLoadedInitialViewedFiles).toBe(true);
+      });
+
+      await act(async () => {
+        await result.current.setFilesViewed(files, true);
+      });
+
+      expect(result.current.viewedFiles.size).toBe(2);
+      expect(mockRecordViewedHashes).toHaveBeenCalledTimes(1);
+      const entries = mockRecordViewedHashes.mock.calls[0]![1];
+      expect(entries).toHaveLength(1);
+      expect(entries[0]!.filePath).toBe('src/dir/b.ts');
+      // The already viewed file keeps its original record
+      expect(result.current.getViewedFileRecord('src/dir/a.ts')?.diffContentHash).toBe(
+        'existing-hash',
+      );
+    });
+
+    it('unmarks multiple files at once and removes their index entries', async () => {
+      const files = [createMockDiffFile('src/dir/a.ts'), createMockDiffFile('src/dir/b.ts')];
+      mockGetViewedFiles.mockReturnValue([
+        {
+          filePath: 'src/dir/a.ts',
+          viewedAt: '2024-01-01T00:00:00Z',
+          diffContentHash: 'hash-a',
+        },
+        {
+          filePath: 'src/dir/b.ts',
+          viewedAt: '2024-01-01T00:00:00Z',
+          diffContentHash: 'hash-b',
+        },
+      ]);
+      const { result } = renderHook(() =>
+        useViewedFiles('main', 'feature-branch', 'abc', undefined, files, 'repo-1'),
+      );
+
+      await waitFor(() => {
+        expect(result.current.viewedFiles.size).toBe(2);
+      });
+
+      await act(async () => {
+        await result.current.setFilesViewed(files, false);
+      });
+
+      expect(result.current.viewedFiles.size).toBe(0);
+      expect(mockRemoveViewedHashes).toHaveBeenCalledWith('repo-1', [
+        { filePath: 'src/dir/a.ts', diffContentHash: 'hash-a' },
+        { filePath: 'src/dir/b.ts', diffContentHash: 'hash-b' },
+      ]);
+    });
+
+    it('does nothing when unmarking files that are not viewed', async () => {
+      const files = [createMockDiffFile('src/dir/a.ts')];
+      const { result } = renderHook(() =>
+        useViewedFiles('main', 'feature-branch', 'abc', undefined, files, 'repo-1'),
+      );
+
+      await waitFor(() => {
+        expect(result.current.hasLoadedInitialViewedFiles).toBe(true);
+      });
+
+      await act(async () => {
+        await result.current.setFilesViewed(files, false);
+      });
+
+      expect(mockSaveViewedFiles).not.toHaveBeenCalled();
+      expect(mockRemoveViewedHashes).not.toHaveBeenCalled();
+    });
+  });
+
   describe('getViewedFileRecord', () => {
     it('should return record for viewed file', async () => {
       const storedRecords: ViewedFileRecord[] = [

--- a/src/client/hooks/useViewedFiles.ts
+++ b/src/client/hooks/useViewedFiles.ts
@@ -22,6 +22,7 @@ interface UseViewedFilesReturn {
   changedSinceViewedFiles: Set<string>;
   hasLoadedInitialViewedFiles: boolean;
   toggleFileViewed: (filePath: string, diffFile: DiffFile) => Promise<void>;
+  setFilesViewed: (diffFiles: DiffFile[], viewed: boolean) => Promise<void>;
   isFileContentChanged: (filePath: string, diffFile: DiffFile) => Promise<boolean>;
   getViewedFileRecord: (filePath: string) => ViewedFileRecord | undefined;
   clearViewedFiles: () => void;
@@ -291,6 +292,52 @@ export function useViewedFiles(
     [viewedFileRecords, getViewedFileRecord, getFileHash, saveViewedFiles, repositoryId],
   );
 
+  // Set viewed state for multiple files at once (e.g. marking an entire folder)
+  const setFilesViewed = useCallback(
+    async (diffFiles: DiffFile[], viewed: boolean): Promise<void> => {
+      if (viewed) {
+        const filesToAdd = diffFiles.filter((file) => !getViewedFileRecord(file.path));
+        if (filesToAdd.length === 0) return;
+
+        const viewedAt = new Date().toISOString();
+        const addedRecords: ViewedFileRecord[] = await Promise.all(
+          filesToAdd.map(async (file) => ({
+            filePath: file.path,
+            viewedAt,
+            diffContentHash: await getFileHash(file),
+          })),
+        );
+
+        saveViewedFiles([...viewedFileRecords, ...addedRecords]);
+        storageService.recordViewedHashes(
+          repositoryId,
+          addedRecords.map((record) => ({
+            filePath: record.filePath,
+            diffContentHash: record.diffContentHash,
+            hashVersion: VIEWED_HASH_VERSION,
+            viewedAt: record.viewedAt,
+          })),
+        );
+      } else {
+        const pathsToRemove = new Set(diffFiles.map((file) => file.path));
+        const removedRecords = viewedFileRecords.filter((record) =>
+          pathsToRemove.has(record.filePath),
+        );
+        if (removedRecords.length === 0) return;
+
+        saveViewedFiles(viewedFileRecords.filter((record) => !pathsToRemove.has(record.filePath)));
+        storageService.removeViewedHashes(
+          repositoryId,
+          removedRecords.map((record) => ({
+            filePath: record.filePath,
+            diffContentHash: record.diffContentHash,
+          })),
+        );
+      }
+    },
+    [viewedFileRecords, getViewedFileRecord, getFileHash, saveViewedFiles, repositoryId],
+  );
+
   // Clear all viewed files
   const clearViewedFiles = useCallback(() => {
     saveViewedFiles([]);
@@ -304,6 +351,7 @@ export function useViewedFiles(
     changedSinceViewedFiles,
     hasLoadedInitialViewedFiles,
     toggleFileViewed,
+    setFilesViewed,
     isFileContentChanged,
     getViewedFileRecord,
     clearViewedFiles,


### PR DESCRIPTION
Closes #419

## What

Adds the ability to mark an entire folder as reviewed/unreviewed from the file tree sidebar.

- Hovering a directory row in the file tree swaps the folder icon for a checkbox (same 16px footprint, so no layout shift). Clicking it marks every file under that folder as reviewed, or unmarks them all when the folder is already fully reviewed.
- The checkbox reflects the existing "all descendants reviewed" state that already drives the directory strikethrough style.
- Files in the diff view collapse/expand in sync with their viewed state, same as the per-file checkbox behavior.

## How

- `useViewedFiles`: new `setFilesViewed(diffFiles, viewed)` batch operation — one storage save and one hash-index update for the whole folder, instead of per-file toggles. Already-viewed files keep their original record (timestamp/hash) when marking, and unmarking only removes the matching (path, hash) index entries.
- `App.tsx`: new `toggleFolderReviewed` callback filters `diffData.files` by the folder path prefix, delegates to `setFilesViewed`, and syncs `collapsedFiles`.
- `FileList.tsx`: directory header rows render the hover-revealed checkbox wired to `onToggleFolderReviewed(path, reviewed)`.

## Notes for review

- Collapsed single-child directory chains (e.g. a node shown as `src/client`) use the deepest path as `node.path`, so the prefix filter covers exactly the files displayed under that node.
- Tests added for the FileList checkbox interaction (mark/unmark) and the `setFilesViewed` batch semantics (skip already-viewed, remove index entries, no-op cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)