### PR TITLE
feat(cli): add `comment resolve` verb to remove threads via CLI

### DIFF
--- a/src/cli/comment.test.ts
+++ b/src/cli/comment.test.ts
@@ -9,10 +9,11 @@ describe('createCommentCommand', () => {
     expect(command.name()).toBe('comment');
   });
 
-  it('has "add" and "get" subcommands', () => {
+  it('has "add", "get", and "resolve" subcommands', () => {
     const subcommandNames = command.commands.map((c) => c.name());
     expect(subcommandNames).toContain('add');
     expect(subcommandNames).toContain('get');
+    expect(subcommandNames).toContain('resolve');
   });
 
   describe('add subcommand', () => {
@@ -46,6 +47,28 @@ describe('createCommentCommand', () => {
       expect(formatOption).toBeDefined();
       expect(formatOption?.defaultValue).toBe('text');
       expect(formatOption?.argChoices).toEqual(['text', 'json']);
+    });
+  });
+
+  describe('resolve subcommand', () => {
+    const resolveCommand = command.commands.find((c) => c.name() === 'resolve')!;
+
+    it('has "remove" alias', () => {
+      expect(resolveCommand.aliases()).toContain('remove');
+    });
+
+    it('requires --port option', () => {
+      const portOption = resolveCommand.options.find((o) => o.long === '--port');
+      expect(portOption).toBeDefined();
+      expect(portOption?.mandatory).toBe(true);
+    });
+
+    it('accepts variadic threadIds argument', () => {
+      const args = resolveCommand.registeredArguments;
+      expect(args).toHaveLength(1);
+      expect(args[0].name()).toBe('threadIds');
+      expect(args[0].required).toBe(true);
+      expect(args[0].variadic).toBe(true);
     });
   });
 });
@@ -202,6 +225,92 @@ describe('comment subcommand integration', () => {
       await command.parseAsync(['node', 'difit', 'get', '--port', '4966']);
 
       expect(consoleOutput).toHaveLength(0);
+    });
+  });
+
+  describe('resolve', () => {
+    it('sends DELETE requests for each thread ID', async () => {
+      mockFetch.mockResolvedValue(jsonResponse({ success: true, threadId: 'abc123', version: 2 }));
+
+      const command = createCommentCommand();
+      await command.parseAsync(['node', 'difit', 'resolve', '--port', '4966', 'abc123', 'def456']);
+
+      expect(mockFetch).toHaveBeenCalledWith('http://localhost:4966/api/comments/abc123', {
+        method: 'DELETE',
+      });
+      expect(mockFetch).toHaveBeenCalledWith('http://localhost:4966/api/comments/def456', {
+        method: 'DELETE',
+      });
+      expect(consoleOutput[0]).toBe(
+        JSON.stringify({
+          success: true,
+          resolved: ['abc123', 'def456'],
+          notFound: [],
+        }),
+      );
+      expect(process.exit).not.toHaveBeenCalled();
+    });
+
+    it('works via the remove alias', async () => {
+      mockFetch.mockResolvedValue(jsonResponse({ success: true, threadId: 'abc123', version: 2 }));
+
+      const command = createCommentCommand();
+      await command.parseAsync(['node', 'difit', 'remove', '--port', '4966', 'abc123']);
+
+      expect(mockFetch).toHaveBeenCalledWith('http://localhost:4966/api/comments/abc123', {
+        method: 'DELETE',
+      });
+      expect(consoleOutput[0]).toContain('"success":true');
+    });
+
+    it('URL-encodes thread IDs', async () => {
+      mockFetch.mockResolvedValue(jsonResponse({ success: true }));
+
+      const command = createCommentCommand();
+      await command.parseAsync(['node', 'difit', 'resolve', '--port', '4966', 'a/b c']);
+
+      expect(mockFetch).toHaveBeenCalledWith('http://localhost:4966/api/comments/a%2Fb%20c', {
+        method: 'DELETE',
+      });
+    });
+
+    it('reports unknown thread IDs and exits with an error', async () => {
+      mockFetch
+        .mockResolvedValueOnce(jsonResponse({ success: true, threadId: 'abc123', version: 2 }))
+        .mockResolvedValueOnce(jsonResponse({ error: 'Thread not found: missing' }, 404));
+
+      const command = createCommentCommand();
+      await command.parseAsync(['node', 'difit', 'resolve', '--port', '4966', 'abc123', 'missing']);
+
+      expect(consoleOutput[0]).toBe(
+        JSON.stringify({
+          success: false,
+          resolved: ['abc123'],
+          notFound: ['missing'],
+        }),
+      );
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+
+    it('handles server error response', async () => {
+      mockFetch.mockResolvedValue(jsonResponse({ error: 'Internal error' }, 500));
+
+      const command = createCommentCommand();
+      await command.parseAsync(['node', 'difit', 'resolve', '--port', '4966', 'abc123']);
+
+      expect(consoleErrors[0]).toContain('Internal error');
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+
+    it('handles connection error', async () => {
+      mockFetch.mockRejectedValue(new TypeError('fetch failed'));
+
+      const command = createCommentCommand();
+      await command.parseAsync(['node', 'difit', 'resolve', '--port', '9999', 'abc123']);
+
+      expect(consoleErrors[0]).toContain('Cannot connect');
+      expect(consoleErrors[0]).toContain('9999');
+      expect(process.exit).toHaveBeenCalledWith(1);
     });
   });
 });

--- a/src/cli/comment.test.ts
+++ b/src/cli/comment.test.ts
@@ -246,6 +246,7 @@ describe('comment subcommand integration', () => {
           success: true,
           resolved: ['abc123', 'def456'],
           notFound: [],
+          errors: [],
         }),
       );
       expect(process.exit).not.toHaveBeenCalled();
@@ -287,18 +288,28 @@ describe('comment subcommand integration', () => {
           success: false,
           resolved: ['abc123'],
           notFound: ['missing'],
+          errors: [],
         }),
       );
       expect(process.exit).toHaveBeenCalledWith(1);
     });
 
-    it('handles server error response', async () => {
-      mockFetch.mockResolvedValue(jsonResponse({ error: 'Internal error' }, 500));
+    it('collects server errors without dropping remaining thread IDs', async () => {
+      mockFetch
+        .mockResolvedValueOnce(jsonResponse({ error: 'Internal error' }, 500))
+        .mockResolvedValueOnce(jsonResponse({ success: true, threadId: 'def456', version: 2 }));
 
       const command = createCommentCommand();
-      await command.parseAsync(['node', 'difit', 'resolve', '--port', '4966', 'abc123']);
+      await command.parseAsync(['node', 'difit', 'resolve', '--port', '4966', 'abc123', 'def456']);
 
-      expect(consoleErrors[0]).toContain('Internal error');
+      expect(consoleOutput[0]).toBe(
+        JSON.stringify({
+          success: false,
+          resolved: ['def456'],
+          notFound: [],
+          errors: [{ threadId: 'abc123', error: 'Internal error' }],
+        }),
+      );
       expect(process.exit).toHaveBeenCalledWith(1);
     });
 

--- a/src/cli/comment.ts
+++ b/src/cli/comment.ts
@@ -30,7 +30,7 @@ async function parseCommentAddInput(json?: string): Promise<string> {
 
 export function createCommentCommand(): Command {
   const comment = new Command('comment').description(
-    'Add or retrieve comments on a running difit server',
+    'Add, retrieve, or resolve comments on a running difit server',
   );
 
   comment
@@ -50,7 +50,9 @@ export function createCommentCommand(): Command {
         });
 
         if (!response.ok) {
-          const errorBody = (await response.json().catch(() => ({}))) as { error?: string };
+          const errorBody = (await response.json().catch(() => ({}))) as {
+            error?: string;
+          };
           console.error(`Error: ${errorBody.error ?? 'Failed to add comments'}`);
           process.exit(1);
         }
@@ -101,6 +103,62 @@ export function createCommentCommand(): Command {
           if (text.trim()) {
             console.log(text);
           }
+        }
+      } catch (error) {
+        if (error instanceof TypeError && error.message.includes('fetch failed')) {
+          console.error(
+            `Error: Cannot connect to difit server on port ${opts.port}. Is the server running?`,
+          );
+        } else {
+          console.error(`Error: ${error instanceof Error ? error.message : 'Unknown error'}`);
+        }
+        process.exit(1);
+      }
+    });
+
+  comment
+    .command('resolve')
+    .alias('remove')
+    .description('Resolve (remove) comment threads on a running difit server')
+    .argument('<threadIds...>', 'thread IDs to resolve')
+    .requiredOption('--port <port>', 'port of the running difit server', parseInt)
+    .action(async (threadIds: string[], opts: { port: number }) => {
+      try {
+        const resolved: string[] = [];
+        const notFound: string[] = [];
+
+        for (const threadId of threadIds) {
+          const response = await fetch(
+            `http://localhost:${opts.port}/api/comments/${encodeURIComponent(threadId)}`,
+            { method: 'DELETE' },
+          );
+
+          if (response.ok) {
+            resolved.push(threadId);
+            continue;
+          }
+
+          if (response.status === 404) {
+            notFound.push(threadId);
+            continue;
+          }
+
+          const errorBody = (await response.json().catch(() => ({}))) as {
+            error?: string;
+          };
+          console.error(`Error: ${errorBody.error ?? `Failed to resolve thread ${threadId}`}`);
+          process.exit(1);
+        }
+
+        console.log(
+          JSON.stringify({
+            success: notFound.length === 0,
+            resolved,
+            notFound,
+          }),
+        );
+        if (notFound.length > 0) {
+          process.exit(1);
         }
       } catch (error) {
         if (error instanceof TypeError && error.message.includes('fetch failed')) {

--- a/src/cli/comment.ts
+++ b/src/cli/comment.ts
@@ -11,6 +11,15 @@ interface CommentImportResponse {
   warnings?: string[];
 }
 
+function handleCommandError(error: unknown, port: number): never {
+  if (error instanceof TypeError && error.message.includes('fetch failed')) {
+    console.error(`Error: Cannot connect to difit server on port ${port}. Is the server running?`);
+  } else {
+    console.error(`Error: ${error instanceof Error ? error.message : 'Unknown error'}`);
+  }
+  process.exit(1);
+}
+
 async function parseCommentAddInput(json?: string): Promise<string> {
   if (typeof json === 'string') {
     return json;
@@ -67,14 +76,7 @@ export function createCommentCommand(): Command {
           }),
         );
       } catch (error) {
-        if (error instanceof TypeError && error.message.includes('fetch failed')) {
-          console.error(
-            `Error: Cannot connect to difit server on port ${opts.port}. Is the server running?`,
-          );
-        } else {
-          console.error(`Error: ${error instanceof Error ? error.message : 'Unknown error'}`);
-        }
-        process.exit(1);
+        handleCommandError(error, opts.port);
       }
     });
 
@@ -105,14 +107,7 @@ export function createCommentCommand(): Command {
           }
         }
       } catch (error) {
-        if (error instanceof TypeError && error.message.includes('fetch failed')) {
-          console.error(
-            `Error: Cannot connect to difit server on port ${opts.port}. Is the server running?`,
-          );
-        } else {
-          console.error(`Error: ${error instanceof Error ? error.message : 'Unknown error'}`);
-        }
-        process.exit(1);
+        handleCommandError(error, opts.port);
       }
     });
 
@@ -124,51 +119,62 @@ export function createCommentCommand(): Command {
     .requiredOption('--port <port>', 'port of the running difit server', parseInt)
     .action(async (threadIds: string[], opts: { port: number }) => {
       try {
-        const resolved: string[] = [];
-        const notFound: string[] = [];
+        const results = await Promise.all(
+          threadIds.map(
+            async (
+              threadId,
+            ): Promise<{
+              threadId: string;
+              status: 'resolved' | 'notFound' | 'error';
+              error?: string;
+            }> => {
+              const response = await fetch(
+                `http://localhost:${opts.port}/api/comments/${encodeURIComponent(threadId)}`,
+                { method: 'DELETE' },
+              );
 
-        for (const threadId of threadIds) {
-          const response = await fetch(
-            `http://localhost:${opts.port}/api/comments/${encodeURIComponent(threadId)}`,
-            { method: 'DELETE' },
-          );
+              if (response.ok) {
+                return { threadId, status: 'resolved' };
+              }
 
-          if (response.ok) {
-            resolved.push(threadId);
-            continue;
-          }
+              if (response.status === 404) {
+                return { threadId, status: 'notFound' };
+              }
 
-          if (response.status === 404) {
-            notFound.push(threadId);
-            continue;
-          }
+              const errorBody = (await response.json().catch(() => ({}))) as {
+                error?: string;
+              };
+              return {
+                threadId,
+                status: 'error',
+                error: errorBody.error ?? `Failed to resolve thread ${threadId}`,
+              };
+            },
+          ),
+        );
 
-          const errorBody = (await response.json().catch(() => ({}))) as {
-            error?: string;
-          };
-          console.error(`Error: ${errorBody.error ?? `Failed to resolve thread ${threadId}`}`);
-          process.exit(1);
-        }
+        const resolved = results.filter((r) => r.status === 'resolved').map((r) => r.threadId);
+        const notFound = results.filter((r) => r.status === 'notFound').map((r) => r.threadId);
+        const errors = results
+          .filter((r) => r.status === 'error')
+          .map((r) => ({
+            threadId: r.threadId,
+            error: r.error ?? `Failed to resolve thread ${r.threadId}`,
+          }));
 
         console.log(
           JSON.stringify({
-            success: notFound.length === 0,
+            success: notFound.length === 0 && errors.length === 0,
             resolved,
             notFound,
+            errors,
           }),
         );
-        if (notFound.length > 0) {
+        if (notFound.length > 0 || errors.length > 0) {
           process.exit(1);
         }
       } catch (error) {
-        if (error instanceof TypeError && error.message.includes('fetch failed')) {
-          console.error(
-            `Error: Cannot connect to difit server on port ${opts.port}. Is the server running?`,
-          );
-        } else {
-          console.error(`Error: ${error instanceof Error ? error.message : 'Unknown error'}`);
-        }
-        process.exit(1);
+        handleCommandError(error, opts.port);
       }
     });
 

--- a/src/server/server.test.ts
+++ b/src/server/server.test.ts
@@ -222,7 +222,10 @@ describe('Server Integration Tests', () => {
 
     it('merges concurrent agent additions instead of clobbering on a stale push', async () => {
       const port = await getAvailablePort(4966);
-      const result = await startServer({ preferredPort: port, openBrowser: false });
+      const result = await startServer({
+        preferredPort: port,
+        openBrowser: false,
+      });
 
       try {
         // Browser establishes a thread; it now knows version 1.
@@ -273,7 +276,10 @@ describe('Server Integration Tests', () => {
 
     it('replaces (honoring deletions) when the push version matches', async () => {
       const port = await getAvailablePort(4966);
-      const result = await startServer({ preferredPort: port, openBrowser: false });
+      const result = await startServer({
+        preferredPort: port,
+        openBrowser: false,
+      });
 
       try {
         await postThreads(result.port, [makeThread('t1', 'src/a.ts', 10, 'human thread')]);
@@ -300,7 +306,10 @@ describe('Server Integration Tests', () => {
 
     it('bumps the version when a reply is imported (so the change is broadcast)', async () => {
       const port = await getAvailablePort(4966);
-      const result = await startServer({ preferredPort: port, openBrowser: false });
+      const result = await startServer({
+        preferredPort: port,
+        openBrowser: false,
+      });
 
       try {
         await postThreads(result.port, [makeThread('t1', 'src/a.ts', 10, 'human thread')]);
@@ -980,6 +989,53 @@ describe('Server Integration Tests', () => {
       expect(threads).toHaveLength(1);
     });
 
+    it('DELETE /api/comments/:threadId removes the thread and bumps the version', async () => {
+      await fetch(`http://localhost:${port}/api/comment-imports`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify([
+          {
+            type: 'thread',
+            id: 'delete-me',
+            filePath: 'src/delete-test.ts',
+            position: { side: 'new', line: 3 },
+            body: 'Thread to delete',
+          },
+        ]),
+      });
+
+      const beforeResponse = await fetch(`http://localhost:${port}/api/comments-json`);
+      const before = (await beforeResponse.json()) as any;
+      expect(before.threads.some((t: any) => t.id === 'delete-me')).toBe(true);
+
+      const deleteResponse = await fetch(`http://localhost:${port}/api/comments/delete-me`, {
+        method: 'DELETE',
+      });
+      const deleteData = (await deleteResponse.json()) as any;
+
+      expect(deleteResponse.ok).toBe(true);
+      expect(deleteData).toMatchObject({
+        success: true,
+        threadId: 'delete-me',
+      });
+      expect(deleteData.version).toBe(before.version + 1);
+
+      const afterResponse = await fetch(`http://localhost:${port}/api/comments-json`);
+      const after = (await afterResponse.json()) as any;
+      expect(after.threads.some((t: any) => t.id === 'delete-me')).toBe(false);
+    });
+
+    it('DELETE /api/comments/:threadId returns 404 for unknown thread', async () => {
+      const response = await fetch(`http://localhost:${port}/api/comments/does-not-exist`, {
+        method: 'DELETE',
+      });
+
+      expect(response.status).toBe(404);
+      const data = (await response.json()) as any;
+      expect(data).toHaveProperty('error');
+      expect(data.error).toContain('does-not-exist');
+    });
+
     it('isolates comment sessions between different diff selections', async () => {
       const importServer = await startServer({
         selection: { targetCommitish: 'HEAD', baseCommitish: 'HEAD^' },
@@ -1187,7 +1243,10 @@ describe('Server Integration Tests', () => {
 
       expect(response.ok).toBe(true);
       expect(data.specialOptions).toHaveLength(3);
-      expect(data.specialOptions).not.toContainEqual({ value: 'merge-base', label: 'Merge Base' });
+      expect(data.specialOptions).not.toContainEqual({
+        value: 'merge-base',
+        label: 'Merge Base',
+      });
       expect(data.branches).toEqual([{ name: 'main', current: true }]);
       expect(data.commits).toEqual([
         { hash: 'abc1234', shortHash: 'abc1234', message: 'Test commit' },

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -199,11 +199,12 @@ export async function startServer(
     Boolean(options.stdinDiff),
   );
 
-  function parseRepositoryRelativePath(
-    filepath: unknown,
-  ):
+  function parseRepositoryRelativePath(filepath: unknown):
     | { ok: true; path: string }
-    | { ok: false; error: 'Invalid file path' | 'File path outside repository' } {
+    | {
+        ok: false;
+        error: 'Invalid file path' | 'File path outside repository';
+      } {
     if (typeof filepath !== 'string' || filepath.length === 0) {
       return { ok: false, error: 'Invalid file path' };
     }
@@ -772,6 +773,26 @@ export async function startServer(
       console.error('Error parsing comment imports:', error);
       res.status(400).json({ error: 'Invalid comment import data' });
     }
+  });
+
+  app.delete('/api/comments/:threadId', (req, res) => {
+    const selection = getCommentSelectionFromQuery(req.query as Record<string, unknown>);
+    const session = getOrCreateCommentSession(selection);
+    const threadId = req.params.threadId;
+    const nextThreads = session.threads.filter((thread) => thread.id !== threadId);
+
+    if (nextThreads.length === session.threads.length) {
+      res.status(404).json({ error: `Thread not found: ${threadId}` });
+      return;
+    }
+
+    updateCommentSession(selection, nextThreads);
+
+    res.json({
+      success: true,
+      threadId,
+      version: session.version,
+    });
   });
 
   app.get('/api/comments-json', (req, res) => {


### PR DESCRIPTION
## Summary

Adds a CLI verb to resolve/remove comment threads on a running difit server, closing the main gap called out in #426: `difit comment add` / `get` already cover an agent review loop, but resolving or deleting a thread previously required re-POSTing the full thread set to the internal `/api/comments` endpoint.

## What changed

- **New endpoint** `DELETE /api/comments/:threadId`: removes the thread from the comment session, bumps the session version, and reuses the existing `commentsChanged` SSE broadcast so open browsers refresh immediately. Returns 404 for unknown thread IDs.
- **New CLI verb** `difit comment resolve <threadIds...> --port <port>` (alias: `remove`): accepts one or more thread IDs (as returned by `difit comment get --format json`), deletes them in parallel, and prints a JSON summary like `{"success":true,"resolved":["abc123"],"notFound":[],"errors":[]}`. Unknown IDs go to `notFound` and non-404 server failures go to `errors` (as `{threadId, error}`) without aborting the remaining IDs; the command exits with code 1 if either is non-empty, so agents can detect partial failures.

## Notes for review

- In the web UI, resolving a thread removes it (there is no `resolved` flag in the data model), so `resolve` and `remove` are aliases for the same operation. If a distinct resolved state is introduced later, the verbs can diverge then.
- Tests added on both sides: CLI (DELETE requests, alias, URL-encoding of IDs, partial-failure collection, 404/connection error handling) and server (thread removal + version bump, 404 for unknown IDs).

Closes the resolve/remove portion of #426.

🤖 Generated with [Claude Code](https://claude.com/claude-code)