### PR TITLE
feat(client): replace resolve/delete browser confirm() with inline confirmation UI

### DIFF
--- a/src/client/components/CommentThreadCard.test.tsx
+++ b/src/client/components/CommentThreadCard.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import type { CommentThread } from '../../types/diff';
 
@@ -33,10 +33,6 @@ const mockThread: CommentThread = {
 };
 
 describe('CommentThreadCard', () => {
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
-
   it('does not show delete action for replies authored by someone else', () => {
     render(
       <CommentThreadCard
@@ -77,11 +73,9 @@ describe('CommentThreadCard', () => {
     expect(screen.queryByTitle('Edit message')).not.toBeInTheDocument();
   });
 
-  it('confirms before resolving a root comment by default', async () => {
+  it('shows an inline confirmation before resolving a root comment by default', async () => {
     const user = userEvent.setup();
-    const confirmSpy = vi.fn(() => false);
     const onRemoveThread = vi.fn();
-    vi.stubGlobal('confirm', confirmSpy);
 
     render(
       <CommentThreadCard
@@ -96,8 +90,104 @@ describe('CommentThreadCard', () => {
 
     await user.click(screen.getByTitle('Resolve thread'));
 
-    expect(confirmSpy).toHaveBeenCalledWith('Resolve this thread?\n\n"Root comment"');
     expect(onRemoveThread).not.toHaveBeenCalled();
+    expect(screen.getByText('Resolve?')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Resolve' }));
+
+    expect(onRemoveThread).toHaveBeenCalledWith('thread-1');
+  });
+
+  it('cancels the inline resolve confirmation with the cancel button', async () => {
+    const user = userEvent.setup();
+    const onRemoveThread = vi.fn();
+
+    render(
+      <CommentThreadCard
+        thread={mockThread}
+        onGeneratePrompt={() => 'thread prompt'}
+        onRemoveThread={onRemoveThread}
+        onReplyToThread={vi.fn().mockResolvedValue(undefined)}
+        onRemoveMessage={vi.fn()}
+        onUpdateMessage={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByTitle('Resolve thread'));
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onRemoveThread).not.toHaveBeenCalled();
+    expect(screen.queryByText('Resolve?')).not.toBeInTheDocument();
+    expect(screen.getByTitle('Resolve thread')).toBeInTheDocument();
+  });
+
+  it('cancels the inline resolve confirmation with Escape', async () => {
+    const user = userEvent.setup();
+    const onRemoveThread = vi.fn();
+
+    render(
+      <CommentThreadCard
+        thread={mockThread}
+        onGeneratePrompt={() => 'thread prompt'}
+        onRemoveThread={onRemoveThread}
+        onReplyToThread={vi.fn().mockResolvedValue(undefined)}
+        onRemoveMessage={vi.fn()}
+        onUpdateMessage={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByTitle('Resolve thread'));
+    await user.keyboard('{Escape}');
+
+    expect(onRemoveThread).not.toHaveBeenCalled();
+    expect(screen.queryByText('Resolve?')).not.toBeInTheDocument();
+  });
+
+  it('cancels the inline resolve confirmation when clicking outside', async () => {
+    const user = userEvent.setup();
+    const onRemoveThread = vi.fn();
+
+    render(
+      <div>
+        <button type="button">outside</button>
+        <CommentThreadCard
+          thread={mockThread}
+          onGeneratePrompt={() => 'thread prompt'}
+          onRemoveThread={onRemoveThread}
+          onReplyToThread={vi.fn().mockResolvedValue(undefined)}
+          onRemoveMessage={vi.fn()}
+          onUpdateMessage={vi.fn()}
+        />
+      </div>,
+    );
+
+    await user.click(screen.getByTitle('Resolve thread'));
+    await user.click(screen.getByRole('button', { name: 'outside' }));
+
+    expect(onRemoveThread).not.toHaveBeenCalled();
+    expect(screen.queryByText('Resolve?')).not.toBeInTheDocument();
+  });
+
+  it('resolves immediately without confirmation when confirmRootAction is false', async () => {
+    const user = userEvent.setup();
+    const onRemoveThread = vi.fn();
+
+    render(
+      <CommentThreadCard
+        thread={mockThread}
+        confirmRootAction={false}
+        onGeneratePrompt={() => 'thread prompt'}
+        onRemoveThread={onRemoveThread}
+        onReplyToThread={vi.fn().mockResolvedValue(undefined)}
+        onRemoveMessage={vi.fn()}
+        onUpdateMessage={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByTitle('Resolve thread'));
+
+    expect(screen.queryByText('Resolve?')).not.toBeInTheDocument();
+    expect(onRemoveThread).toHaveBeenCalledWith('thread-1');
   });
 
   it('shows the "Outdated" badge when the thread is marked outdated', () => {
@@ -133,11 +223,9 @@ describe('CommentThreadCard', () => {
     expect(screen.queryByLabelText('Outdated comment')).not.toBeInTheDocument();
   });
 
-  it('confirms before deleting a user-authored reply', async () => {
+  it('shows an inline confirmation before deleting a user-authored reply', async () => {
     const user = userEvent.setup();
-    const confirmSpy = vi.fn(() => false);
     const onRemoveMessage = vi.fn();
-    vi.stubGlobal('confirm', confirmSpy);
 
     render(
       <CommentThreadCard
@@ -161,7 +249,11 @@ describe('CommentThreadCard', () => {
 
     await user.click(screen.getByTitle('Delete reply'));
 
-    expect(confirmSpy).toHaveBeenCalledWith('Delete this reply?\n\n"Reply comment"');
     expect(onRemoveMessage).not.toHaveBeenCalled();
+    expect(screen.getByText('Delete?')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+    expect(onRemoveMessage).toHaveBeenCalledWith('thread-1', 'message-2');
   });
 });

--- a/src/client/components/CommentThreadCard.test.tsx
+++ b/src/client/components/CommentThreadCard.test.tsx
@@ -143,6 +143,33 @@ describe('CommentThreadCard', () => {
     expect(screen.queryByText('Resolve?')).not.toBeInTheDocument();
   });
 
+  it('consumes Escape so surrounding Escape handlers do not fire', async () => {
+    const user = userEvent.setup();
+    const outerKeyDown = vi.fn();
+    document.addEventListener('keydown', outerKeyDown);
+
+    try {
+      render(
+        <CommentThreadCard
+          thread={mockThread}
+          onGeneratePrompt={() => 'thread prompt'}
+          onRemoveThread={vi.fn()}
+          onReplyToThread={vi.fn().mockResolvedValue(undefined)}
+          onRemoveMessage={vi.fn()}
+          onUpdateMessage={vi.fn()}
+        />,
+      );
+
+      await user.click(screen.getByTitle('Resolve thread'));
+      await user.keyboard('{Escape}');
+
+      expect(screen.queryByText('Resolve?')).not.toBeInTheDocument();
+      expect(outerKeyDown).not.toHaveBeenCalled();
+    } finally {
+      document.removeEventListener('keydown', outerKeyDown);
+    }
+  });
+
   it('cancels the inline resolve confirmation when clicking outside', async () => {
     const user = userEvent.setup();
     const onRemoveThread = vi.fn();

--- a/src/client/components/CommentThreadCard.tsx
+++ b/src/client/components/CommentThreadCard.tsx
@@ -1,5 +1,5 @@
 import { Check, Copy, Edit2, MessageSquareReply, Trash2 } from 'lucide-react';
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import { type CommentThread, type DiffCommentMessage } from '../../types/diff';
 import { copyTextToClipboard } from '../utils/clipboard';
@@ -18,7 +18,7 @@ interface ThreadMessageItemProps {
   onUpdate: (newBody: string) => void;
   onResolveOrDelete: () => void;
   actionLabel: string;
-  confirmMessage?: string;
+  confirmPrompt?: string;
   onClick?: (e: React.MouseEvent) => void;
 }
 
@@ -32,12 +32,39 @@ function ThreadMessageItem({
   onUpdate,
   onResolveOrDelete,
   actionLabel,
-  confirmMessage,
+  confirmPrompt,
   onClick,
 }: ThreadMessageItemProps) {
   const [isEditing, setIsEditing] = useState(false);
+  const [isConfirming, setIsConfirming] = useState(false);
+  const confirmContainerRef = useRef<HTMLDivElement>(null);
+  const confirmButtonRef = useRef<HTMLButtonElement>(null);
   const showAuthorHeader = showAuthorBadge && Boolean(message.author);
   const isUserAuthoredMessage = message.author?.trim() === 'User';
+
+  useEffect(() => {
+    if (!isConfirming) return;
+
+    confirmButtonRef.current?.focus();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsConfirming(false);
+      }
+    };
+    const handleMouseDown = (event: MouseEvent) => {
+      if (!confirmContainerRef.current?.contains(event.target as Node)) {
+        setIsConfirming(false);
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    document.addEventListener('mousedown', handleMouseDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.removeEventListener('mousedown', handleMouseDown);
+    };
+  }, [isConfirming]);
 
   const handleStartEdit = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -76,37 +103,73 @@ function ThreadMessageItem({
               syntaxTheme={syntaxTheme}
             />
           </div>
-          {(isRootMessage || isUserAuthoredMessage) && (
-            <div className="flex shrink-0 items-start gap-2 pt-0.5">
-              {isUserAuthoredMessage && (
+          {(isRootMessage || isUserAuthoredMessage) &&
+            (isConfirming ? (
+              <div
+                ref={confirmContainerRef}
+                className="flex shrink-0 items-center gap-1.5 pt-0.5"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <span className="whitespace-nowrap text-xs text-github-text-secondary">
+                  {confirmPrompt}
+                </span>
+                <button
+                  ref={confirmButtonRef}
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setIsConfirming(false);
+                    onResolveOrDelete();
+                  }}
+                  className={`whitespace-nowrap rounded border border-github-border bg-github-bg-tertiary px-2 py-1 text-xs font-medium transition-all hover:bg-github-bg-primary ${
+                    isRootMessage ? 'text-green-700 hover:text-green-800' : 'text-github-danger'
+                  }`}
+                >
+                  {isRootMessage ? 'Resolve' : 'Delete'}
+                </button>
                 <button
                   type="button"
-                  onClick={handleStartEdit}
-                  className="rounded border border-github-border bg-github-bg-tertiary p-1.5 text-github-text-primary transition-all hover:bg-github-bg-primary"
-                  title="Edit message"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setIsConfirming(false);
+                  }}
+                  className="whitespace-nowrap rounded border border-github-border bg-github-bg-tertiary px-2 py-1 text-xs text-github-text-primary transition-all hover:bg-github-bg-primary"
                 >
-                  <Edit2 size={12} />
+                  Cancel
                 </button>
-              )}
-              <button
-                type="button"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  if (confirmMessage && !confirm(confirmMessage)) {
-                    return;
-                  }
-                  onResolveOrDelete();
-                }}
-                className={`rounded border border-github-border bg-github-bg-tertiary p-1.5 transition-all hover:bg-github-bg-primary ${
-                  isRootMessage ? 'text-green-700 hover:text-green-800' : 'text-github-danger'
-                }`}
-                title={actionLabel}
-                aria-label={actionLabel}
-              >
-                {isRootMessage ? <Check size={12} /> : <Trash2 size={12} />}
-              </button>
-            </div>
-          )}
+              </div>
+            ) : (
+              <div className="flex shrink-0 items-start gap-2 pt-0.5">
+                {isUserAuthoredMessage && (
+                  <button
+                    type="button"
+                    onClick={handleStartEdit}
+                    className="rounded border border-github-border bg-github-bg-tertiary p-1.5 text-github-text-primary transition-all hover:bg-github-bg-primary"
+                    title="Edit message"
+                  >
+                    <Edit2 size={12} />
+                  </button>
+                )}
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    if (confirmPrompt) {
+                      setIsConfirming(true);
+                      return;
+                    }
+                    onResolveOrDelete();
+                  }}
+                  className={`rounded border border-github-border bg-github-bg-tertiary p-1.5 transition-all hover:bg-github-bg-primary ${
+                    isRootMessage ? 'text-green-700 hover:text-green-800' : 'text-github-danger'
+                  }`}
+                  title={actionLabel}
+                  aria-label={actionLabel}
+                >
+                  {isRootMessage ? <Check size={12} /> : <Trash2 size={12} />}
+                </button>
+              </div>
+            ))}
         </>
       ) : (
         <CommentForm
@@ -244,9 +307,7 @@ export function CommentThreadCard({
           onUpdate={(newBody) => onUpdateMessage(thread.id, rootMessage.id, newBody)}
           onResolveOrDelete={() => onRemoveThread(thread.id)}
           actionLabel="Resolve thread"
-          confirmMessage={
-            confirmRootAction ? `Resolve this thread?\n\n"${rootMessage.body}"` : undefined
-          }
+          confirmPrompt={confirmRootAction ? 'Resolve?' : undefined}
         />
 
         {thread.messages.slice(1).map((message) => (
@@ -260,7 +321,7 @@ export function CommentThreadCard({
               onUpdate={(newBody) => onUpdateMessage(thread.id, message.id, newBody)}
               onResolveOrDelete={() => onRemoveMessage(thread.id, message.id)}
               actionLabel="Delete reply"
-              confirmMessage={`Delete this reply?\n\n"${message.body}"`}
+              confirmPrompt="Delete?"
             />
           </div>
         ))}

--- a/src/client/components/CommentThreadCard.tsx
+++ b/src/client/components/CommentThreadCard.tsx
@@ -2,6 +2,7 @@ import { Check, Copy, Edit2, MessageSquareReply, Trash2 } from 'lucide-react';
 import React, { useEffect, useRef, useState } from 'react';
 
 import { type CommentThread, type DiffCommentMessage } from '../../types/diff';
+import { useClickOutside } from '../hooks/useClickOutside';
 import { copyTextToClipboard } from '../utils/clipboard';
 
 import { CommentBodyRenderer } from './CommentBodyRenderer';
@@ -42,28 +43,25 @@ function ThreadMessageItem({
   const showAuthorHeader = showAuthorBadge && Boolean(message.author);
   const isUserAuthoredMessage = message.author?.trim() === 'User';
 
+  useClickOutside(confirmContainerRef, () => setIsConfirming(false), isConfirming);
+
   useEffect(() => {
     if (!isConfirming) return;
 
     confirmButtonRef.current?.focus();
 
+    // Capture phase so Escape only cancels the confirmation and never reaches
+    // surrounding Escape handlers (e.g. the CommentsListModal close hotkey).
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
-        setIsConfirming(false);
-      }
-    };
-    const handleMouseDown = (event: MouseEvent) => {
-      if (!confirmContainerRef.current?.contains(event.target as Node)) {
+        event.preventDefault();
+        event.stopPropagation();
         setIsConfirming(false);
       }
     };
 
-    document.addEventListener('keydown', handleKeyDown);
-    document.addEventListener('mousedown', handleMouseDown);
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown);
-      document.removeEventListener('mousedown', handleMouseDown);
-    };
+    document.addEventListener('keydown', handleKeyDown, true);
+    return () => document.removeEventListener('keydown', handleKeyDown, true);
   }, [isConfirming]);
 
   const handleStartEdit = (e: React.MouseEvent) => {

--- a/src/client/components/CommentsDropdown.tsx
+++ b/src/client/components/CommentsDropdown.tsx
@@ -1,5 +1,7 @@
 import { Copy, Eraser, ChevronDown, Check, List } from 'lucide-react';
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef } from 'react';
+
+import { useClickOutside } from '../hooks/useClickOutside';
 
 interface CommentsDropdownProps {
   commentsCount: number;
@@ -25,16 +27,7 @@ export function CommentsDropdown({
   const isCompact = compact;
   const isUp = direction === 'up';
 
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
-        setIsOpen(false);
-      }
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
+  useClickOutside(dropdownRef, () => setIsOpen(false));
 
   const handleCopyAll = () => {
     onCopyAll();

--- a/src/client/hooks/useClickOutside.ts
+++ b/src/client/hooks/useClickOutside.ts
@@ -1,0 +1,23 @@
+import { useEffect, useRef, type RefObject } from 'react';
+
+export function useClickOutside<T extends HTMLElement>(
+  ref: RefObject<T | null>,
+  onClickOutside: () => void,
+  enabled = true,
+): void {
+  const handlerRef = useRef(onClickOutside);
+  handlerRef.current = onClickOutside;
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handleMouseDown = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        handlerRef.current();
+      }
+    };
+
+    document.addEventListener('mousedown', handleMouseDown);
+    return () => document.removeEventListener('mousedown', handleMouseDown);
+  }, [enabled, ref]);
+}


### PR DESCRIPTION
## What

Replaces the browser-native `confirm()` dialog in `CommentThreadCard` with an inline confirmation UI. Clicking resolve on a root comment (or delete on a user-authored reply) now swaps the action buttons for a compact confirm/cancel pair rendered inside the card:

- Root comment: `Resolve?` + **Resolve** / **Cancel** text buttons (green accent)
- Reply: `Delete?` + **Delete** / **Cancel** text buttons (danger accent)

The confirm button is focused automatically, so <kbd>Enter</kbd> confirms immediately. <kbd>Escape</kbd> or clicking anywhere outside the confirmation cancels it.

## Why

Addresses item 4 of #426: the blocking browser `confirm()` dialog gets in the way of agent-driven review loops (and can't be styled to match the app). An inline confirmation keeps the safety check without a modal dialog.

## Notes for reviewers

- The `confirmRootAction` prop keeps its existing semantics: when `false` (as passed by `CommentsListModal`), the root action still runs immediately with no confirmation.
- `CommentsListModal` has its own `confirm()` call shared with the `d` hotkey path; that is intentionally left unchanged here to keep this PR scoped to the thread card. It can be migrated in a follow-up.
- The internal `confirmMessage` prop (full message body in the dialog text) was replaced by a short `confirmPrompt` label, since the comment body is already visible right next to the inline prompt.
- Existing tests that stubbed `global.confirm` were rewritten to drive the inline UI, with added coverage for cancel via button, Escape, outside click, and the `confirmRootAction={false}` fast path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)