### PR TITLE
feat(client): render comment bodies as markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "react-dom": "^19.1.0",
     "react-hotkeys-hook": "^5.2.4",
     "react-markdown": "^10.1.0",
+    "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "simple-git": "^3.28.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.17)(react@19.2.7)
+      remark-breaks:
+        specifier: ^4.0.0
+        version: 4.0.0
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -3168,6 +3171,9 @@ packages:
   mdast-util-mdxjs-esm@2.0.1:
     resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
 
+  mdast-util-newline-to-break@2.0.0:
+    resolution: {integrity: sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==}
+
   mdast-util-phrasing@4.1.0:
     resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
 
@@ -3665,6 +3671,9 @@ packages:
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
+
+  remark-breaks@4.0.0:
+    resolution: {integrity: sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==}
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
@@ -7196,6 +7205,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mdast-util-newline-to-break@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-find-and-replace: 3.0.2
+
   mdast-util-phrasing@4.1.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -7919,6 +7933,12 @@ snapshots:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
+
+  remark-breaks@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-newline-to-break: 2.0.0
+      unified: 11.0.5
 
   remark-gfm@4.0.1:
     dependencies:

--- a/src/client/components/CommentBodyRenderer.test.tsx
+++ b/src/client/components/CommentBodyRenderer.test.tsx
@@ -44,6 +44,23 @@ describe('CommentBodyRenderer', () => {
     expect(container).toHaveTextContent('line two');
   });
 
+  it('keeps consecutive spaces inside paragraphs', () => {
+    const { container } = render(<CommentBodyRenderer body={'aligned:    value'} />);
+
+    const paragraph = container.querySelector('p');
+    expect(paragraph).not.toBeNull();
+    expect(paragraph?.textContent).toBe('aligned:    value');
+    expect(paragraph?.className).toContain('whitespace-pre-wrap');
+  });
+
+  it('treats 4-space indented lines as code blocks (markdown semantics)', () => {
+    const { container } = render(<CommentBodyRenderer body={'intro\n\n    indented line'} />);
+
+    const pre = container.querySelector('pre');
+    expect(pre).not.toBeNull();
+    expect(pre).toHaveTextContent('indented line');
+  });
+
   it('renders fenced code blocks inside <pre>', () => {
     const { container } = render(
       <CommentBodyRenderer body={'Check this:\n\n```ts\nconst x = 1;\n```'} />,

--- a/src/client/components/CommentBodyRenderer.test.tsx
+++ b/src/client/components/CommentBodyRenderer.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { WordHighlightProvider } from '../contexts/WordHighlightContext';
+
+import { CommentBodyRenderer } from './CommentBodyRenderer';
+
+describe('CommentBodyRenderer', () => {
+  it('renders plain text', () => {
+    render(<CommentBodyRenderer body="Just a plain comment" />);
+
+    expect(screen.getByText('Just a plain comment')).toBeInTheDocument();
+  });
+
+  it('renders bold text as <strong>', () => {
+    const { container } = render(<CommentBodyRenderer body="This is **important**" />);
+
+    const strong = container.querySelector('strong');
+    expect(strong).not.toBeNull();
+    expect(strong).toHaveTextContent('important');
+  });
+
+  it('renders inline code as <code>', () => {
+    const { container } = render(<CommentBodyRenderer body="Use `foo()` here" />);
+
+    const code = container.querySelector('code');
+    expect(code).not.toBeNull();
+    expect(code).toHaveTextContent('foo()');
+  });
+
+  it('renders strikethrough via GFM', () => {
+    const { container } = render(<CommentBodyRenderer body="~~removed~~" />);
+
+    const del = container.querySelector('del');
+    expect(del).not.toBeNull();
+    expect(del).toHaveTextContent('removed');
+  });
+
+  it('keeps single newlines as line breaks', () => {
+    const { container } = render(<CommentBodyRenderer body={'line one\nline two'} />);
+
+    expect(container.querySelector('br')).not.toBeNull();
+    expect(container).toHaveTextContent('line one');
+    expect(container).toHaveTextContent('line two');
+  });
+
+  it('renders fenced code blocks inside <pre>', () => {
+    const { container } = render(
+      <CommentBodyRenderer body={'Check this:\n\n```ts\nconst x = 1;\n```'} />,
+    );
+
+    const pre = container.querySelector('pre');
+    expect(pre).not.toBeNull();
+    expect(pre).toHaveTextContent('const x = 1;');
+  });
+
+  it('renders fenced diff blocks with addition/deletion backgrounds', () => {
+    const { container } = render(
+      <CommentBodyRenderer body={'```diff\n- const x = 1;\n+ const x = 2;\n  unchanged\n```'} />,
+    );
+
+    const addedLine = container.querySelector('.bg-diff-addition-bg');
+    const deletedLine = container.querySelector('.bg-diff-deletion-bg');
+    expect(addedLine).not.toBeNull();
+    expect(addedLine).toHaveTextContent('+ const x = 2;');
+    expect(deletedLine).not.toBeNull();
+    expect(deletedLine).toHaveTextContent('- const x = 1;');
+    expect(container).toHaveTextContent('unchanged');
+  });
+
+  it('renders safe links as anchors', () => {
+    const { container } = render(
+      <CommentBodyRenderer body="See [docs](https://example.com/docs)" />,
+    );
+
+    const anchor = container.querySelector('a');
+    expect(anchor).not.toBeNull();
+    expect(anchor).toHaveAttribute('href', 'https://example.com/docs');
+    expect(anchor).toHaveAttribute('target', '_blank');
+    expect(anchor).toHaveTextContent('docs');
+  });
+
+  it('does not render unsafe links as anchors', () => {
+    const { container } = render(<CommentBodyRenderer body="Click [here](javascript:alert(1))" />);
+
+    expect(container.querySelector('a')).toBeNull();
+    expect(container).toHaveTextContent('here');
+  });
+
+  it('does not render raw HTML', () => {
+    const { container } = render(<CommentBodyRenderer body='<img src="x" onerror="alert(1)">' />);
+
+    expect(container.querySelector('img')).toBeNull();
+  });
+
+  it('renders suggestion blocks with the suggested code', () => {
+    const { container } = render(
+      <WordHighlightProvider>
+        <CommentBodyRenderer
+          body={'Try this:\n\n```suggestion\nconst y = 2;\n```'}
+          originalCode="const y = 1;"
+        />
+      </WordHighlightProvider>,
+    );
+
+    expect(container).toHaveTextContent('Try this:');
+    expect(container).toHaveTextContent('const y = 2;');
+    expect(container).toHaveTextContent('const y = 1;');
+    expect(container.querySelector('.bg-diff-addition-bg')).not.toBeNull();
+    expect(container.querySelector('.bg-diff-deletion-bg')).not.toBeNull();
+  });
+
+  it('renders markdown around suggestion blocks', () => {
+    const { container } = render(
+      <WordHighlightProvider>
+        <CommentBodyRenderer
+          body={'**Before** the block\n\n```suggestion\nnew code\n```\n\n*After* the block'}
+        />
+      </WordHighlightProvider>,
+    );
+
+    expect(container.querySelector('strong')).toHaveTextContent('Before');
+    expect(container.querySelector('em')).toHaveTextContent('After');
+    expect(container).toHaveTextContent('new code');
+  });
+});

--- a/src/client/components/CommentBodyRenderer.tsx
+++ b/src/client/components/CommentBodyRenderer.tsx
@@ -1,9 +1,14 @@
-import { useMemo } from 'react';
+import React, { useMemo } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkBreaks from 'remark-breaks';
+import remarkGfm from 'remark-gfm';
 
 import { type DiffLine, type ExpandedLine } from '../../types/diff';
 import { hasSuggestionBlock, parseSuggestionBlocks } from '../../utils/suggestionUtils';
+import { extractMarkdownText, isElementWithCodeProps, isSafeUrl } from '../utils/markdownUtils';
 
 import { DiffCodeLine } from './DiffCodeLine';
+import { PrismSyntaxHighlighter } from './PrismSyntaxHighlighter';
 import type { AppearanceSettings } from './SettingsModal';
 
 type SuggestionPart = {
@@ -59,6 +64,151 @@ function SuggestionLines({
   );
 }
 
+const getDiffCodeLineClass = (line: string) => {
+  if (line.startsWith('+')) return 'bg-diff-addition-bg';
+  if (line.startsWith('-')) return 'bg-diff-deletion-bg';
+  return '';
+};
+
+function CommentDiffCodeBlock({ code }: { code: string }) {
+  return (
+    <div className="my-2 rounded-md border border-github-border bg-github-bg-secondary overflow-x-auto font-mono text-xs leading-5">
+      {code.split('\n').map((line, index) => (
+        <div key={index} className={`px-3 whitespace-pre ${getDiffCodeLineClass(line)}`}>
+          {line || ' '}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+const getCommentMarkdownComponents = (syntaxTheme?: AppearanceSettings['syntaxTheme']) => ({
+  h1: ({ children }: { children?: React.ReactNode }) => (
+    <h1 className="text-lg font-semibold mt-4 mb-2 first:mt-0">{children}</h1>
+  ),
+  h2: ({ children }: { children?: React.ReactNode }) => (
+    <h2 className="text-base font-semibold mt-4 mb-2 first:mt-0">{children}</h2>
+  ),
+  h3: ({ children }: { children?: React.ReactNode }) => (
+    <h3 className="text-sm font-semibold mt-3 mb-1 first:mt-0">{children}</h3>
+  ),
+  h4: ({ children }: { children?: React.ReactNode }) => (
+    <h4 className="text-sm font-semibold mt-3 mb-1 first:mt-0">{children}</h4>
+  ),
+  h5: ({ children }: { children?: React.ReactNode }) => (
+    <h5 className="text-sm font-semibold mt-3 mb-1 first:mt-0">{children}</h5>
+  ),
+  h6: ({ children }: { children?: React.ReactNode }) => (
+    <h6 className="text-sm font-semibold mt-3 mb-1 first:mt-0">{children}</h6>
+  ),
+  p: ({ children }: { children?: React.ReactNode }) => (
+    <p className="my-2 first:mt-0 last:mb-0">{children}</p>
+  ),
+  ul: ({ children }: { children?: React.ReactNode }) => (
+    <ul className="list-disc pl-5 my-2 first:mt-0 last:mb-0 space-y-0.5">{children}</ul>
+  ),
+  ol: ({ children }: { children?: React.ReactNode }) => (
+    <ol className="list-decimal pl-5 my-2 first:mt-0 last:mb-0 space-y-0.5">{children}</ol>
+  ),
+  li: ({ children }: { children?: React.ReactNode }) => <li>{children}</li>,
+  blockquote: ({ children }: { children?: React.ReactNode }) => (
+    <blockquote className="border-l-4 border-github-border pl-3 my-2 text-github-text-muted">
+      {children}
+    </blockquote>
+  ),
+  hr: () => <hr className="my-3 border-github-border" />,
+  a: ({ href, children }: { href?: string; children?: React.ReactNode }) => {
+    const safeHref = href ?? '';
+    if (!safeHref || !isSafeUrl(safeHref)) {
+      return <span>{children}</span>;
+    }
+    const isExternal = safeHref.startsWith('http');
+    return (
+      <a
+        href={safeHref}
+        target={isExternal ? '_blank' : undefined}
+        rel={isExternal ? 'noreferrer' : undefined}
+        className="text-sky-400 hover:text-sky-300 underline underline-offset-4"
+      >
+        {children}
+      </a>
+    );
+  },
+  img: ({ src, alt }: { src?: string; alt?: string }) => {
+    const safeSrc = src ?? '';
+    if (!safeSrc || !isSafeUrl(safeSrc)) {
+      return null;
+    }
+    return (
+      <img
+        src={safeSrc}
+        alt={alt ?? ''}
+        loading="lazy"
+        className="max-w-full rounded border border-github-border"
+      />
+    );
+  },
+  pre: ({ children }: { children?: React.ReactNode }) => {
+    const nodes = Array.isArray(children) ? children : [children];
+    const codeElement = nodes.find(isElementWithCodeProps);
+    const codeText = extractMarkdownText(codeElement ?? children);
+    const match = /language-(\S+)/.exec(codeElement?.props.className ?? '');
+    const language = match?.[1];
+    const normalizedCodeText = codeText.replace(/\n$/, '');
+
+    if (language === 'diff' && normalizedCodeText) {
+      return <CommentDiffCodeBlock code={normalizedCodeText} />;
+    }
+
+    if (!codeText.trim()) {
+      return (
+        <pre className="my-2 rounded-md border border-github-border bg-github-bg-secondary p-3 overflow-x-auto text-xs leading-5">
+          {children}
+        </pre>
+      );
+    }
+
+    return (
+      <pre className="my-2 rounded-md border border-github-border bg-github-bg-secondary p-3 overflow-x-auto text-xs leading-5">
+        <PrismSyntaxHighlighter
+          code={normalizedCodeText}
+          language={language}
+          syntaxTheme={syntaxTheme}
+          className="font-mono text-github-text-primary"
+        />
+      </pre>
+    );
+  },
+  code: ({ className, children }: { className?: string; children?: React.ReactNode }) => {
+    if (className) {
+      return <code className={className}>{children}</code>;
+    }
+    return (
+      <code className="px-1 py-0.5 rounded bg-github-bg-tertiary border border-github-border font-mono text-[85%]">
+        {children}
+      </code>
+    );
+  },
+  table: ({ children }: { children?: React.ReactNode }) => (
+    <div className="overflow-x-auto my-2 first:mt-0 last:mb-0">
+      <table className="border-collapse">{children}</table>
+    </div>
+  ),
+  thead: ({ children }: { children?: React.ReactNode }) => (
+    <thead className="bg-github-bg-secondary">{children}</thead>
+  ),
+  tbody: ({ children }: { children?: React.ReactNode }) => <tbody>{children}</tbody>,
+  tr: ({ children }: { children?: React.ReactNode }) => (
+    <tr className="border-b border-github-border">{children}</tr>
+  ),
+  th: ({ children }: { children?: React.ReactNode }) => (
+    <th className="px-2 py-1 text-left font-semibold border border-github-border">{children}</th>
+  ),
+  td: ({ children }: { children?: React.ReactNode }) => (
+    <td className="px-2 py-1 border border-github-border">{children}</td>
+  ),
+});
+
 interface CommentBodyRendererProps {
   body: string;
   originalCode?: string;
@@ -112,14 +262,28 @@ export function CommentBodyRenderer({
     return result;
   }, [body, originalCode]);
 
+  const markdownComponents = useMemo(
+    () => getCommentMarkdownComponents(syntaxTheme),
+    [syntaxTheme],
+  );
+
   return (
     <div className="text-github-text-primary text-sm leading-6">
       {parts.map((part, index) => {
         if (part.type === 'text') {
+          if (!part.content.trim()) {
+            return null;
+          }
           return (
-            <span key={index} className="whitespace-pre-wrap">
-              {part.content}
-            </span>
+            <div key={index}>
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm, remarkBreaks]}
+                urlTransform={(url) => (isSafeUrl(url) ? url : '')}
+                components={markdownComponents}
+              >
+                {part.content}
+              </ReactMarkdown>
+            </div>
           );
         }
 

--- a/src/client/components/CommentBodyRenderer.tsx
+++ b/src/client/components/CommentBodyRenderer.tsx
@@ -11,6 +11,10 @@ import { DiffCodeLine } from './DiffCodeLine';
 import { PrismSyntaxHighlighter } from './PrismSyntaxHighlighter';
 import type { AppearanceSettings } from './SettingsModal';
 
+const COMMENT_REMARK_PLUGINS = [remarkGfm, remarkBreaks];
+
+const transformCommentUrl = (url: string) => (isSafeUrl(url) ? url : '');
+
 type SuggestionPart = {
   type: 'text';
   content: string;
@@ -101,8 +105,10 @@ const getCommentMarkdownComponents = (syntaxTheme?: AppearanceSettings['syntaxTh
   h6: ({ children }: { children?: React.ReactNode }) => (
     <h6 className="text-sm font-semibold mt-3 mb-1 first:mt-0">{children}</h6>
   ),
+  // whitespace-pre-wrap keeps consecutive spaces/tabs inside a paragraph, which the
+  // pre-markdown plain-text rendering preserved (e.g. agent comments aligned with spaces).
   p: ({ children }: { children?: React.ReactNode }) => (
-    <p className="my-2 first:mt-0 last:mb-0">{children}</p>
+    <p className="my-2 first:mt-0 last:mb-0 whitespace-pre-wrap">{children}</p>
   ),
   ul: ({ children }: { children?: React.ReactNode }) => (
     <ul className="list-disc pl-5 my-2 first:mt-0 last:mb-0 space-y-0.5">{children}</ul>
@@ -110,7 +116,9 @@ const getCommentMarkdownComponents = (syntaxTheme?: AppearanceSettings['syntaxTh
   ol: ({ children }: { children?: React.ReactNode }) => (
     <ol className="list-decimal pl-5 my-2 first:mt-0 last:mb-0 space-y-0.5">{children}</ol>
   ),
-  li: ({ children }: { children?: React.ReactNode }) => <li>{children}</li>,
+  li: ({ children }: { children?: React.ReactNode }) => (
+    <li className="whitespace-pre-wrap">{children}</li>
+  ),
   blockquote: ({ children }: { children?: React.ReactNode }) => (
     <blockquote className="border-l-4 border-github-border pl-3 my-2 text-github-text-muted">
       {children}
@@ -277,8 +285,8 @@ export function CommentBodyRenderer({
           return (
             <div key={index}>
               <ReactMarkdown
-                remarkPlugins={[remarkGfm, remarkBreaks]}
-                urlTransform={(url) => (isSafeUrl(url) ? url : '')}
+                remarkPlugins={COMMENT_REMARK_PLUGINS}
+                urlTransform={transformCommentUrl}
                 components={markdownComponents}
               >
                 {part.content}

--- a/src/client/utils/markdownUtils.ts
+++ b/src/client/utils/markdownUtils.ts
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import { getFileExtension } from '../../utils/fileUtils';
 
 const MARKDOWN_EXTENSIONS = ['md', 'markdown'];
@@ -8,3 +10,32 @@ export function isMarkdownFile(filename: string): boolean {
   const extension = getFileExtension(filename);
   return extension ? MARKDOWN_EXTENSIONS.includes(extension) : false;
 }
+
+export const isSafeUrl = (url: string) => /^(https?:|mailto:|#|\.{0,2}\/|\/)/i.test(url.trim());
+
+export const isElementWithCodeProps = (
+  node: React.ReactNode,
+): node is React.ReactElement<{
+  className?: string;
+  children?: React.ReactNode;
+}> => React.isValidElement(node);
+
+const isElementWithChildren = (
+  node: React.ReactNode,
+): node is React.ReactElement<{ children?: React.ReactNode }> => React.isValidElement(node);
+
+export const extractMarkdownText = (node: React.ReactNode): string => {
+  if (node === null || node === undefined || typeof node === 'boolean') {
+    return '';
+  }
+  if (typeof node === 'string' || typeof node === 'number') {
+    return String(node);
+  }
+  if (Array.isArray(node)) {
+    return node.map(extractMarkdownText).join('');
+  }
+  if (isElementWithChildren(node)) {
+    return extractMarkdownText(node.props.children);
+  }
+  return '';
+};

--- a/src/client/viewers/MarkdownDiffViewer.tsx
+++ b/src/client/viewers/MarkdownDiffViewer.tsx
@@ -6,6 +6,7 @@ import type { DiffLine } from '../../types/diff';
 import { MermaidDiagram } from '../components/MermaidDiagram';
 import { PrismSyntaxHighlighter } from '../components/PrismSyntaxHighlighter';
 import type { MergedChunk } from '../hooks/useExpandedLines';
+import { extractMarkdownText, isElementWithCodeProps, isSafeUrl } from '../utils/markdownUtils';
 
 import { PreviewModeTabs, type PreviewMode } from './PreviewModeTabs';
 import { TextDiffViewer } from './TextDiffViewer';
@@ -57,8 +58,6 @@ const isDeletionLine = (line: DiffLine) => line.type === 'delete' || line.type =
 
 const isContextLine = (line: DiffLine) => line.type === 'normal' || line.type === 'context';
 
-const isSafeUrl = (url: string) => /^(https?:|mailto:|#|\.{0,2}\/|\/)/i.test(url.trim());
-
 const appendBlockLine = (blocks: PreviewBlock[], type: PreviewBlockType, line: string) => {
   const last = blocks[blocks.length - 1];
   if (last && last.type === type) {
@@ -108,31 +107,6 @@ const buildPreviewBlocks = (chunks: MergedChunk[]): PreviewBlock[] => {
   });
 
   return blocks;
-};
-
-const isElementWithChildren = (
-  node: React.ReactNode,
-): node is React.ReactElement<{ children?: React.ReactNode }> => React.isValidElement(node);
-
-const isElementWithCodeProps = (
-  node: React.ReactNode,
-): node is React.ReactElement<{ className?: string; children?: React.ReactNode }> =>
-  React.isValidElement(node);
-
-const extractText = (node: React.ReactNode): string => {
-  if (node === null || node === undefined || typeof node === 'boolean') {
-    return '';
-  }
-  if (typeof node === 'string' || typeof node === 'number') {
-    return String(node);
-  }
-  if (Array.isArray(node)) {
-    return node.map(extractText).join('');
-  }
-  if (isElementWithChildren(node)) {
-    return extractText(node.props.children);
-  }
-  return '';
 };
 
 const getMarkdownComponents = (syntaxTheme?: DiffViewerBodyProps['syntaxTheme']) => ({
@@ -204,7 +178,7 @@ const getMarkdownComponents = (syntaxTheme?: DiffViewerBodyProps['syntaxTheme'])
   pre: ({ children }: { children?: React.ReactNode }) => {
     const nodes = Array.isArray(children) ? children : [children];
     const codeElement = nodes.find(isElementWithCodeProps);
-    const codeText = extractText(codeElement ?? children);
+    const codeText = extractMarkdownText(codeElement ?? children);
     const match = /language-(\S+)/.exec(codeElement?.props.className ?? '');
     const language = match?.[1];
     const normalizedCodeText = codeText.replace(/\n$/, '');

--- a/src/client/viewers/NotebookDiffViewer.tsx
+++ b/src/client/viewers/NotebookDiffViewer.tsx
@@ -7,6 +7,7 @@ import type { DiffLine } from '../../types/diff';
 import { EnhancedPrismSyntaxHighlighter } from '../components/EnhancedPrismSyntaxHighlighter';
 import { PrismSyntaxHighlighter } from '../components/PrismSyntaxHighlighter';
 import type { MergedChunk } from '../hooks/useExpandedLines';
+import { extractMarkdownText, isElementWithCodeProps, isSafeUrl } from '../utils/markdownUtils';
 
 import { PreviewModeTabs, type PreviewMode } from './PreviewModeTabs';
 import { TextDiffViewer } from './TextDiffViewer';
@@ -506,11 +507,17 @@ const buildDiffLines = (beforeText: string, afterText: string): NotebookDiffLine
   if (!beforeText && !afterText) return [];
 
   if (!beforeText) {
-    return splitDiffValue(afterText).map((line) => ({ type: 'add', content: line }));
+    return splitDiffValue(afterText).map((line) => ({
+      type: 'add',
+      content: line,
+    }));
   }
 
   if (!afterText) {
-    return splitDiffValue(beforeText).map((line) => ({ type: 'delete', content: line }));
+    return splitDiffValue(beforeText).map((line) => ({
+      type: 'delete',
+      content: line,
+    }));
   }
 
   return diffLines(beforeText, afterText).flatMap((change) => {
@@ -521,31 +528,6 @@ const buildDiffLines = (beforeText: string, afterText: string): NotebookDiffLine
       content: line,
     }));
   });
-};
-
-const isElementWithChildren = (
-  node: React.ReactNode,
-): node is React.ReactElement<{ children?: React.ReactNode }> => React.isValidElement(node);
-
-const isElementWithCodeProps = (
-  node: React.ReactNode,
-): node is React.ReactElement<{ className?: string; children?: React.ReactNode }> =>
-  React.isValidElement(node);
-
-const extractText = (node: React.ReactNode): string => {
-  if (node === null || node === undefined || typeof node === 'boolean') {
-    return '';
-  }
-  if (typeof node === 'string' || typeof node === 'number') {
-    return String(node);
-  }
-  if (Array.isArray(node)) {
-    return node.map(extractText).join('');
-  }
-  if (isElementWithChildren(node)) {
-    return extractText(node.props.children);
-  }
-  return '';
 };
 
 const getCellBorderStyle = (status: NotebookCellStatus) => {
@@ -604,8 +586,6 @@ const getCodeLinePrefixClass = (type: PreviewLineType) => {
       return 'text-github-text-muted';
   }
 };
-
-const isSafeUrl = (url: string) => /^(https?:|mailto:|#|\.{0,2}\/|\/)/i.test(url.trim());
 
 const getMarkdownComponents = (syntaxTheme?: DiffViewerBodyProps['syntaxTheme']) => ({
   h1: ({ children }: { children?: React.ReactNode }) => (
@@ -676,7 +656,7 @@ const getMarkdownComponents = (syntaxTheme?: DiffViewerBodyProps['syntaxTheme'])
   pre: ({ children }: { children?: React.ReactNode }) => {
     const nodes = Array.isArray(children) ? children : [children];
     const codeElement = nodes.find(isElementWithCodeProps);
-    const codeText = extractText(codeElement ?? children);
+    const codeText = extractMarkdownText(codeElement ?? children);
     const match = /language-(\S+)/.exec(codeElement?.props.className ?? '');
     const language = match?.[1];
 
@@ -743,11 +723,19 @@ const buildSectionsForCell = (cell: NotebookCellPreview): Section[] => {
   }
 
   if (cell.status === 'delete') {
-    sections.push({ label: 'Before', content: beforeText || afterText, tone: 'before' });
+    sections.push({
+      label: 'Before',
+      content: beforeText || afterText,
+      tone: 'before',
+    });
     return sections;
   }
 
-  sections.push({ label: 'After', content: afterText || beforeText, tone: 'after' });
+  sections.push({
+    label: 'After',
+    content: afterText || beforeText,
+    tone: 'after',
+  });
   return sections;
 };
 


### PR DESCRIPTION
## Summary

Implements the second request in #426: markdown rendering in comment bodies.

Comment bodies were rendered as plain text (`whitespace-pre-wrap` span), so markdown like `**bold**`, inline code, and fenced code blocks showed up as literal characters. This PR renders the text parts of comment bodies with react-markdown + GFM.

## Changes

- **`CommentBodyRenderer`**: text parts now go through `react-markdown` with `remark-gfm`, using a comment-scaled component set (headings, lists, blockquotes, tables, links, images)
  - Fenced code blocks get Prism syntax highlighting via the existing `PrismSyntaxHighlighter`
  - ` ```diff ` blocks are rendered with difit's own diff line backgrounds (`+`/`-` lines get addition/deletion colors) instead of relying on Prism theme token colors, so they look like the rest of the diff viewer
  - ` ```suggestion ` blocks are still extracted before markdown parsing, so the existing suggestion rendering is unchanged
- **`remark-breaks`** added so single newlines stay as line breaks — existing plain-text comments keep their current look
- **Safety**: raw HTML is not rendered (react-markdown default kept), and link/image URLs are restricted to `https?:`/`mailto:`/relative paths (same `isSafeUrl` policy as `MarkdownDiffViewer`)
- **`markdownUtils`**: `isSafeUrl` / `extractMarkdownText` / `isElementWithCodeProps` extracted and shared with `MarkdownDiffViewer`, `NotebookDiffViewer`, and `CommentBodyRenderer`
- **Tests**: new `CommentBodyRenderer.test.tsx` (14 cases: GFM elements, diff blocks, unsafe links, raw HTML, suggestion coexistence, line breaks, whitespace fidelity)

## Whitespace behavior vs. the old plain-text rendering

Markdown parsing inherently changes some whitespace handling. Mitigations and remaining trade-offs:

- **Kept**: single newlines stay as line breaks (`remark-breaks`), and consecutive spaces/tabs *inside* paragraphs and list items are preserved (`whitespace-pre-wrap` on `p`/`li`) — so agent comments aligned with spaces still read correctly
- **Changed (GitHub-consistent)**: 4-space indented lines are interpreted as code blocks, leading whitespace of continuation lines is stripped by the markdown parser, and runs of 3+ blank lines collapse. These match how the same comment body would render on GitHub

## Notes for reviewers

- Rendered at comment-scale `text-sm`, matching the existing comment card design; heading sizes are intentionally modest (h1 = `text-lg`) so comments don't shout
- `CommentForm`'s preview mode reuses `CommentBodyRenderer`, so the suggestion preview gets markdown rendering for free

Item 2 of #426.

🤖 Generated with [Claude Code](https://claude.com/claude-code)