### PR TITLE
feat(client): add GDScript syntax highlighting

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -200,7 +200,7 @@ npx skills add yoshiko-pg/difit
 - **システム言語**：C, C++, C#, Rust, Go
 - **モバイル言語**：Swift, Kotlin, Dart
 - **IaC**：Terraform (HCL), Nix
-- **その他**：Python, Protobuf, YAML, Solidity, Vim Script
+- **その他**：Python, Protobuf, YAML, Solidity, Vim Script, GDScript
 
 ## 🔍 自動折りたたみファイル
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -200,7 +200,7 @@ npx skills add yoshiko-pg/difit
 - **시스템 언어**: C, C++, C#, Rust, Go
 - **모바일 언어**: Swift, Kotlin, Dart
 - **인프라 코드**: Terraform (HCL), Nix
-- **기타**: Python, Protobuf, YAML, Solidity, Vim 스크립트
+- **기타**: Python, Protobuf, YAML, Solidity, Vim 스크립트, GDScript
 
 ## 🔍 자동 접힘 파일
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ After code edits or automated review, the agent can start the difit server with 
 - **Systems Languages**: C, C++, C#, Rust, Go
 - **Mobile Languages**: Swift, Kotlin, Dart
 - **Infrastructure as Code**: Terraform (HCL), Nix
-- **Others**: Python, Protobuf, YAML, Solidity, Vim script
+- **Others**: Python, Protobuf, YAML, Solidity, Vim script, GDScript
 
 ## 🔍 Auto-collapsed Files
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -200,7 +200,7 @@ npx skills add yoshiko-pg/difit
 - **系统语言**：C, C++, C#, Rust, Go
 - **移动语言**：Swift, Kotlin, Dart
 - **基础设施即代码**：Terraform (HCL), Nix
-- **其他**：Python, Protobuf, YAML, Solidity, Vim Script
+- **其他**：Python, Protobuf, YAML, Solidity, Vim Script, GDScript
 
 ## 🔍 自动折叠文件
 

--- a/src/client/utils/languageDetection.ts
+++ b/src/client/utils/languageDetection.ts
@@ -52,6 +52,7 @@ const DIFF_EXTENSION_LANGUAGE_MAP: Record<string, string> = {
   cljs: 'clojure',
   cljc: 'clojure',
   edn: 'clojure',
+  gd: 'gdscript',
 };
 
 // Prism syntax highlighting: use Prism language IDs (e.g. tsx -> tsx, scss -> css).
@@ -120,6 +121,7 @@ const PRISM_EXTENSION_LANGUAGE_MAP: Record<string, string> = {
   cljs: 'clojure',
   cljc: 'clojure',
   edn: 'clojure',
+  gd: 'gdscript',
 };
 
 const PRISM_FILENAME_LANGUAGE_MAP: Record<string, string> = {

--- a/src/client/utils/languageLoader.ts
+++ b/src/client/utils/languageLoader.ts
@@ -35,6 +35,7 @@ export function loadPrismLanguage(lang: string): Promise<void> {
       nix: () => import('prismjs/components/prism-nix.js'),
       haskell: () => import('prismjs/components/prism-haskell.js'),
       clojure: () => import('prismjs/components/prism-clojure.js'),
+      gdscript: () => import('prismjs/components/prism-gdscript.js'),
       // Svelte grammar ships as a third-party plugin (not in prismjs core);
       // it extends markup and embeds js/css, all available by default.
       svelte: () => import('prism-svelte'),


### PR DESCRIPTION
Prism already ships syntax highlighting for GDScript so this change registers it for `.gd` files.