### PR TITLE
feat(vscode): bundle difit into the extension instead of requiring a global install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ openspec/
 
 # VS Code extension artifacts
 packages/vscode/*.vsix
+packages/vscode/.cache/

--- a/knip.json
+++ b/knip.json
@@ -1,3 +1,15 @@
 {
-  "ignoreBinaries": ["gh"]
+  "ignoreBinaries": ["gh"],
+  "workspaces": {
+    ".": {},
+    "packages/vscode": {
+      "entry": [
+        "src/extension.ts",
+        "src/server-entry.ts",
+        "src/watcher-shim.ts",
+        "src/open-stub.ts"
+      ],
+      "ignoreUnresolved": ["#parcel-watcher-wrapper"]
+    }
+  }
 }

--- a/packages/vscode/.vscodeignore
+++ b/packages/vscode/.vscodeignore
@@ -1,6 +1,5 @@
-**/*
+**
 !dist/**
-!package.json
-!README.md
-!LICENSE
 !assets/**
+!LICENSE
+!README.md

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -1,48 +1,32 @@
-# difit VS Code Extension
+# difit for VS Code
 
-Open difit with one click and render it in a VS Code tab using Simple Browser.
+Review your Git changes in a GitHub-like diff viewer, right inside VS Code.
 
-- Project: https://github.com/yoshiko-pg/difit
+[difit](https://github.com/yoshiko-pg/difit) is bundled with this extension — no separate install, no PATH setup, no Node version manager headaches. The server runs on the Node.js runtime that ships with VS Code.
 
-## Requirements
+## Usage
 
-- VS Code `^1.98.0`
-- `difit` CLI installed on your machine (or install from the extension prompt)
-
-## What It Does
-
-- Adds `difit: Open Review` and `difit: Stop Review` commands.
-- Shows an editor title button (top-right icon) for quick open.
-- Shows a status bar button (`difit`) for quick open.
-- Reuses a running difit process per workspace.
-- Chooses launch args automatically:
-  - with uncommitted changes: `difit . --no-open`
-  - without uncommitted changes: `difit HEAD --no-open`
-- Opens the URL in a VS Code tab via `simpleBrowser.api.open`.
-- Writes runtime logs to Output channel `difit`.
+- Click the **difit** status bar item (or the icon in the editor title), or run **difit: Open Review** from the command palette.
+- With uncommitted changes, it reviews them (like `difit .`). With a clean working tree, it reviews the latest commit (like `difit HEAD`).
+- The review opens beside your editor in the built-in Simple Browser. Comments, viewed-state, and live reload work just like the difit CLI.
+- Run **difit: Stop Review** to shut the server down. It also stops automatically when VS Code exits.
 
 ## Settings
 
-- `difit.executablePath` (default: `difit`)
-- `difit.installCommand` (default: `npm install -g difit`)
+| Setting                | Description                                                                                                                                                             |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `difit.executablePath` | Optional path to an external `difit` executable. Leave empty (default) to use the bundled difit. Set this if you want to run a newer or local build of the CLI instead. |
 
-## Build VSIX Locally
+## How it works
 
-From repository root:
+The extension forks the bundled difit server with VS Code's own Node.js runtime and talks to it over IPC, so it works regardless of your shell or Node setup. Native file-watcher binaries for all supported platforms are included; on an unsupported platform difit still works, just without live reload.
+
+## Development
 
 ```bash
+# from the repository root
 pnpm install
-pnpm run package:vscode
+pnpm run build              # builds the difit client assets into dist/client
+pnpm -C packages/vscode run build     # bundles the extension into packages/vscode/dist
+pnpm -C packages/vscode run package   # produces the .vsix
 ```
-
-Generated file:
-
-- `packages/vscode/difit-vscode-<version>.vsix`
-
-## Install VSIX
-
-1. Open Extensions view.
-2. Click `...` (More Actions).
-3. Choose `Install from VSIX...`.
-4. Select `packages/vscode/difit-vscode-<version>.vsix`.
-5. Run `Developer: Reload Window`.

--- a/packages/vscode/build.mjs
+++ b/packages/vscode/build.mjs
@@ -1,0 +1,156 @@
+// Builds the VS Code extension: bundles the extension host code and the difit
+// server (from the monorepo source) with esbuild, then copies the prebuilt
+// client assets and the @parcel/watcher native prebuilds into dist/.
+import { spawnSync } from 'node:child_process';
+import { copyFileSync, cpSync, existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { build } from 'esbuild';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, '..', '..');
+const distDir = path.join(here, 'dist');
+const require = createRequire(import.meta.url);
+
+// Native prebuilds shipped in the VSIX. Covers every platform VS Code desktop
+// runs on; a missing prebuild only disables live reload there (difit loads the
+// watcher lazily), so unavailable targets are skipped with a warning.
+const WATCHER_PREBUILD_PACKAGES = [
+  '@parcel/watcher-darwin-arm64',
+  '@parcel/watcher-darwin-x64',
+  '@parcel/watcher-win32-x64',
+  '@parcel/watcher-win32-arm64',
+  '@parcel/watcher-linux-x64-glibc',
+  '@parcel/watcher-linux-x64-musl',
+  '@parcel/watcher-linux-arm64-glibc',
+  '@parcel/watcher-linux-arm64-musl',
+  '@parcel/watcher-linux-arm-glibc',
+  '@parcel/watcher-linux-arm-musl',
+];
+
+rmSync(distDir, { recursive: true, force: true });
+
+const commonOptions = {
+  bundle: true,
+  platform: 'node',
+  format: 'cjs',
+  target: 'node22',
+  logLevel: 'info',
+};
+
+// 1. Extension host bundle.
+await build({
+  ...commonOptions,
+  entryPoints: [path.join(here, 'src/extension.ts')],
+  outfile: path.join(distDir, 'extension.js'),
+  external: ['vscode'],
+});
+
+// 2. difit server bundle, built straight from the monorepo source.
+const watcherPackageJson = require.resolve('@parcel/watcher/package.json');
+await build({
+  ...commonOptions,
+  entryPoints: [path.join(here, 'src/server-entry.ts')],
+  outfile: path.join(distDir, 'server/index.js'),
+  alias: {
+    '@': path.join(repoRoot, 'src'),
+    // Load the native binding from dist/server/prebuilds instead of node_modules.
+    '@parcel/watcher': path.join(here, 'src/watcher-shim.ts'),
+    '#parcel-watcher-wrapper': path.join(path.dirname(watcherPackageJson), 'wrapper.js'),
+    // The server never opens a browser from inside the extension.
+    open: path.join(here, 'src/open-stub.ts'),
+  },
+  // server.ts derives __dirname from import.meta.url; emulate it in CJS.
+  define: { 'import.meta.url': '__difitImportMetaUrl' },
+  banner: {
+    js: "const __difitImportMetaUrl = require('node:url').pathToFileURL(__filename).href;",
+  },
+});
+
+// 3. Prebuilt difit client (built by `pnpm --dir ../.. run build`).
+const clientSource = path.join(repoRoot, 'dist', 'client');
+if (!existsSync(path.join(clientSource, 'index.html'))) {
+  console.error('error: dist/client is missing. Run `pnpm --dir ../.. run build` first.');
+  process.exit(1);
+}
+cpSync(clientSource, path.join(distDir, 'client'), { recursive: true });
+
+// 4. @parcel/watcher native prebuilds for all supported platforms.
+const watcherVersion = /** @type {{ version: string }} */ (require(watcherPackageJson)).version;
+const cacheDir = path.join(here, '.cache', `watcher-prebuilds-${watcherVersion}`);
+const requireFromWatcher = createRequire(watcherPackageJson);
+
+let copied = 0;
+for (const packageName of WATCHER_PREBUILD_PACKAGES) {
+  const binary =
+    resolveLocalPrebuild(packageName) ?? (await fetchPrebuild(packageName, watcherVersion));
+  if (!binary) {
+    console.warn(`warn: skipping ${packageName} (not installed and download failed)`);
+    continue;
+  }
+
+  const destination = path.join(distDir, 'server', 'prebuilds', packageName, 'watcher.node');
+  mkdirSync(path.dirname(destination), { recursive: true });
+  copyFileSync(binary, destination);
+  copied += 1;
+}
+console.log(`watcher prebuilds: ${copied}/${WATCHER_PREBUILD_PACKAGES.length} bundled`);
+
+/**
+ * @param {string} packageName
+ * @returns {string | undefined}
+ */
+function resolveLocalPrebuild(packageName) {
+  try {
+    return requireFromWatcher.resolve(packageName);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * @param {string} packageName
+ * @param {string} version
+ * @returns {Promise<string | undefined>}
+ */
+async function fetchPrebuild(packageName, version) {
+  const extractDir = path.join(cacheDir, packageName);
+  const cachedBinary = path.join(extractDir, 'package', 'watcher.node');
+  if (existsSync(cachedBinary)) {
+    return cachedBinary;
+  }
+
+  const tarballBaseName = packageName.split('/')[1];
+  const url = `https://registry.npmjs.org/${packageName}/-/${tarballBaseName}-${version}.tgz`;
+
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+
+    mkdirSync(extractDir, { recursive: true });
+    const tarballPath = path.join(extractDir, 'package.tgz');
+    writeFileSync(tarballPath, Buffer.from(await response.arrayBuffer()));
+
+    const result = spawnSync('tar', [
+      '-xzf',
+      tarballPath,
+      '-C',
+      extractDir,
+      'package/watcher.node',
+    ]);
+    rmSync(tarballPath, { force: true });
+    if (result.status !== 0) {
+      throw new Error(result.stderr?.toString().trim() || 'tar extraction failed');
+    }
+
+    return cachedBinary;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`warn: failed to download ${packageName}@${version}: ${message}`);
+    return undefined;
+  }
+}

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "difit-vscode",
   "displayName": "difit",
   "version": "0.1.0",
-  "description": "Launch difit and open it in a VS Code tab.",
+  "description": "GitHub-like diff review inside VS Code. difit is bundled — no extra install needed.",
   "categories": [
     "Other"
   ],
@@ -18,15 +18,17 @@
   "publisher": "yoshiko-pg",
   "main": "./dist/extension.js",
   "scripts": {
-    "build": "tsc -p .",
-    "watch": "tsc -w -p .",
-    "lint": "tsc -p . --noEmit",
-    "package": "pnpm run build && vsce package"
+    "build": "node build.mjs",
+    "typecheck": "tsc --noEmit",
+    "package": "pnpm --dir ../.. run build && node build.mjs && vsce package --no-dependencies"
   },
   "devDependencies": {
+    "@parcel/watcher": "^2.5.1",
     "@types/node": "^24.0.8",
-    "@types/vscode": "^1.98.0",
+    "@types/vscode": "^1.102.0",
     "@vscode/vsce": "^3.6.2",
+    "detect-libc": "^2.0.3",
+    "esbuild": "^0.25.0",
     "typescript": "^6.0.0"
   },
   "contributes": {
@@ -57,24 +59,17 @@
       "properties": {
         "difit.executablePath": {
           "type": "string",
-          "default": "difit",
-          "description": "Path to the difit executable."
-        },
-        "difit.installCommand": {
-          "type": "string",
-          "default": "npm install -g difit",
-          "description": "Command sent to an integrated terminal when difit is not installed."
+          "default": "",
+          "description": "Optional path to an external difit executable. Leave empty to use the difit version bundled with this extension."
         }
       }
     }
   },
   "activationEvents": [
-    "onCommand:difit.openReview",
-    "onCommand:difit.stopReview",
     "onStartupFinished"
   ],
   "icon": "assets/logo.png",
   "engines": {
-    "vscode": "^1.98.0"
+    "vscode": "^1.102.0"
   }
 }

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -1,56 +1,41 @@
-import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
-import path from 'node:path';
+import { type ChildProcess, fork, spawn } from 'node:child_process';
 
 import * as vscode from 'vscode';
 
+import { type DiffSelection } from '../../../src/types/diff.js';
+import { DiffMode } from '../../../src/types/watch.js';
+import { createDiffSelection, getDiffSelectionKey } from '../../../src/utils/diffSelection.js';
+
 const OPEN_REVIEW_COMMAND = 'difit.openReview';
 const STOP_REVIEW_COMMAND = 'difit.stopReview';
+const STARTUP_TIMEOUT_MS = 30_000;
 const SERVER_URL_PATTERN = /difit server started on (https?:\/\/\S+)/i;
-const STARTUP_TIMEOUT_MS = 20_000;
-const INSTALL_ACTION_LABEL = 'Install';
-const DEFAULT_LOGIN_SHELL = process.env.SHELL?.trim() || '/bin/zsh';
-const LOGIN_SHELL_ARGS_PREFIX = ['-i', '-l', '-c'] as const;
-const EXTENSION_HOST_NODE_DIR = path.dirname(process.execPath);
 
-type LaunchStrategy = 'direct' | 'login-shell';
-
-type DifitSession = {
-  readonly process: ChildProcessWithoutNullStreams;
-  readonly workspaceFolder: vscode.WorkspaceFolder;
-  readonly difitArgs: readonly string[];
-  readonly launchStrategy: LaunchStrategy;
-  startupPromise: Promise<string>;
-  url?: string;
-};
-
-const sessions = new Map<string, DifitSession>();
-let outputChannel: vscode.OutputChannel | undefined;
-
-class StartupExitError extends Error {
-  readonly code: number | null;
-  readonly signal: NodeJS.Signals | null;
-
-  constructor(workspaceName: string, code: number | null, signal: NodeJS.Signals | null) {
-    super(
-      `difit exited before startup in ${workspaceName} (code: ${String(code)}, signal: ${String(signal)})`,
-    );
-    this.name = 'StartupExitError';
-    this.code = code;
-    this.signal = signal;
-  }
+interface ReviewTarget {
+  selection: DiffSelection;
+  diffMode: DiffMode;
+  /** Positional argument used when launching an external difit CLI. */
+  cliArg: string;
 }
 
+interface Session {
+  readonly child: ChildProcess;
+  readonly selectionKey: string;
+  readonly url: Promise<string>;
+}
+
+const sessions = new Map<string, Session>();
+let extensionContext: vscode.ExtensionContext | undefined;
+let outputChannel: vscode.OutputChannel | undefined;
+
 export function activate(context: vscode.ExtensionContext): void {
-  outputChannel = vscode.window.createOutputChannel('difit');
-  context.subscriptions.push(outputChannel);
+  extensionContext = context;
+  context.subscriptions.push(getOutputChannel());
 
   context.subscriptions.push(
     vscode.commands.registerCommand(OPEN_REVIEW_COMMAND, () => {
       void openReview();
     }),
-  );
-
-  context.subscriptions.push(
     vscode.commands.registerCommand(STOP_REVIEW_COMMAND, () => {
       stopReview();
     }),
@@ -79,86 +64,49 @@ async function openReview(): Promise<void> {
     return;
   }
 
-  const key = workspaceKey(workspaceFolder);
-  const existingSession = sessions.get(key);
-
-  if (existingSession && isProcessAlive(existingSession.process)) {
-    try {
-      const url = existingSession.url ?? (await existingSession.startupPromise);
-      await openInSimpleBrowser(url);
-    } catch (error) {
-      sessions.delete(key);
-      const message = error instanceof Error ? error.message : 'Unknown error';
-      void vscode.window.showErrorMessage(`difit: ${message}`);
-    }
-    return;
-  }
-
-  sessions.delete(key);
-
-  const executablePath = getExecutablePath();
-  const availability = await checkDifitExecutable(executablePath);
-
-  if (availability === 'missing') {
-    await promptInstallFlow(getInstallCommand());
-    return;
-  }
-
-  if (availability === 'error') {
+  let repoRoot: string;
+  try {
+    repoRoot = (await runGit(workspaceFolder.uri.fsPath, ['rev-parse', '--show-toplevel'])).trim();
+  } catch {
     void vscode.window.showErrorMessage(
-      `difit: Failed to run '${executablePath} --version'. Check "difit.executablePath".`,
+      `difit: "${workspaceFolder.name}" is not inside a Git repository.`,
     );
     return;
   }
 
-  const difitArgs = await resolveDifitLaunchArgs(workspaceFolder);
-  let session = createSession(workspaceFolder, executablePath, difitArgs, 'direct');
-  sessions.set(key, session);
+  const target = await resolveReviewTarget(repoRoot);
+  const selectionKey = getDiffSelectionKey(target.selection);
+
+  const existing = sessions.get(repoRoot);
+  if (existing && isProcessAlive(existing.child)) {
+    if (existing.selectionKey === selectionKey) {
+      try {
+        await openInBrowser(await existing.url);
+        return;
+      } catch {
+        // Fall through and restart the session.
+      }
+    }
+    // The repository state changed (e.g. changes were committed) or the
+    // session is broken; restart with the new selection.
+    stopSession(existing);
+  }
+  sessions.delete(repoRoot);
 
   try {
-    const url = await session.startupPromise;
-    await openInSimpleBrowser(url);
+    const url = await vscode.window.withProgress(
+      { location: vscode.ProgressLocation.Window, title: 'Starting difit...' },
+      () => startSession(repoRoot, target),
+    );
+    await openInBrowser(url);
   } catch (error) {
-    if (shouldRetryWithLoginShell(error)) {
-      sessions.delete(key);
-      getOutputChannel().appendLine(
-        `[${workspaceFolder.name}] direct launch exited with code 127. Retrying via login shell.`,
-      );
-      session = createSession(workspaceFolder, executablePath, difitArgs, 'login-shell');
-      sessions.set(key, session);
-
-      try {
-        const url = await session.startupPromise;
-        await openInSimpleBrowser(url);
-      } catch (retryError) {
-        sessions.delete(key);
-        const message = formatStartupError(retryError, executablePath);
-        void vscode.window.showErrorMessage(`difit: ${message}`);
-      }
-      return;
-    }
-
-    sessions.delete(key);
-    const message = formatStartupError(error, executablePath);
+    sessions.delete(repoRoot);
+    const message = error instanceof Error ? error.message : String(error);
     void vscode.window.showErrorMessage(`difit: ${message}`);
   }
 }
 
 function stopReview(): void {
-  const workspaceFolder = resolveTargetWorkspaceFolder();
-  if (workspaceFolder) {
-    const key = workspaceKey(workspaceFolder);
-    const session = sessions.get(key);
-    if (session) {
-      stopSession(session);
-      sessions.delete(key);
-      void vscode.window.showInformationMessage(
-        `difit: Stopped review server for ${workspaceFolder.name}.`,
-      );
-      return;
-    }
-  }
-
   if (sessions.size === 0) {
     void vscode.window.showInformationMessage('difit: No running review server.');
     return;
@@ -171,176 +119,198 @@ function stopReview(): void {
   void vscode.window.showInformationMessage('difit: Stopped all running review servers.');
 }
 
-function stopSession(session: DifitSession): void {
-  if (!isProcessAlive(session.process)) {
-    return;
+/**
+ * Review uncommitted changes when there are any (like `difit .`), otherwise
+ * review the latest commit (like `difit HEAD`).
+ */
+async function resolveReviewTarget(repoRoot: string): Promise<ReviewTarget> {
+  const status = await runGit(repoRoot, ['status', '--porcelain']).catch(() => '');
+  // Untracked files are excluded: including them requires `git add
+  // --intent-to-add`, which mutates the user's repository state.
+  const hasTrackedChanges = status
+    .split('\n')
+    .some((line) => line.trim().length > 0 && !line.startsWith('??'));
+
+  if (hasTrackedChanges) {
+    return {
+      selection: createDiffSelection('HEAD', '.'),
+      diffMode: DiffMode.DOT,
+      cliArg: '.',
+    };
   }
 
-  const stoppedWithSigInt = session.process.kill('SIGINT');
-  if (!stoppedWithSigInt) {
-    session.process.kill();
-  }
+  return {
+    selection: createDiffSelection('HEAD^', 'HEAD'),
+    diffMode: DiffMode.DEFAULT,
+    cliArg: 'HEAD',
+  };
 }
 
-function createSession(
-  workspaceFolder: vscode.WorkspaceFolder,
-  executablePath: string,
-  difitArgs: readonly string[],
-  launchStrategy: LaunchStrategy,
-): DifitSession {
-  const channel = getOutputChannel();
-  const command = launchStrategy === 'direct' ? executablePath : DEFAULT_LOGIN_SHELL;
-  const commandArgs =
-    launchStrategy === 'direct'
-      ? [...difitArgs]
-      : [...LOGIN_SHELL_ARGS_PREFIX, buildShellCommand(executablePath, difitArgs)];
+function startSession(repoRoot: string, target: ReviewTarget): Promise<string> {
+  const externalPath = getConfiguredExecutablePath();
+  const child = externalPath
+    ? spawnExternal(externalPath, repoRoot, target)
+    : forkBundled(repoRoot, target);
 
-  const child = spawn(command, commandArgs, {
-    cwd: workspaceFolder.uri.fsPath,
-    env: buildSpawnEnv(),
-    stdio: ['pipe', 'pipe', 'pipe'],
+  const url = waitForStartup(child, repoRoot);
+  const session: Session = {
+    child,
+    selectionKey: getDiffSelectionKey(target.selection),
+    url,
+  };
+  sessions.set(repoRoot, session);
+
+  child.once('exit', (code, signal) => {
+    getOutputChannel().appendLine(
+      `[${repoRoot}] server exited (code: ${String(code)}, signal: ${String(signal)})`,
+    );
+    if (sessions.get(repoRoot)?.child === child) {
+      sessions.delete(repoRoot);
+    }
   });
 
-  if (launchStrategy === 'direct') {
-    channel.appendLine(
-      `[${workspaceFolder.name}] starting: ${executablePath} ${difitArgs.join(' ')} (cwd: ${workspaceFolder.uri.fsPath})`,
-    );
-  } else {
-    channel.appendLine(
-      `[${workspaceFolder.name}] starting via login shell: ${DEFAULT_LOGIN_SHELL} ${LOGIN_SHELL_ARGS_PREFIX.join(' ')} ${buildShellCommand(executablePath, difitArgs)} (cwd: ${workspaceFolder.uri.fsPath})`,
-    );
+  return url;
+}
+
+function forkBundled(repoRoot: string, target: ReviewTarget): ChildProcess {
+  const context = extensionContext;
+  if (!context) {
+    throw new Error('Extension is not activated.');
   }
 
-  const session: DifitSession = {
-    process: child,
-    workspaceFolder,
-    difitArgs,
-    launchStrategy,
-    startupPromise: Promise.resolve(''),
+  const serverModule = context.asAbsolutePath('dist/server/index.js');
+  const request = {
+    selection: target.selection,
+    diffMode: target.diffMode,
+    repoPath: repoRoot,
   };
 
-  let settled = false;
-  let timeoutHandle: NodeJS.Timeout | undefined;
+  getOutputChannel().appendLine(
+    `[${repoRoot}] starting bundled difit (reviewing ${target.cliArg})`,
+  );
 
-  const settleResolve = (url: string, resolve: (value: string) => void): void => {
-    if (settled) {
-      return;
-    }
+  return fork(serverModule, [JSON.stringify(request)], {
+    cwd: repoRoot,
+    silent: true,
+    // Never inherit the extension host's execArgv (e.g. --inspect), which
+    // would make the child fight over the debug port.
+    execArgv: [],
+    env: { ...process.env, NODE_ENV: 'production' },
+  });
+}
 
-    settled = true;
-    session.url = url;
-    if (timeoutHandle) {
-      clearTimeout(timeoutHandle);
-    }
-    resolve(url);
-  };
+function spawnExternal(
+  executablePath: string,
+  repoRoot: string,
+  target: ReviewTarget,
+): ChildProcess {
+  const args = [target.cliArg, '--no-open', '--keep-alive'];
+  getOutputChannel().appendLine(
+    `[${repoRoot}] starting external difit: ${executablePath} ${args.join(' ')}`,
+  );
 
-  const settleReject = (error: Error, reject: (reason: Error) => void): void => {
-    if (settled) {
-      return;
-    }
+  return spawn(executablePath, args, {
+    cwd: repoRoot,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
 
-    settled = true;
-    if (timeoutHandle) {
-      clearTimeout(timeoutHandle);
-    }
-    reject(error);
-  };
+function waitForStartup(child: ChildProcess, repoRoot: string): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    let settled = false;
 
-  session.startupPromise = new Promise<string>((resolve, reject) => {
-    const handleOutput = (source: 'stdout' | 'stderr', data: Buffer): void => {
-      const text = data.toString();
-      appendOutput(channel, workspaceFolder.name, source, text);
-
-      const matchedUrl = extractServerUrl(text);
-      if (matchedUrl) {
-        settleResolve(matchedUrl, resolve);
+    const settle = (fn: () => void): void => {
+      if (settled) {
+        return;
       }
+      settled = true;
+      clearTimeout(timeoutHandle);
+      fn();
     };
 
-    child.stdout.on('data', (data: Buffer) => {
-      handleOutput('stdout', data);
+    const timeoutHandle = setTimeout(() => {
+      settle(() => {
+        child.kill();
+        reject(new Error('Timed out waiting for the difit server to start.'));
+      });
+    }, STARTUP_TIMEOUT_MS);
+
+    // The bundled server reports readiness over the fork IPC channel.
+    child.on('message', (message: unknown) => {
+      const payload = message as {
+        type?: string;
+        url?: string;
+        message?: string;
+      };
+      if (payload.type === 'ready' && typeof payload.url === 'string') {
+        const url = payload.url;
+        settle(() => {
+          resolve(url);
+        });
+      } else if (payload.type === 'error') {
+        settle(() => {
+          reject(new Error(payload.message ?? 'difit failed to start.'));
+        });
+      }
     });
 
-    child.stderr.on('data', (data: Buffer) => {
-      handleOutput('stderr', data);
-    });
+    // An external difit CLI reports its URL on stdout instead.
+    const handleOutput = (data: Buffer): void => {
+      const text = data.toString();
+      appendServerOutput(repoRoot, text);
+      const matchedUrl = text.match(SERVER_URL_PATTERN)?.[1];
+      if (matchedUrl) {
+        settle(() => {
+          resolve(matchedUrl);
+        });
+      }
+    };
+    child.stdout?.on('data', handleOutput);
+    child.stderr?.on('data', handleOutput);
 
     child.once('error', (error) => {
-      appendOutput(channel, workspaceFolder.name, 'stderr', String(error));
-      settleReject(
-        new Error(
-          `Failed to start difit in ${workspaceFolder.name}: ${error.message || String(error)}`,
-        ),
-        reject,
-      );
+      settle(() => {
+        const hint =
+          (error as NodeJS.ErrnoException).code === 'ENOENT'
+            ? ' Check the "difit.executablePath" setting.'
+            : '';
+        reject(new Error(`Failed to launch difit: ${error.message}.${hint}`));
+      });
     });
 
-    child.once('close', (code, signal) => {
-      channel.appendLine(
-        `[${workspaceFolder.name}] process exited (code: ${String(code)}, signal: ${String(signal)})`,
-      );
-
-      const key = workspaceKey(workspaceFolder);
-      const current = sessions.get(key);
-      if (current?.process === child) {
-        sessions.delete(key);
-      }
-
-      if (!settled) {
-        settleReject(new StartupExitError(workspaceFolder.name, code, signal), reject);
-      }
+    child.once('exit', (code, signal) => {
+      settle(() => {
+        reject(
+          new Error(
+            `difit exited before startup (code: ${String(code)}, signal: ${String(signal)}).`,
+          ),
+        );
+      });
     });
-
-    timeoutHandle = setTimeout(() => {
-      settleReject(
-        new Error(`Timed out waiting for difit startup in ${workspaceFolder.name}.`),
-        reject,
-      );
-    }, STARTUP_TIMEOUT_MS);
   });
-
-  return session;
 }
 
-function buildShellCommand(executablePath: string, difitArgs: readonly string[]): string {
-  return [executablePath, ...difitArgs].map(shellQuote).join(' ');
-}
-
-function shellQuote(value: string): string {
-  return `'${value.replace(/'/g, `'\\''`)}'`;
-}
-
-function shouldRetryWithLoginShell(error: unknown): boolean {
-  return error instanceof StartupExitError && error.code === 127;
-}
-
-function formatStartupError(error: unknown, executablePath: string): string {
-  if (shouldRetryWithLoginShell(error)) {
-    return `Launch failed with exit code 127. Check "${executablePath}" and ensure Node.js is available in VS Code PATH.`;
+function stopSession(session: Session): void {
+  if (!isProcessAlive(session.child)) {
+    return;
   }
-
-  return error instanceof Error ? error.message : 'Unknown error';
+  session.child.kill();
 }
 
-function appendOutput(
-  channel: vscode.OutputChannel,
-  workspaceName: string,
-  source: 'stdout' | 'stderr',
-  output: string,
-): void {
-  const lines = output.split(/\r?\n/u);
-  for (const line of lines) {
-    if (!line.trim()) {
-      continue;
-    }
-    channel.appendLine(`[${workspaceName}] ${source}: ${line}`);
+function isProcessAlive(child: ChildProcess): boolean {
+  return child.exitCode === null && child.signalCode === null && !child.killed;
+}
+
+async function openInBrowser(url: string): Promise<void> {
+  try {
+    await vscode.commands.executeCommand('simpleBrowser.api.open', vscode.Uri.parse(url), {
+      viewColumn: vscode.ViewColumn.Beside,
+      preserveFocus: false,
+    });
+  } catch {
+    // Simple Browser is unavailable (disabled built-in); open externally.
+    await vscode.env.openExternal(vscode.Uri.parse(url));
   }
-}
-
-function extractServerUrl(output: string): string | undefined {
-  const match = output.match(SERVER_URL_PATTERN);
-  return match?.[1];
 }
 
 function resolveTargetWorkspaceFolder(): vscode.WorkspaceFolder | undefined {
@@ -355,164 +325,49 @@ function resolveTargetWorkspaceFolder(): vscode.WorkspaceFolder | undefined {
   return vscode.workspace.workspaceFolders?.[0];
 }
 
-function workspaceKey(workspaceFolder: vscode.WorkspaceFolder): string {
-  return workspaceFolder.uri.toString();
+function getConfiguredExecutablePath(): string {
+  return vscode.workspace.getConfiguration('difit').get<string>('executablePath', '').trim();
 }
 
-function isProcessAlive(process: ChildProcessWithoutNullStreams): boolean {
-  return process.exitCode === null && !process.killed;
-}
-
-async function openInSimpleBrowser(url: string): Promise<void> {
-  try {
-    await vscode.commands.executeCommand('simpleBrowser.api.open', vscode.Uri.parse(url), {
-      viewColumn: vscode.ViewColumn.Beside,
-      preserveFocus: false,
-    });
-  } catch {
-    void vscode.window.showErrorMessage(
-      `difit: Failed to open URL in Simple Browser. Install/enable the built-in Simple Browser extension. URL: ${url}`,
-    );
-  }
-}
-
-type ExecutableAvailability = 'available' | 'missing' | 'error';
-
-async function resolveDifitLaunchArgs(
-  workspaceFolder: vscode.WorkspaceFolder,
-): Promise<readonly string[]> {
-  const hasUncommittedChanges = await detectUncommittedChanges(workspaceFolder);
-  return hasUncommittedChanges ? ['.', '--no-open'] : ['HEAD', '--no-open'];
-}
-
-async function detectUncommittedChanges(workspaceFolder: vscode.WorkspaceFolder): Promise<boolean> {
-  return await new Promise<boolean>((resolve) => {
-    const gitStatus = spawn('git', ['status', '--porcelain'], {
-      cwd: workspaceFolder.uri.fsPath,
-      stdio: ['ignore', 'pipe', 'ignore'],
+async function runGit(cwd: string, args: readonly string[]): Promise<string> {
+  return await new Promise<string>((resolve, reject) => {
+    const child = spawn('git', [...args], {
+      cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
     });
 
-    let output = '';
-    gitStatus.stdout.on('data', (data: Buffer) => {
-      output += data.toString();
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (data: Buffer) => {
+      stdout += data.toString();
+    });
+    child.stderr.on('data', (data: Buffer) => {
+      stderr += data.toString();
     });
 
-    gitStatus.once('error', () => {
-      resolve(false);
-    });
-
-    gitStatus.once('close', (code) => {
-      if (code !== 0) {
-        resolve(false);
-        return;
-      }
-      resolve(output.trim().length > 0);
-    });
-  });
-}
-
-async function checkDifitExecutable(executablePath: string): Promise<ExecutableAvailability> {
-  return await new Promise<ExecutableAvailability>((resolve) => {
-    const probe = spawn(executablePath, ['--version'], {
-      env: buildSpawnEnv(),
-      stdio: 'ignore',
-    });
-
-    let settled = false;
-
-    const settle = (value: ExecutableAvailability): void => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      resolve(value);
-    };
-
-    probe.once('error', (error) => {
-      const errNoException = error as NodeJS.ErrnoException;
-      if (errNoException.code === 'ENOENT') {
-        settle('missing');
-        return;
-      }
-      settle('error');
-    });
-
-    probe.once('exit', (code, signal) => {
-      if (signal) {
-        settle('error');
-        return;
-      }
-
-      if (code !== 0) {
-        getOutputChannel().appendLine(
-          `[probe] '${executablePath} --version' exited with code ${String(code)}. Continuing launch.`,
+    child.once('error', reject);
+    child.once('close', (code) => {
+      if (code === 0) {
+        resolve(stdout);
+      } else {
+        reject(
+          new Error(stderr.trim() || `git ${args.join(' ')} exited with code ${String(code)}`),
         );
       }
-      settle('available');
     });
   });
 }
 
-function buildSpawnEnv(): NodeJS.ProcessEnv {
-  const env: NodeJS.ProcessEnv = { ...process.env };
-  const pathKey = resolvePathKey(env);
-  const currentPath = env[pathKey] ?? '';
-  const entries = currentPath.split(path.delimiter).filter((entry) => entry.length > 0);
-
-  if (!entries.includes(EXTENSION_HOST_NODE_DIR)) {
-    entries.unshift(EXTENSION_HOST_NODE_DIR);
+function appendServerOutput(repoRoot: string, output: string): void {
+  const channel = getOutputChannel();
+  for (const line of output.split(/\r?\n/u)) {
+    if (line.trim()) {
+      channel.appendLine(`[${repoRoot}] ${line}`);
+    }
   }
-
-  env[pathKey] = entries.join(path.delimiter);
-  return env;
-}
-
-function resolvePathKey(env: NodeJS.ProcessEnv): string {
-  const existing = Object.keys(env).find((key) => key.toLowerCase() === 'path');
-  return existing ?? 'PATH';
-}
-
-async function promptInstallFlow(installCommand: string): Promise<void> {
-  const action = await vscode.window.showInformationMessage(
-    'difit command was not found. Install it globally?',
-    {
-      modal: true,
-      detail: `The following command will run in VS Code terminal:\n${installCommand}`,
-    },
-    INSTALL_ACTION_LABEL,
-  );
-
-  if (action !== INSTALL_ACTION_LABEL) {
-    return;
-  }
-
-  const terminal = vscode.window.createTerminal({ name: 'difit setup' });
-  terminal.show(true);
-  terminal.sendText(installCommand, true);
-  void vscode.window.showInformationMessage(
-    'difit install command was sent to the terminal. Run "difit: Open Review" again after install finishes.',
-  );
-}
-
-function getExecutablePath(): string {
-  const configured = vscode.workspace
-    .getConfiguration('difit')
-    .get<string>('executablePath', 'difit');
-  const normalized = configured.trim();
-  return normalized.length > 0 ? normalized : 'difit';
-}
-
-function getInstallCommand(): string {
-  const configured = vscode.workspace
-    .getConfiguration('difit')
-    .get<string>('installCommand', 'npm install -g difit');
-  const normalized = configured.trim();
-  return normalized.length > 0 ? normalized : 'npm install -g difit';
 }
 
 function getOutputChannel(): vscode.OutputChannel {
-  if (!outputChannel) {
-    outputChannel = vscode.window.createOutputChannel('difit');
-  }
+  outputChannel ??= vscode.window.createOutputChannel('difit');
   return outputChannel;
 }

--- a/packages/vscode/src/modules.d.ts
+++ b/packages/vscode/src/modules.d.ts
@@ -1,0 +1,11 @@
+// Resolved by esbuild (build.mjs) to @parcel/watcher's internal wrapper.js.
+declare module '#parcel-watcher-wrapper' {
+  type Watcher = typeof import('@parcel/watcher');
+
+  export function createWrapper(binding: unknown): {
+    writeSnapshot: Watcher['writeSnapshot'];
+    getEventsSince: Watcher['getEventsSince'];
+    subscribe: Watcher['subscribe'];
+    unsubscribe: Watcher['unsubscribe'];
+  };
+}

--- a/packages/vscode/src/open-stub.ts
+++ b/packages/vscode/src/open-stub.ts
@@ -1,0 +1,4 @@
+// Replaces the `open` package in the bundled VS Code build. The extension
+// always launches the server with openBrowser: false and opens the URL through
+// the VS Code API itself, so browser-opening logic is never needed here.
+export default async function open(_target: string): Promise<void> {}

--- a/packages/vscode/src/server-entry.ts
+++ b/packages/vscode/src/server-entry.ts
@@ -1,0 +1,41 @@
+import { startServer } from '../../../src/server/server.js';
+import { type DiffSelection } from '../../../src/types/diff.js';
+import { type DiffMode } from '../../../src/types/watch.js';
+
+interface LaunchRequest {
+  selection: DiffSelection;
+  diffMode: DiffMode;
+  repoPath: string;
+}
+
+// The extension host owns this process through the IPC channel; exit when it
+// goes away so no orphan servers are left behind.
+process.on('disconnect', () => {
+  process.exit(0);
+});
+
+async function main(): Promise<void> {
+  const raw = process.argv[2];
+  if (!raw) {
+    throw new Error('Missing launch request argument');
+  }
+
+  const request = JSON.parse(raw) as LaunchRequest;
+
+  const { url, port, isEmpty } = await startServer({
+    selection: request.selection,
+    diffMode: request.diffMode,
+    repoPath: request.repoPath,
+    openBrowser: false,
+    keepAlive: true,
+  });
+
+  process.send?.({ type: 'ready', url, port, isEmpty });
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  process.send?.({ type: 'error', message });
+  console.error(`difit server failed to start: ${message}`);
+  process.exit(1);
+});

--- a/packages/vscode/src/watcher-shim.ts
+++ b/packages/vscode/src/watcher-shim.ts
@@ -1,0 +1,27 @@
+// Drop-in replacement for @parcel/watcher used in the bundled VS Code build.
+// The real package resolves its native binding through node_modules at load
+// time; here the prebuilt binaries ship inside the extension at
+// dist/server/prebuilds/<package-name>/watcher.node instead.
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+import { MUSL, familySync } from 'detect-libc';
+
+import { createWrapper } from '#parcel-watcher-wrapper';
+
+function bindingPackageName(): string {
+  let name = `@parcel/watcher-${process.platform}-${process.arch}`;
+  if (process.platform === 'linux') {
+    name += familySync() === MUSL ? '-musl' : '-glibc';
+  }
+  return name;
+}
+
+const requireBinding = createRequire(__filename);
+const bindingPath = path.join(__dirname, 'prebuilds', bindingPackageName(), 'watcher.node');
+const wrapper = createWrapper(requireBinding(bindingPath));
+
+export const writeSnapshot = wrapper.writeSnapshot;
+export const getEventsSince = wrapper.getEventsSince;
+export const subscribe = wrapper.subscribe;
+export const unsubscribe = wrapper.unsubscribe;

--- a/packages/vscode/tsconfig.json
+++ b/packages/vscode/tsconfig.json
@@ -1,18 +1,22 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "Node16",
-    "moduleResolution": "Node16",
     "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["node"],
     "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "outDir": "dist",
-    "rootDir": "src",
-    "types": ["node", "vscode"],
-    "sourceMap": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": true
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "paths": {
+      "@/*": ["../../src/*"]
+    }
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*", "../../src/server/**/*", "../../src/types/**/*", "../../src/utils/**/*"],
+  "exclude": ["../../src/**/*.test.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,15 +138,24 @@ importers:
 
   packages/vscode:
     devDependencies:
+      '@parcel/watcher':
+        specifier: ^2.5.1
+        version: 2.5.6
       '@types/node':
         specifier: ^24.0.8
         version: 24.13.2
       '@types/vscode':
-        specifier: ^1.98.0
+        specifier: ^1.102.0
         version: 1.125.0
       '@vscode/vsce':
         specifier: ^3.6.2
         version: 3.9.2
+      detect-libc:
+        specifier: ^2.0.3
+        version: 2.1.2
+      esbuild:
+        specifier: ^0.25.0
+        version: 0.25.12
       typescript:
         specifier: ^6.0.0
         version: 6.0.3
@@ -319,6 +328,162 @@ packages:
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -2257,6 +2422,11 @@ packages:
   es-toolkit@1.47.0:
     resolution: {integrity: sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==}
 
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -3348,10 +3518,6 @@ packages:
     resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
-    engines: {node: '>=12'}
-
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
@@ -4354,6 +4520,84 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@2.7.0))':
     dependencies:
       eslint: 9.39.2(jiti@2.7.0)
@@ -4818,7 +5062,7 @@ snapshots:
       detect-libc: 2.1.2
       is-glob: 4.0.3
       node-addon-api: 7.1.1
-      picomatch: 4.0.3
+      picomatch: 4.0.4
     optionalDependencies:
       '@parcel/watcher-android-arm64': 2.5.6
       '@parcel/watcher-darwin-arm64': 2.5.6
@@ -6071,6 +6315,35 @@ snapshots:
       hasown: 2.0.4
 
   es-toolkit@1.47.0: {}
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
 
   escalade@3.2.0: {}
 
@@ -7472,8 +7745,6 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
-
-  picomatch@4.0.3: {}
 
   picomatch@4.0.4: {}
 

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'child_process';
 import { fstatSync, type Stats } from 'node:fs';
-import { createInterface } from 'readline/promises';
+import { createInterface } from 'node:readline/promises';
 
 import type { SimpleGit } from 'simple-git';
 

--- a/src/server/file-watcher.ts
+++ b/src/server/file-watcher.ts
@@ -1,6 +1,5 @@
 import { join, resolve } from 'path';
 
-import { subscribe } from '@parcel/watcher';
 import { type Response } from 'express';
 import { simpleGit, type SimpleGit } from 'simple-git';
 
@@ -88,6 +87,11 @@ export class FileWatcherService {
   }
 
   private async setupWatchers(modeConfig: ModeWatchConfig, basePath: string): Promise<void> {
+    // Loaded lazily so environments without a native @parcel/watcher binding
+    // (e.g. an unsupported platform) degrade to no live reload instead of
+    // failing at module load time.
+    const { subscribe } = await import('@parcel/watcher');
+
     for (const watchPath of modeConfig.watchPaths) {
       let fullPath = join(basePath, watchPath);
 


### PR DESCRIPTION
## What

Rebuilds the VS Code extension from scratch so that difit ships **inside** the extension and runs on the extension host's own Node.js runtime, instead of requiring a globally installed `difit` CLI.

- **Bundled server**: `packages/vscode/src/server-entry.ts` calls `startServer()` from the monorepo source and is bundled with esbuild into `dist/server/index.js` (~1.4 MB). The prebuilt client assets are copied into `dist/client`.
- **fork + IPC launch**: the extension launches the server with `child_process.fork`, which always uses VS Code's own Node runtime — no dependency on the user's shell or PATH. The server URL is reported over the IPC channel instead of scraping stdout. `execArgv: []` prevents debug-port conflicts when the extension host runs with `--inspect`.
- **Native watcher prebuilds**: `@parcel/watcher` is aliased to a small shim that loads the platform binary from `dist/server/prebuilds/`; the VSIX ships binaries for all 10 VS Code desktop platforms (~4.4 MB). `build.mjs` copies them from local node_modules or fetches them from the npm registry (cached under `.cache/`).
- **Graceful degradation (core change)**: `FileWatcherService` now imports `@parcel/watcher` lazily, so a missing native binding degrades to "no live reload" instead of failing server startup. This also makes the CLI more robust.
- **Escape hatch**: the `difit.executablePath` setting still allows running an external difit CLI; the install-prompt flow and login-shell fallback are gone.
- `src/cli/utils.ts` now imports `node:readline/promises` (the unprefixed specifier is not recognized as a builtin by esbuild).

## Why

The previous extension spawned a globally installed `difit` and had to fight shell/PATH differences (login-shell fallback, PATH injection, exit-127 retry). That failure class is unfixable across nvm/mise/volta/fish/Windows setups. Bundling removes it entirely: the VSIX is 3.31 MB and works out of the box.

## Notes for reviewers

- Smoke-tested the fork+IPC path: server starts, `ready` arrives over IPC, `/`, `/api/diff`, and assets all return 200.
- `vsce package --no-dependencies` produces `difit-vscode-0.1.0.vsix` (125 files, 3.31 MB).
- All repo checks pass (oxlint type-aware, oxfmt, knip, 684 tests).
- Follow-up (not in this PR): CI to build and publish the VSIX on difit release tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)