### PR TITLE
feat: persist UI settings to ~/.difit/config.json so they survive across ports

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -42,6 +42,7 @@ import { useKeyboardNavigation } from './hooks/useKeyboardNavigation';
 import { useLazyDiffRendering } from './hooks/useLazyDiffRendering';
 import { useViewedFiles } from './hooks/useViewedFiles';
 import { useViewport } from './hooks/useViewport';
+import { fetchClientSettings, saveClientSettings } from './services/userSettings';
 import { hasMultipleCommentAuthors } from './utils/commentAuthors';
 import { copyTextToClipboard } from './utils/clipboard';
 import { getFileElementId } from './utils/domUtils';
@@ -63,25 +64,25 @@ const SIDEBAR_MIN_WIDTH = 200;
 const SIDEBAR_MAX_WIDTH = 600;
 const SIDEBAR_DEFAULT_WIDTH = 280;
 
+const parseDiffViewMode = (value: unknown): DiffViewMode | null => {
+  switch (value) {
+    case 'split':
+    case 'side-by-side':
+    case 'unified':
+    case 'inline':
+      return normalizeDiffViewMode(value);
+    default:
+      return null;
+  }
+};
+
 const getStoredDiffViewMode = (): DiffViewMode | null => {
   if (typeof window === 'undefined') {
     return null;
   }
 
   try {
-    const stored = window.localStorage.getItem(DIFF_VIEW_MODE_STORAGE_KEY);
-    if (stored === null) {
-      return null;
-    }
-    switch (stored) {
-      case 'split':
-      case 'side-by-side':
-      case 'unified':
-      case 'inline':
-        return normalizeDiffViewMode(stored);
-      default:
-        return null;
-    }
+    return parseDiffViewMode(window.localStorage.getItem(DIFF_VIEW_MODE_STORAGE_KEY));
   } catch {
     return null;
   }
@@ -89,37 +90,41 @@ const getStoredDiffViewMode = (): DiffViewMode | null => {
 
 const getInitialDiffViewMode = () => getStoredDiffViewMode() ?? DEFAULT_DIFF_VIEW_MODE;
 
-const getInitialSidebarWidth = () => {
+const clampSidebarWidth = (width: number) =>
+  Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, width));
+
+const getStoredSidebarWidth = (): number | null => {
   if (typeof window === 'undefined') {
-    return SIDEBAR_DEFAULT_WIDTH;
+    return null;
   }
   const stored = window.localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY);
   if (!stored) {
-    return SIDEBAR_DEFAULT_WIDTH;
+    return null;
   }
   const parsed = Number.parseInt(stored, 10);
   if (!Number.isFinite(parsed)) {
-    return SIDEBAR_DEFAULT_WIDTH;
+    return null;
   }
-  return Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, parsed));
+  return clampSidebarWidth(parsed);
 };
 
-const getInitialFileTreeOpen = () => {
+const getInitialSidebarWidth = () => getStoredSidebarWidth() ?? SIDEBAR_DEFAULT_WIDTH;
+
+const getStoredSidebarOpen = (): boolean | null => {
   if (typeof window === 'undefined') {
-    return true;
+    return null;
   }
   const stored = window.localStorage.getItem(SIDEBAR_OPEN_STORAGE_KEY);
-  if (stored === null) {
-    return true;
-  }
   if (stored === 'true') {
     return true;
   }
   if (stored === 'false') {
     return false;
   }
-  return true;
+  return null;
 };
+
+const getInitialFileTreeOpen = () => getStoredSidebarOpen() ?? true;
 
 function App() {
   const [diffData, setDiffData] = useState<DiffResponse | null>(null);
@@ -443,6 +448,7 @@ function App() {
     } catch {
       // Ignore localStorage errors (e.g. disabled storage).
     }
+    saveClientSettings({ diffViewMode: mode });
   }, []);
 
   // Lift expand state to App level so navigation and rendering share the same merged chunks
@@ -766,20 +772,84 @@ function App() {
     }
   }, [diffMode, isMobile]);
 
+  // Hydrate UI settings from the server-persisted config so they survive
+  // across ports (localStorage is origin-scoped and resets on a new port).
+  // Settings the server doesn't know yet are seeded from localStorage.
+  useEffect(() => {
+    let cancelled = false;
+
+    void fetchClientSettings().then((client) => {
+      if (cancelled || !client) {
+        return;
+      }
+
+      const seed: Record<string, unknown> = {};
+
+      const remoteDiffViewMode = parseDiffViewMode(client.diffViewMode);
+      if (remoteDiffViewMode) {
+        setDiffMode(remoteDiffViewMode);
+      } else {
+        const localDiffViewMode = getStoredDiffViewMode();
+        if (localDiffViewMode) {
+          seed.diffViewMode = localDiffViewMode;
+        }
+      }
+
+      if (typeof client.sidebarWidth === 'number' && Number.isFinite(client.sidebarWidth)) {
+        setSidebarWidth(clampSidebarWidth(client.sidebarWidth));
+      } else {
+        const localSidebarWidth = getStoredSidebarWidth();
+        if (localSidebarWidth !== null) {
+          seed.sidebarWidth = localSidebarWidth;
+        }
+      }
+
+      if (typeof client.sidebarOpen === 'boolean') {
+        setIsFileTreeOpen(client.sidebarOpen);
+      } else {
+        const localSidebarOpen = getStoredSidebarOpen();
+        if (localSidebarOpen !== null) {
+          seed.sidebarOpen = localSidebarOpen;
+        }
+      }
+
+      if (Object.keys(seed).length > 0) {
+        saveClientSettings(seed);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const skipInitialSidebarWidthSaveRef = useRef(true);
   useEffect(() => {
     try {
       window.localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, String(sidebarWidth));
     } catch {
       // Ignore localStorage errors (e.g. disabled storage).
     }
+    // Skip the mount run so simply opening difit doesn't write the config file.
+    if (skipInitialSidebarWidthSaveRef.current) {
+      skipInitialSidebarWidthSaveRef.current = false;
+      return;
+    }
+    saveClientSettings({ sidebarWidth });
   }, [sidebarWidth]);
 
+  const skipInitialSidebarOpenSaveRef = useRef(true);
   useEffect(() => {
     try {
       window.localStorage.setItem(SIDEBAR_OPEN_STORAGE_KEY, String(isFileTreeOpen));
     } catch {
       // Ignore localStorage errors (e.g. disabled storage).
     }
+    if (skipInitialSidebarOpenSaveRef.current) {
+      skipInitialSidebarOpenSaveRef.current = false;
+      return;
+    }
+    saveClientSettings({ sidebarOpen: isFileTreeOpen });
   }, [isFileTreeOpen]);
 
   // Fetch revision options on mount

--- a/src/client/hooks/useAppearanceSettings.test.ts
+++ b/src/client/hooks/useAppearanceSettings.test.ts
@@ -2,6 +2,7 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { DEFAULT_EDITOR_OPTION } from '../../utils/editorOptions';
+import { resetClientSettingsForTests } from '../services/userSettings';
 import { APPEARANCE_STORAGE_KEY } from '../utils/appearanceTheme';
 
 import { useAppearanceSettings } from './useAppearanceSettings';
@@ -40,7 +41,10 @@ const setMatchMedia = (initialMatches: boolean) => {
   return {
     setMatches(nextMatches: boolean) {
       matches = nextMatches;
-      const event = { matches: nextMatches, media: mediaQueryList.media } as MediaQueryListEvent;
+      const event = {
+        matches: nextMatches,
+        media: mediaQueryList.media,
+      } as MediaQueryListEvent;
       listeners.forEach((listener) => listener(event));
     },
   };
@@ -128,7 +132,11 @@ describe('useAppearanceSettings', () => {
       localStorage.setItem(
         APPEARANCE_STORAGE_KEY,
         JSON.stringify({
-          editor: { id: 'custom', command: 'emacsclient', argsTemplate: '+%line %file' },
+          editor: {
+            id: 'custom',
+            command: 'emacsclient',
+            argsTemplate: '+%line %file',
+          },
         }),
       );
 
@@ -151,6 +159,66 @@ describe('useAppearanceSettings', () => {
         command: DEFAULT_EDITOR_OPTION.command,
         argsTemplate: DEFAULT_EDITOR_OPTION.argsTemplate,
       });
+    });
+  });
+
+  describe('server-persisted settings', () => {
+    beforeEach(() => {
+      setMatchMedia(false);
+      resetClientSettingsForTests();
+    });
+
+    it('hydrates settings from the server config and caches them locally', async () => {
+      (global.fetch as any).mockImplementation((url: string) => {
+        if (url.includes('/api/user-settings')) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              version: 1,
+              client: { appearance: { theme: 'light', fontSize: 16 } },
+            }),
+          });
+        }
+        return Promise.resolve({ ok: false });
+      });
+
+      const { result } = renderHook(() => useAppearanceSettings());
+
+      await waitFor(() => {
+        expect(result.current.settings.theme).toBe('light');
+        expect(result.current.settings.fontSize).toBe(16);
+      });
+
+      expect(JSON.parse(localStorage.getItem(APPEARANCE_STORAGE_KEY) ?? '{}')).toMatchObject({
+        theme: 'light',
+        fontSize: 16,
+      });
+    });
+
+    it('seeds the server from localStorage when the server has no appearance settings', async () => {
+      localStorage.setItem(APPEARANCE_STORAGE_KEY, JSON.stringify({ theme: 'light' }));
+
+      const putBodies: any[] = [];
+      (global.fetch as any).mockImplementation((url: string, init?: RequestInit) => {
+        if (url.includes('/api/user-settings') && init?.method === 'PUT') {
+          putBodies.push(JSON.parse(String(init.body)));
+          return Promise.resolve({ ok: true, json: async () => ({}) });
+        }
+        if (url.includes('/api/user-settings')) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ version: 1, client: {} }),
+          });
+        }
+        return Promise.resolve({ ok: false });
+      });
+
+      renderHook(() => useAppearanceSettings());
+
+      await waitFor(() => {
+        expect(putBodies.length).toBeGreaterThan(0);
+      });
+      expect(putBodies[0].client.appearance).toMatchObject({ theme: 'light' });
     });
   });
 });

--- a/src/client/hooks/useAppearanceSettings.ts
+++ b/src/client/hooks/useAppearanceSettings.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 
 import {
   DEFAULT_EDITOR_OPTION,
@@ -6,6 +6,7 @@ import {
   resolveEditorOption,
 } from '../../utils/editorOptions';
 import type { AppearanceSettings } from '../components/SettingsModal';
+import { fetchClientSettings, saveClientSettings } from '../services/userSettings';
 import { normalizeAutoViewedPatterns } from '../utils/autoViewedPatterns';
 import {
   APPEARANCE_STORAGE_KEY,
@@ -69,6 +70,27 @@ const normalizeEditorSettings = (raw: unknown): AppearanceSettings['editor'] => 
   return DEFAULT_SETTINGS.editor;
 };
 
+// Key for appearance settings inside the server-persisted client settings object.
+const APPEARANCE_SETTINGS_KEY = 'appearance';
+
+const normalizeStoredSettings = (raw: unknown): AppearanceSettings | null => {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return null;
+  }
+
+  const parsed = raw as Partial<AppearanceSettings> & {
+    autoViewedPatterns?: unknown;
+    editor?: unknown;
+  };
+
+  return {
+    ...DEFAULT_SETTINGS,
+    ...parsed,
+    editor: normalizeEditorSettings(parsed.editor),
+    autoViewedPatterns: normalizeAutoViewedPatterns(parsed.autoViewedPatterns),
+  };
+};
+
 interface UseAppearanceSettingsReturn {
   settings: AppearanceSettings;
   updateSettings: (newSettings: AppearanceSettings) => void;
@@ -79,23 +101,58 @@ export function useAppearanceSettings(): UseAppearanceSettingsReturn {
     try {
       const stored = localStorage.getItem(APPEARANCE_STORAGE_KEY);
       if (stored) {
-        const parsed = JSON.parse(stored) as Partial<AppearanceSettings> & {
-          autoViewedPatterns?: unknown;
-          editor?: unknown;
-        };
-
-        return {
-          ...DEFAULT_SETTINGS,
-          ...parsed,
-          editor: normalizeEditorSettings(parsed.editor),
-          autoViewedPatterns: normalizeAutoViewedPatterns(parsed.autoViewedPatterns),
-        };
+        const normalized = normalizeStoredSettings(JSON.parse(stored));
+        if (normalized) {
+          return normalized;
+        }
       }
     } catch (error) {
       console.warn('Failed to load appearance settings from localStorage:', error);
     }
     return DEFAULT_SETTINGS;
   });
+
+  const settingsRef = useRef(settings);
+  useEffect(() => {
+    settingsRef.current = settings;
+  }, [settings]);
+
+  // Hydrate from the server-persisted settings (shared across ports); if the
+  // server has none yet but localStorage does, seed the server from it.
+  useEffect(() => {
+    let cancelled = false;
+
+    void fetchClientSettings().then((client) => {
+      if (cancelled || !client) {
+        return;
+      }
+
+      const remote = normalizeStoredSettings(client[APPEARANCE_SETTINGS_KEY]);
+      if (remote) {
+        setSettings(remote);
+        try {
+          localStorage.setItem(APPEARANCE_STORAGE_KEY, JSON.stringify(remote));
+        } catch {
+          // localStorage is only a cache here; ignore write failures.
+        }
+        return;
+      }
+
+      let hasLocalSettings = false;
+      try {
+        hasLocalSettings = localStorage.getItem(APPEARANCE_STORAGE_KEY) !== null;
+      } catch {
+        // Treat unreadable localStorage as empty.
+      }
+      if (hasLocalSettings) {
+        saveClientSettings({ [APPEARANCE_SETTINGS_KEY]: settingsRef.current });
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const applyTheme = useCallback(
     (theme: 'light' | 'dark', colorVision: ColorVisionMode = 'normal') => {
@@ -110,6 +167,7 @@ export function useAppearanceSettings(): UseAppearanceSettingsReturn {
     } catch (error) {
       console.warn('Failed to save appearance settings to localStorage:', error);
     }
+    saveClientSettings({ [APPEARANCE_SETTINGS_KEY]: newSettings });
   }, []);
 
   const getSettingsForResolvedTheme = useCallback(

--- a/src/client/services/userSettings.test.ts
+++ b/src/client/services/userSettings.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import {
+  fetchClientSettings,
+  saveClientSettings,
+  resetClientSettingsForTests,
+} from './userSettings';
+
+describe('userSettings service', () => {
+  let mockFetch: ReturnType<typeof vi.fn<typeof fetch>>;
+
+  beforeEach(() => {
+    resetClientSettingsForTests();
+    mockFetch = vi.fn<typeof fetch>();
+    global.fetch = mockFetch as any;
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('fetchClientSettings', () => {
+    it('returns the client settings object from the server', async () => {
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify({ version: 1, client: { diffViewMode: 'split' } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+
+      await expect(fetchClientSettings()).resolves.toEqual({
+        diffViewMode: 'split',
+      });
+      expect(mockFetch).toHaveBeenCalledWith('/api/user-settings');
+    });
+
+    it('caches the result so concurrent callers share one request', async () => {
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify({ version: 1, client: {} }), {
+          status: 200,
+        }),
+      );
+
+      await Promise.all([fetchClientSettings(), fetchClientSettings()]);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns null when the server responds with an error', async () => {
+      mockFetch.mockResolvedValue(new Response('nope', { status: 404 }));
+      await expect(fetchClientSettings()).resolves.toBeNull();
+    });
+
+    it('returns null when the response is not a settings payload', async () => {
+      mockFetch.mockResolvedValue(new Response(JSON.stringify({ files: [] }), { status: 200 }));
+      await expect(fetchClientSettings()).resolves.toBeNull();
+    });
+
+    it('returns null when fetch fails (static demo site)', async () => {
+      mockFetch.mockRejectedValue(new TypeError('fetch failed'));
+      await expect(fetchClientSettings()).resolves.toBeNull();
+    });
+  });
+
+  describe('saveClientSettings', () => {
+    it('debounces rapid changes into a single merged PUT', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      saveClientSettings({ sidebarWidth: 300 });
+      saveClientSettings({ sidebarWidth: 320 });
+      saveClientSettings({ sidebarOpen: false });
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      await vi.runAllTimersAsync();
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledWith('/api/user-settings', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          client: { sidebarWidth: 320, sidebarOpen: false },
+        }),
+      });
+    });
+
+    it('ignores network failures', async () => {
+      mockFetch.mockRejectedValue(new TypeError('fetch failed'));
+
+      saveClientSettings({ sidebarOpen: true });
+      await expect(vi.runAllTimersAsync()).resolves.not.toThrow();
+    });
+  });
+});

--- a/src/client/services/userSettings.ts
+++ b/src/client/services/userSettings.ts
@@ -1,0 +1,66 @@
+// Client access to the server-persisted user settings (~/.difit/config.json).
+// localStorage stays as the synchronous cache and as the only store when no
+// API server is available (e.g. the static demo site).
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+let cachedSettings: Promise<Record<string, unknown> | null> | null = null;
+
+export function fetchClientSettings(): Promise<Record<string, unknown> | null> {
+  cachedSettings ??= (async () => {
+    try {
+      const response = await fetch('/api/user-settings');
+      if (!response?.ok) {
+        return null;
+      }
+      const data: unknown = await response.json();
+      if (isPlainObject(data) && isPlainObject(data.client)) {
+        return data.client;
+      }
+    } catch {
+      // No API server (static demo site) or the request failed.
+    }
+    return null;
+  })();
+  return cachedSettings;
+}
+
+const FLUSH_DELAY_MS = 300;
+
+let pendingPatch: Record<string, unknown> = {};
+let flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+// Fire-and-forget: batches rapid changes (e.g. sidebar drag) into one PUT.
+export function saveClientSettings(patch: Record<string, unknown>): void {
+  Object.assign(pendingPatch, patch);
+  if (flushTimer) {
+    clearTimeout(flushTimer);
+  }
+  flushTimer = setTimeout(() => {
+    const client = pendingPatch;
+    pendingPatch = {};
+    flushTimer = null;
+    void (async () => {
+      try {
+        await fetch('/api/user-settings', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ client }),
+        });
+      } catch {
+        // Persisting settings is best-effort; localStorage still has them.
+      }
+    })();
+  }, FLUSH_DELAY_MS);
+}
+
+export function resetClientSettingsForTests(): void {
+  cachedSettings = null;
+  pendingPatch = {};
+  if (flushTimer) {
+    clearTimeout(flushTimer);
+    flushTimer = null;
+  }
+}

--- a/src/server/server.test.ts
+++ b/src/server/server.test.ts
@@ -1,3 +1,7 @@
+import { promises as fs } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // Set environment variable to skip fetch mocking
@@ -1034,6 +1038,83 @@ describe('Server Integration Tests', () => {
       const data = (await response.json()) as any;
       expect(data).toHaveProperty('error');
       expect(data.error).toContain('does-not-exist');
+    });
+
+    describe('user settings API', () => {
+      const originalConfigDir = process.env.DIFIT_CONFIG_DIR;
+      let configDir: string;
+
+      beforeEach(async () => {
+        configDir = await fs.mkdtemp(join(tmpdir(), 'difit-user-settings-'));
+        process.env.DIFIT_CONFIG_DIR = configDir;
+      });
+
+      afterEach(async () => {
+        if (originalConfigDir === undefined) {
+          delete process.env.DIFIT_CONFIG_DIR;
+        } else {
+          process.env.DIFIT_CONFIG_DIR = originalConfigDir;
+        }
+        await fs.rm(configDir, { recursive: true, force: true });
+      });
+
+      it('GET /api/user-settings returns defaults when no config exists', async () => {
+        const response = await fetch(`http://localhost:${port}/api/user-settings`);
+
+        expect(response.ok).toBe(true);
+        const data = (await response.json()) as any;
+        expect(data).toEqual({ version: 1, client: {} });
+      });
+
+      it('PUT /api/user-settings merges and persists client settings', async () => {
+        const first = await fetch(`http://localhost:${port}/api/user-settings`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            client: { diffViewMode: 'split', sidebarWidth: 320 },
+          }),
+        });
+        expect(first.ok).toBe(true);
+
+        const second = await fetch(`http://localhost:${port}/api/user-settings`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ client: { sidebarWidth: 400 } }),
+        });
+        expect(second.ok).toBe(true);
+        const merged = (await second.json()) as any;
+        expect(merged.client).toEqual({
+          diffViewMode: 'split',
+          sidebarWidth: 400,
+        });
+
+        const getResponse = await fetch(`http://localhost:${port}/api/user-settings`);
+        const data = (await getResponse.json()) as any;
+        expect(data.client).toEqual({
+          diffViewMode: 'split',
+          sidebarWidth: 400,
+        });
+
+        const stored = JSON.parse(
+          await fs.readFile(join(configDir, 'config.json'), 'utf-8'),
+        ) as any;
+        expect(stored.client).toEqual({
+          diffViewMode: 'split',
+          sidebarWidth: 400,
+        });
+      });
+
+      it('PUT /api/user-settings rejects invalid payloads', async () => {
+        const response = await fetch(`http://localhost:${port}/api/user-settings`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ client: 'dark' }),
+        });
+
+        expect(response.status).toBe(400);
+        const data = (await response.json()) as any;
+        expect(data).toHaveProperty('error');
+      });
     });
 
     it('isolates comment sessions between different diff selections', async () => {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -27,6 +27,7 @@ import { getFileExtension } from '../utils/fileUtils.js';
 
 import { FileWatcherService } from './file-watcher.js';
 import { GitDiffParser } from './git-diff.js';
+import { parseUserSettingsPatch, readUserConfig, updateUserClientSettings } from './user-config.js';
 
 import {
   type BaseMode,
@@ -814,6 +815,34 @@ export async function startServer(
       res.send(output);
     } else {
       res.send('');
+    }
+  });
+
+  app.get('/api/user-settings', async (_req, res) => {
+    const config = await readUserConfig();
+    res.json(config);
+  });
+
+  app.put('/api/user-settings', async (req, res) => {
+    let patch: Record<string, unknown> | null;
+    try {
+      const body: unknown = typeof req.body === 'string' ? JSON.parse(req.body) : req.body;
+      patch = parseUserSettingsPatch(body);
+    } catch {
+      patch = null;
+    }
+
+    if (!patch) {
+      res.status(400).json({ error: 'Invalid user settings payload' });
+      return;
+    }
+
+    try {
+      const config = await updateUserClientSettings(patch);
+      res.json(config);
+    } catch (error) {
+      console.error('Error saving user settings:', error);
+      res.status(500).json({ error: 'Failed to save user settings' });
     }
   });
 

--- a/src/server/user-config.test.ts
+++ b/src/server/user-config.test.ts
@@ -1,0 +1,135 @@
+import { promises as fs } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import {
+  getUserConfigPath,
+  readUserConfig,
+  parseUserSettingsPatch,
+  updateUserClientSettings,
+  MAX_USER_CONFIG_BYTES,
+} from './user-config.js';
+
+describe('user-config', () => {
+  let configDir: string;
+  let configPath: string;
+
+  beforeEach(async () => {
+    configDir = await fs.mkdtemp(join(tmpdir(), 'difit-user-config-'));
+    configPath = join(configDir, 'config.json');
+  });
+
+  afterEach(async () => {
+    await fs.rm(configDir, { recursive: true, force: true });
+  });
+
+  describe('getUserConfigPath', () => {
+    const originalConfigDir = process.env.DIFIT_CONFIG_DIR;
+
+    afterEach(() => {
+      if (originalConfigDir === undefined) {
+        delete process.env.DIFIT_CONFIG_DIR;
+      } else {
+        process.env.DIFIT_CONFIG_DIR = originalConfigDir;
+      }
+    });
+
+    it('defaults to ~/.difit/config.json', () => {
+      delete process.env.DIFIT_CONFIG_DIR;
+      expect(getUserConfigPath()).toMatch(/\.difit[/\\]config\.json$/);
+    });
+
+    it('respects DIFIT_CONFIG_DIR', () => {
+      process.env.DIFIT_CONFIG_DIR = configDir;
+      expect(getUserConfigPath()).toBe(join(configDir, 'config.json'));
+    });
+  });
+
+  describe('readUserConfig', () => {
+    it('returns defaults when the file does not exist', async () => {
+      const config = await readUserConfig(configPath);
+      expect(config).toEqual({ version: 1, client: {} });
+    });
+
+    it('returns defaults when the file is corrupt', async () => {
+      await fs.writeFile(configPath, 'not json', 'utf-8');
+      const config = await readUserConfig(configPath);
+      expect(config).toEqual({ version: 1, client: {} });
+    });
+
+    it('returns defaults when client is not an object', async () => {
+      await fs.writeFile(configPath, JSON.stringify({ version: 1, client: [1, 2] }), 'utf-8');
+      const config = await readUserConfig(configPath);
+      expect(config).toEqual({ version: 1, client: {} });
+    });
+
+    it('reads stored client settings', async () => {
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({ version: 1, client: { diffViewMode: 'split' } }),
+        'utf-8',
+      );
+      const config = await readUserConfig(configPath);
+      expect(config.client).toEqual({ diffViewMode: 'split' });
+    });
+  });
+
+  describe('updateUserClientSettings', () => {
+    it('creates the config directory and file on first write', async () => {
+      const nestedPath = join(configDir, 'nested', 'config.json');
+      const config = await updateUserClientSettings({ sidebarOpen: false }, nestedPath);
+
+      expect(config).toEqual({ version: 1, client: { sidebarOpen: false } });
+      const stored = JSON.parse(await fs.readFile(nestedPath, 'utf-8'));
+      expect(stored).toEqual({ version: 1, client: { sidebarOpen: false } });
+    });
+
+    it('shallow-merges the patch into existing settings', async () => {
+      await updateUserClientSettings({ diffViewMode: 'split', sidebarWidth: 300 }, configPath);
+      const config = await updateUserClientSettings({ sidebarWidth: 400 }, configPath);
+
+      expect(config.client).toEqual({
+        diffViewMode: 'split',
+        sidebarWidth: 400,
+      });
+    });
+
+    it('rejects settings exceeding the size limit', async () => {
+      const huge = { blob: 'x'.repeat(MAX_USER_CONFIG_BYTES) };
+      await expect(updateUserClientSettings(huge, configPath)).rejects.toThrow(
+        'maximum allowed size',
+      );
+    });
+
+    it('leaves no temp file behind', async () => {
+      await updateUserClientSettings({ sidebarOpen: true }, configPath);
+      const entries = await fs.readdir(configDir);
+      expect(entries).toEqual(['config.json']);
+    });
+  });
+
+  describe('parseUserSettingsPatch', () => {
+    it('accepts a body with a client object', () => {
+      expect(parseUserSettingsPatch({ client: { diffViewMode: 'split' } })).toEqual({
+        diffViewMode: 'split',
+      });
+    });
+
+    it('rejects missing or non-object client', () => {
+      expect(parseUserSettingsPatch(undefined)).toBeNull();
+      expect(parseUserSettingsPatch({})).toBeNull();
+      expect(parseUserSettingsPatch({ client: 'dark' })).toBeNull();
+      expect(parseUserSettingsPatch({ client: [1] })).toBeNull();
+    });
+
+    it('rejects oversized patches', () => {
+      expect(
+        parseUserSettingsPatch({
+          client: { blob: 'x'.repeat(MAX_USER_CONFIG_BYTES) },
+        }),
+      ).toBeNull();
+    });
+  });
+});

--- a/src/server/user-config.ts
+++ b/src/server/user-config.ts
@@ -1,0 +1,78 @@
+import { promises as fs } from 'fs';
+import { homedir } from 'os';
+import { dirname, join } from 'path';
+
+export interface UserConfig {
+  version: 1;
+  client: Record<string, unknown>;
+}
+
+const CONFIG_VERSION = 1 as const;
+
+// Generous ceiling for UI preferences; anything larger is a bug or abuse.
+export const MAX_USER_CONFIG_BYTES = 64 * 1024;
+
+export function getUserConfigPath(): string {
+  const configDir = process.env.DIFIT_CONFIG_DIR?.trim();
+  if (configDir) {
+    return join(configDir, 'config.json');
+  }
+  return join(homedir(), '.difit', 'config.json');
+}
+
+function createDefaultUserConfig(): UserConfig {
+  return { version: CONFIG_VERSION, client: {} };
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function parseUserSettingsPatch(body: unknown): Record<string, unknown> | null {
+  if (!isPlainObject(body) || !isPlainObject(body.client)) {
+    return null;
+  }
+  if (Buffer.byteLength(JSON.stringify(body.client), 'utf-8') > MAX_USER_CONFIG_BYTES) {
+    return null;
+  }
+  return body.client;
+}
+
+export async function readUserConfig(path: string = getUserConfigPath()): Promise<UserConfig> {
+  try {
+    const raw = await fs.readFile(path, 'utf-8');
+    const parsed: unknown = JSON.parse(raw);
+    if (isPlainObject(parsed) && isPlainObject(parsed.client)) {
+      return { version: CONFIG_VERSION, client: parsed.client };
+    }
+  } catch {
+    // Missing or unreadable config falls back to defaults.
+  }
+  return createDefaultUserConfig();
+}
+
+// Shallow-merges the patch into the stored client settings. Concurrent difit
+// servers may write the same file; settings changes are rare enough that
+// last-write-wins per top-level key is acceptable.
+export async function updateUserClientSettings(
+  patch: Record<string, unknown>,
+  path: string = getUserConfigPath(),
+): Promise<UserConfig> {
+  const current = await readUserConfig(path);
+  const next: UserConfig = {
+    version: CONFIG_VERSION,
+    client: { ...current.client, ...patch },
+  };
+
+  const serialized = `${JSON.stringify(next, null, 2)}\n`;
+  if (Buffer.byteLength(serialized, 'utf-8') > MAX_USER_CONFIG_BYTES) {
+    throw new Error('User settings exceed the maximum allowed size');
+  }
+
+  await fs.mkdir(dirname(path), { recursive: true });
+  // Write via a temp file + rename so a crash mid-write can't corrupt the config.
+  const tmpPath = `${path}.${process.pid}.tmp`;
+  await fs.writeFile(tmpPath, serialized, 'utf-8');
+  await fs.rename(tmpPath, path);
+  return next;
+}


### PR DESCRIPTION
## Summary

Implements the last remaining item of #426: UI settings reset whenever difit starts on a new port, because localStorage is scoped to the origin (port included). This PR persists global UI settings server-side in `~/.difit/config.json`, so they survive across ports, sessions, and browsers.

## What changed

**Server**
- New `src/server/user-config.ts` module that reads/writes `~/.difit/config.json` (location overridable via `DIFIT_CONFIG_DIR`, mainly for tests). Writes are atomic (temp file + rename), the schema is versioned (`{"version": 1, "client": {...}}`) for forward compatibility, and a 64KB size guard rejects runaway payloads. Corrupt or missing files fall back to defaults.
- New endpoints: `GET /api/user-settings` returns the stored config; `PUT /api/user-settings` shallow-merges the patch per top-level key. With multiple difit servers running concurrently (the agent-review use case), this gives last-write-wins per setting rather than whole-file clobbering.

**Client**
- New `src/client/services/userSettings.ts`: a cached one-time fetch shared by all callers, and a debounced (300ms) fire-and-forget save that batches rapid changes (e.g. sidebar drag) into one PUT.
- Synced settings are the global UI preferences only: appearance settings (`useAppearanceSettings`), diff view mode, and sidebar width/open state (App.tsx). Repository-scoped data (comments, viewed files) stays in localStorage as before.
- On boot the client hydrates from the server config; localStorage remains the synchronous cache and the sole store when no API server exists (the static demo site — the fetch fails and everything behaves as today).
- Migration: if the server config has no value for a setting but localStorage does, the local value seeds the config once, so existing users keep their settings.
- Just opening difit doesn't create the config file — it's only written when a setting is changed (or seeded from existing localStorage values).

## Notes for review

- `resolve`-style per-key merging means a settings write from one difit server can't wipe out a different setting written by another server in the same window.
- Tests: unit tests for the config module (merge, size limit, corrupt file, no temp file left behind), real-server integration tests for GET/PUT, service tests for caching/debouncing, and hook tests for hydrate/seed behavior.

Closes #426.

🤖 Generated with [Claude Code](https://claude.com/claude-code)