### PR TITLE
Support shift-click range comments

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1070,9 +1070,10 @@ function App() {
     const target = e.target as HTMLElement;
     const isCommentButton = target.closest('[data-comment-button="true"]');
     const isOpenInEditorButton = target.closest('[data-open-in-editor-button="true"]');
+    const isShiftRangeClick = e.shiftKey && target.closest('[data-diff-line-row="true"]');
 
     // Close empty comment forms (unless clicking on a comment button)
-    if (!isCommentButton && !isOpenInEditorButton) {
+    if (!isCommentButton && !isOpenInEditorButton && !isShiftRangeClick) {
       closeEmptyCommentForms(e);
     }
   };

--- a/src/client/components/DiffChunk.test.tsx
+++ b/src/client/components/DiffChunk.test.tsx
@@ -1,0 +1,148 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { DiffChunk as DiffChunkData } from '../../types/diff';
+import { DEFAULT_DIFF_VIEW_MODE } from '../../utils/diffMode';
+import { WordHighlightProvider } from '../contexts/WordHighlightContext';
+
+import { DiffChunk } from './DiffChunk';
+import { SideBySideDiffChunk } from './SideBySideDiffChunk';
+
+const testChunk: DiffChunkData = {
+  header: '@@ -10,3 +10,3 @@',
+  oldStart: 10,
+  oldLines: 2,
+  newStart: 10,
+  newLines: 3,
+  lines: [
+    {
+      type: 'normal',
+      content: 'const first = 1;',
+      oldLineNumber: 10,
+      newLineNumber: 10,
+    },
+    {
+      type: 'normal',
+      content: 'const second = 2;',
+      oldLineNumber: 11,
+      newLineNumber: 11,
+    },
+    {
+      type: 'add',
+      content: 'const third = 3;',
+      newLineNumber: 12,
+    },
+  ],
+};
+
+const noop = () => {};
+const asyncNoop = async () => {};
+const renderWithProviders = (ui: ReactNode) =>
+  render(<WordHighlightProvider>{ui}</WordHighlightProvider>);
+
+describe('DiffChunk range comments', () => {
+  it('opens a unified range comment with shift-click', async () => {
+    const onAddComment = vi.fn().mockResolvedValue(undefined);
+    const { container } = renderWithProviders(
+      <DiffChunk
+        chunk={testChunk}
+        chunkIndex={0}
+        threads={[]}
+        mode="unified"
+        onAddComment={onAddComment}
+        onGenerateThreadPrompt={() => ''}
+        onRemoveThread={noop}
+        onReplyToThread={asyncNoop}
+        onRemoveMessage={noop}
+        onUpdateMessage={noop}
+        filename="src/example.ts"
+      />,
+    );
+
+    const rows = container.querySelectorAll('[data-diff-line-row="true"]');
+    fireEvent.click(rows[0]!);
+    fireEvent.click(rows[2]!, { shiftKey: true });
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: 'Please revisit this range' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => {
+      expect(onAddComment).toHaveBeenCalledWith(
+        [10, 12],
+        'Please revisit this range',
+        ['const first = 1;', 'const second = 2;', 'const third = 3;'].join('\n'),
+        'new',
+      );
+    });
+  });
+
+  it('opens a split-view range comment with shift-click on the same side', async () => {
+    const onAddComment = vi.fn().mockResolvedValue(undefined);
+    const { container } = renderWithProviders(
+      <SideBySideDiffChunk
+        chunk={testChunk}
+        chunkIndex={0}
+        threads={[]}
+        onAddComment={onAddComment}
+        onGenerateThreadPrompt={() => ''}
+        onRemoveThread={noop}
+        onReplyToThread={asyncNoop}
+        onRemoveMessage={noop}
+        onUpdateMessage={noop}
+        filename="src/example.ts"
+      />,
+    );
+
+    const rows = container.querySelectorAll('[data-diff-line-row="true"]');
+    fireEvent.click(rows[0]!.children[2]!);
+    fireEvent.click(rows[2]!.children[2]!, { shiftKey: true });
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: 'Please revisit this range' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => {
+      expect(onAddComment).toHaveBeenCalledWith(
+        [10, 12],
+        'Please revisit this range',
+        ['const first = 1;', 'const second = 2;', 'const third = 3;'].join('\n'),
+        'new',
+      );
+    });
+  });
+
+  it('falls back to a single-line comment when shift-click has no anchor', async () => {
+    const onAddComment = vi.fn().mockResolvedValue(undefined);
+    const { container } = renderWithProviders(
+      <DiffChunk
+        chunk={testChunk}
+        chunkIndex={0}
+        threads={[]}
+        mode={DEFAULT_DIFF_VIEW_MODE}
+        onAddComment={onAddComment}
+        onGenerateThreadPrompt={() => ''}
+        onRemoveThread={noop}
+        onReplyToThread={asyncNoop}
+        onRemoveMessage={noop}
+        onUpdateMessage={noop}
+        filename="src/example.ts"
+      />,
+    );
+
+    const rows = container.querySelectorAll('[data-diff-line-row="true"]');
+    fireEvent.click(rows[2]!.children[2]!, { shiftKey: true });
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: 'Single line only' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => {
+      expect(onAddComment).toHaveBeenCalledWith(12, 'Single line only', 'const third = 3;', 'new');
+    });
+  });
+});

--- a/src/client/components/DiffChunk.tsx
+++ b/src/client/components/DiffChunk.tsx
@@ -7,6 +7,7 @@ import {
   type CommentThread,
   type LineNumber,
   type DiffViewMode,
+  type LineSelection,
 } from '../../types/diff';
 import { DEFAULT_DIFF_VIEW_MODE } from '../../utils/diffMode';
 import { type CursorPosition } from '../hooks/keyboardNavigation';
@@ -87,6 +88,10 @@ export const DiffChunk = memo(function DiffChunk({
     side: DiffSide;
     lineNumber: LineNumber;
   } | null>(null);
+  const [selectionAnchor, setSelectionAnchor] = useState<{
+    side: DiffSide;
+    lineNumber: number;
+  } | null>(null);
   const [hoveredLine, setHoveredLine] = useState<number | null>(null);
 
   // Handle comment trigger from keyboard navigation
@@ -114,6 +119,71 @@ export const DiffChunk = memo(function DiffChunk({
     },
     [commentingLine],
   );
+
+  const getCommentLineFromAnchor = (selection: LineSelection): LineNumber => {
+    if (!selectionAnchor || selectionAnchor.side !== selection.side) {
+      return selection.lineNumber;
+    }
+
+    const min = Math.min(selectionAnchor.lineNumber, selection.lineNumber);
+    const max = Math.max(selectionAnchor.lineNumber, selection.lineNumber);
+    return min === max ? selection.lineNumber : [min, max];
+  };
+
+  const openShiftClickComment = (selection: LineSelection) => {
+    handleAddComment(selection.side, getCommentLineFromAnchor(selection));
+    setSelectionAnchor(selection);
+  };
+
+  const startCommentDrag = (selection: LineSelection) => {
+    setSelectionAnchor(selection);
+    setStartLine(selection.lineNumber);
+    setEndLine(selection.lineNumber);
+    setDragSide(selection.side);
+    setIsDragging(true);
+  };
+
+  const handleCommentButtonMouseDown = ({
+    isShiftClick,
+    selection,
+  }: {
+    isShiftClick: boolean;
+    selection: LineSelection | null;
+  }) => {
+    if (!selection) return;
+
+    if (isShiftClick) {
+      openShiftClickComment(selection);
+      return;
+    }
+
+    startCommentDrag(selection);
+  };
+
+  const handleRowClick = ({
+    isShiftClick,
+    lineIndex,
+    navigationSide,
+    selection,
+  }: {
+    isShiftClick: boolean;
+    lineIndex: number;
+    navigationSide: 'left' | 'right';
+    selection: LineSelection | null;
+  }) => {
+    if (!selection) {
+      onLineClick?.(fileIndex, chunkIndex, lineIndex, navigationSide);
+      return;
+    }
+
+    if (isShiftClick) {
+      openShiftClickComment(selection);
+      return;
+    }
+
+    setSelectionAnchor(selection);
+    onLineClick?.(fileIndex, chunkIndex, lineIndex, navigationSide);
+  };
 
   // Global mouse up handler for drag selection: commit the selection wherever
   // the mouse is released, not only on the comment button itself
@@ -367,6 +437,9 @@ export const DiffChunk = memo(function DiffChunk({
             const lineId = `file-${fileIndex}-chunk-${chunkIndex}-line-${index}`;
             const isCurrentLine =
               cursor && cursor.chunkIndex === chunkIndex && cursor.lineIndex === index;
+            const selection = commentLineNumber
+              ? { side: commentSide, lineNumber: commentLineNumber }
+              : null;
 
             return (
               <React.Fragment key={index}>
@@ -394,13 +467,13 @@ export const DiffChunk = memo(function DiffChunk({
                   }}
                   onCommentButtonMouseDown={(e) => {
                     e.stopPropagation();
-                    const lineNumber = line.newLineNumber || line.oldLineNumber;
-                    if (lineNumber) {
-                      setStartLine(lineNumber);
-                      setEndLine(lineNumber);
-                      setDragSide(line.type === 'delete' ? 'old' : 'new');
-                      setIsDragging(true);
+                    if (e.shiftKey) {
+                      e.preventDefault();
                     }
+                    handleCommentButtonMouseDown({
+                      isShiftClick: e.shiftKey,
+                      selection,
+                    });
                   }}
                   onOpenInEditor={
                     onOpenInEditor &&
@@ -418,10 +491,18 @@ export const DiffChunk = memo(function DiffChunk({
                   syntaxTheme={syntaxTheme}
                   filename={filename}
                   diffSegments={wordLevelDiffMap.get(index)}
-                  onClick={() => {
+                  onClick={(e) => {
                     // Determine the side based on line type for unified mode
                     const side = line.type === 'delete' ? 'left' : 'right';
-                    onLineClick?.(fileIndex, chunkIndex, index, side);
+                    if (e.shiftKey) {
+                      e.preventDefault();
+                    }
+                    handleRowClick({
+                      isShiftClick: e.shiftKey,
+                      lineIndex: index,
+                      navigationSide: side,
+                      selection,
+                    });
                   }}
                 />
 

--- a/src/client/components/DiffLineRow.tsx
+++ b/src/client/components/DiffLineRow.tsx
@@ -21,7 +21,7 @@ interface DiffLineRowProps {
   onCommentButtonMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => void;
   onOpenInEditor?: () => void;
   syntaxTheme?: AppearanceSettings['syntaxTheme'];
-  onClick?: () => void;
+  onClick?: (e: React.MouseEvent<HTMLTableRowElement>) => void;
   filename?: string;
   diffSegments?: DiffSegment[];
 }
@@ -67,6 +67,7 @@ export const DiffLineRow: React.FC<DiffLineRowProps> = React.memo(
     return (
       <tr
         id={lineId}
+        data-diff-line-row="true"
         className={`group ${getLineClass(line)} relative ${selectedLineStyle} ${highlightClass} cursor-pointer`}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}

--- a/src/client/components/SideBySideDiffChunk.tsx
+++ b/src/client/components/SideBySideDiffChunk.tsx
@@ -69,6 +69,12 @@ interface SideBySideLine {
   wordLevelDiff?: WordLevelDiffResult;
 }
 
+interface ClickedLineTarget {
+  selection: LineSelection;
+  lineIndex: number;
+  navigationSide: 'left' | 'right';
+}
+
 // Type guard to check if a line is an expanded line (#6)
 const isExpandedLine = (line: DiffLine | undefined): boolean => {
   return line !== undefined && 'isExpanded' in line && line.isExpanded === true;
@@ -89,6 +95,49 @@ const getSideBySideLineClass = (line: DiffLine | undefined, isExpanded: boolean)
     return 'bg-transparent';
   }
   return 'bg-github-bg-secondary';
+};
+
+const getClickedLineTarget = (
+  target: HTMLElement,
+  sideLine: SideBySideLine,
+): ClickedLineTarget | null => {
+  const isInOldSide = target.closest('td:nth-child(1)') || target.closest('td:nth-child(2)');
+  if (isInOldSide) {
+    if (
+      !sideLine.oldLineNumber ||
+      sideLine.oldLineOriginalIndex === undefined ||
+      sideLine.oldLineOriginalIndex < 0
+    ) {
+      return null;
+    }
+    return {
+      selection: {
+        side: 'old',
+        lineNumber: sideLine.oldLineNumber,
+      },
+      lineIndex: sideLine.oldLineOriginalIndex,
+      navigationSide: 'left',
+    };
+  }
+
+  const isInNewSide = target.closest('td:nth-child(3)') || target.closest('td:nth-child(4)');
+  if (!isInNewSide) return null;
+
+  if (
+    !sideLine.newLineNumber ||
+    sideLine.newLineOriginalIndex === undefined ||
+    sideLine.newLineOriginalIndex < 0
+  ) {
+    return null;
+  }
+  return {
+    selection: {
+      side: 'new',
+      lineNumber: sideLine.newLineNumber,
+    },
+    lineIndex: sideLine.newLineOriginalIndex,
+    navigationSide: 'right',
+  };
 };
 
 export function SideBySideDiffChunk({
@@ -119,6 +168,7 @@ export function SideBySideDiffChunk({
     side: DiffSide;
     lineNumber: LineNumber;
   } | null>(null);
+  const [selectionAnchor, setSelectionAnchor] = useState<LineSelection | null>(null);
   const [hoveredLine, setHoveredLine] = useState<LineSelection | null>(null);
 
   // Handle comment trigger from keyboard navigation
@@ -145,6 +195,68 @@ export function SideBySideDiffChunk({
     },
     [commentingLine],
   );
+
+  const getCommentLineFromAnchor = (selection: LineSelection): LineNumber => {
+    if (!selectionAnchor || selectionAnchor.side !== selection.side) {
+      return selection.lineNumber;
+    }
+
+    const min = Math.min(selectionAnchor.lineNumber, selection.lineNumber);
+    const max = Math.max(selectionAnchor.lineNumber, selection.lineNumber);
+    return min === max ? selection.lineNumber : [min, max];
+  };
+
+  const openShiftClickComment = (selection: LineSelection) => {
+    handleAddComment(selection.side, getCommentLineFromAnchor(selection));
+    setSelectionAnchor(selection);
+  };
+
+  const startCommentDrag = (selection: LineSelection) => {
+    setSelectionAnchor(selection);
+    setStartLine(selection);
+    setEndLine(selection);
+    setIsDragging(true);
+  };
+
+  const handleCommentButtonMouseDown = ({
+    isShiftClick,
+    selection,
+  }: {
+    isShiftClick: boolean;
+    selection: LineSelection | null;
+  }) => {
+    if (!selection) return;
+
+    if (isShiftClick) {
+      openShiftClickComment(selection);
+      return;
+    }
+
+    startCommentDrag(selection);
+  };
+
+  const handleRowClick = ({
+    isShiftClick,
+    target,
+    sideLine,
+  }: {
+    isShiftClick: boolean;
+    target: HTMLElement;
+    sideLine: SideBySideLine;
+  }) => {
+    if (isDragging) return;
+
+    const clickedLine = getClickedLineTarget(target, sideLine);
+    if (!clickedLine) return;
+
+    if (isShiftClick) {
+      openShiftClickComment(clickedLine.selection);
+      return;
+    }
+
+    setSelectionAnchor(clickedLine.selection);
+    onLineClick?.(fileIndex, chunkIndex, clickedLine.lineIndex, clickedLine.navigationSide);
+  };
 
   // Global mouse up handler for drag selection: commit the selection wherever
   // the mouse is released, not only on the comment button itself
@@ -445,26 +557,35 @@ export function SideBySideDiffChunk({
             const highlightNewCell = isHighlighted && cursor?.side === 'right';
 
             const cellHighlightClass = 'keyboard-cursor';
+            const oldSelection = sideLine.oldLineNumber
+              ? {
+                  side: 'old' as const,
+                  lineNumber: sideLine.oldLineNumber,
+                }
+              : null;
+            const newSelection = sideLine.newLineNumber
+              ? {
+                  side: 'new' as const,
+                  lineNumber: sideLine.newLineNumber,
+                }
+              : null;
 
             return (
               <React.Fragment key={index}>
                 <tr
+                  data-diff-line-row="true"
                   className="group cursor-pointer"
                   onClick={(e) => {
-                    if (!isDragging) {
-                      const target = e.target;
-                      if (!(target instanceof HTMLElement)) return;
-                      const isInOldSide =
-                        target.closest('td:nth-child(1)') || target.closest('td:nth-child(2)');
-                      const isInNewSide =
-                        target.closest('td:nth-child(3)') || target.closest('td:nth-child(4)');
-
-                      if (isInOldSide && oldLineOriginalIndex >= 0) {
-                        onLineClick?.(fileIndex, chunkIndex, oldLineOriginalIndex, 'left');
-                      } else if (isInNewSide && newLineOriginalIndex >= 0) {
-                        onLineClick?.(fileIndex, chunkIndex, newLineOriginalIndex, 'right');
-                      }
+                    const target = e.target;
+                    if (!(target instanceof HTMLElement)) return;
+                    if (e.shiftKey) {
+                      e.preventDefault();
                     }
+                    handleRowClick({
+                      isShiftClick: e.shiftKey,
+                      target,
+                      sideLine,
+                    });
                   }}
                   onMouseEnter={(e) => {
                     const target = e.target;
@@ -558,17 +679,13 @@ export function SideBySideDiffChunk({
                           <CommentButton
                             onMouseDown={(e) => {
                               e.stopPropagation();
-                              if (sideLine.oldLineNumber) {
-                                setStartLine({
-                                  side: 'old',
-                                  lineNumber: sideLine.oldLineNumber,
-                                });
-                                setEndLine({
-                                  side: 'old',
-                                  lineNumber: sideLine.oldLineNumber,
-                                });
-                                setIsDragging(true);
+                              if (e.shiftKey) {
+                                e.preventDefault();
                               }
+                              handleCommentButtonMouseDown({
+                                isShiftClick: e.shiftKey,
+                                selection: oldSelection,
+                              });
                             }}
                           />
                         </>
@@ -621,17 +738,13 @@ export function SideBySideDiffChunk({
                           <CommentButton
                             onMouseDown={(e) => {
                               e.stopPropagation();
-                              if (sideLine.newLineNumber) {
-                                setStartLine({
-                                  side: 'new',
-                                  lineNumber: sideLine.newLineNumber,
-                                });
-                                setEndLine({
-                                  side: 'new',
-                                  lineNumber: sideLine.newLineNumber,
-                                });
-                                setIsDragging(true);
+                              if (e.shiftKey) {
+                                e.preventDefault();
                               }
+                              handleCommentButtonMouseDown({
+                                isShiftClick: e.shiftKey,
+                                selection: newSelection,
+                              });
                             }}
                           />
                         </>


### PR DESCRIPTION
## Summary

Related to https://github.com/yoshiko-pg/difit/issues/425#issuecomment-4931203905

This PR adds shift-click range selection for line comments, just like as GitHub and GitLab supports.
Notice that I didn't split or created new files from existing.

## Changes

- `DiffChunk.tsx`: track a line-selection anchor from normal row clicks and comment-button mouse down. Shift-click opens a range comment from the anchor to the clicked line.
- `SideBySideDiffChunk.tsx`: same behavior for split view, preserving old/new side separation so ranges are only built within the clicked side.
- `App.tsx`: avoid immediately closing the empty comment form when it was opened by a Shift-click range action.
- `DiffLineRow.tsx`: pass row click events through so Shift-click can be handled by the diff chunk.
- `DiffChunk.test.tsx`: 
  - Add coverage for unified Shift-click ranges, split-view Shift-click ranges, and the single-line fallback when there is no anchor.
  - Notice that this test file yet doesn't cover full `DiffChunk.tsx`, that means, it's only covers "shift-click to range" feature only, not "dragging comment button to range".

## Testing

- `pnpm format` `pnpm check` `pnpm test` `pnpm build` passed on my working environment.

---

Disclaimer: I wrote this changes and messages with codex gpt-5.5.