### PR TITLE
fix: support plain unified diffs from stdin

### DIFF
--- a/src/client/components/DiffViewer.tsx
+++ b/src/client/components/DiffViewer.tsx
@@ -214,7 +214,8 @@ export const DiffViewer = memo(function DiffViewer({
   const [isVisible, setIsVisible] = useState(false);
 
   const viewer = getViewerForFile(file);
-  const canExpandHiddenLines = viewer.canExpandHiddenLines?.(file) ?? false;
+  const hasBlobContent = baseCommitish !== 'stdin' && targetCommitish !== 'stdin';
+  const canExpandHiddenLines = hasBlobContent && (viewer.canExpandHiddenLines?.(file) ?? false);
   // Tokenize the whole file so embedded blocks (e.g. <script>/<style>) are
   // highlighted by their own language instead of line-by-line, which can't see
   // the surrounding context.

--- a/src/client/hooks/useExpandedLines.test.ts
+++ b/src/client/hooks/useExpandedLines.test.ts
@@ -176,4 +176,23 @@ describe('useExpandedLines', () => {
       'base a rewritten line 1',
     );
   });
+
+  it('does not request unavailable blob data for stdin diffs', async () => {
+    const file = createMockDiffFile();
+    const { result } = renderHook(() =>
+      useExpandedLines({
+        baseCommitish: 'stdin',
+        targetCommitish: 'stdin',
+        diffIdentity: 'stdin-diff',
+      }),
+    );
+
+    await act(async () => {
+      await result.current.prefetchFileContent(file);
+      await result.current.expandLines(file, 0, 'up', 1);
+    });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(result.current.expandedState).toEqual({});
+  });
 });

--- a/src/client/hooks/useExpandedLines.ts
+++ b/src/client/hooks/useExpandedLines.ts
@@ -88,6 +88,7 @@ export function useExpandedLines({
   targetCommitish,
   diffIdentity,
 }: UseExpandedLinesOptions): UseExpandedLinesResult {
+  const isStdinDiff = baseCommitish === 'stdin' || targetCommitish === 'stdin';
   const [expandedState, setExpandedState] = useState<ExpandedLinesState>({});
   const [isLoading, setIsLoading] = useState(false);
   const [lastUpdatedFilePath, setLastUpdatedFilePath] = useState<string | null>(null);
@@ -111,6 +112,10 @@ export function useExpandedLines({
 
   const ensureFileContent = useCallback(
     async (file: DiffFile): Promise<FileExpandedState | null> => {
+      if (isStdinDiff) {
+        return null;
+      }
+
       const revisionGeneration = revisionGenerationRef.current;
       const pendingFetchKey = `${revisionGeneration}:${file.path}`;
 
@@ -178,7 +183,7 @@ export function useExpandedLines({
         pendingFetchesRef.current.delete(pendingFetchKey);
       }
     },
-    [baseCommitish, targetCommitish],
+    [baseCommitish, targetCommitish, isStdinDiff],
   );
 
   const markFileUpdated = useCallback((filePath: string) => {
@@ -337,6 +342,10 @@ export function useExpandedLines({
   // Pre-fetch only line counts (lightweight) to show bottom expand button
   const prefetchFileContent = useCallback(
     async (file: DiffFile) => {
+      if (isStdinDiff) {
+        return;
+      }
+
       const revisionGeneration = revisionGenerationRef.current;
       // Skip if we already have total lines info
       const existing = expandedStateRef.current[file.path];
@@ -380,7 +389,7 @@ export function useExpandedLines({
         console.error('Failed to prefetch line count:', error);
       }
     },
-    [baseCommitish, targetCommitish, markFileUpdated],
+    [baseCommitish, targetCommitish, isStdinDiff, markFileUpdated],
   );
 
   const getExpandedCount = useCallback(

--- a/src/client/hooks/useFileLevelTokens.test.ts
+++ b/src/client/hooks/useFileLevelTokens.test.ts
@@ -133,6 +133,21 @@ describe('useFileLevelTokens', () => {
     expect(result.current.getNewTokens).toBeNull();
   });
 
+  it('stdin diffではenabled=trueでもblobをfetchしない', () => {
+    const { result } = renderHook(() =>
+      useFileLevelTokens({
+        file: createVueFile(),
+        enabled: true,
+        baseCommitish: 'stdin',
+        targetCommitish: 'stdin',
+      }),
+    );
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(result.current.getOldTokens).toBeNull();
+    expect(result.current.getNewTokens).toBeNull();
+  });
+
   it('enabled=trueなら.tsファイルでもファイル単位トークン化する（拡張子で判断しない）', async () => {
     const tsContent = "const greeting = 'hi';\n";
     mockBlobFetch({ HEAD: tsContent, '.': tsContent });

--- a/src/client/hooks/useFileLevelTokens.ts
+++ b/src/client/hooks/useFileLevelTokens.ts
@@ -59,6 +59,7 @@ export function useFileLevelTokens({
   reloadKey,
 }: UseFileLevelTokensParams): FileLevelTokens {
   const language = useMemo(() => getPrismLanguageFromFilename(file.path), [file.path]);
+  const isStdinDiff = baseCommitish === 'stdin' || targetCommitish === 'stdin';
 
   const [oldContent, setOldContent] = useState<string | null>(null);
   const [newContent, setNewContent] = useState<string | null>(null);
@@ -86,7 +87,7 @@ export function useFileLevelTokens({
   }, [enabled, language]);
 
   useEffect(() => {
-    if (!enabled) {
+    if (!enabled || isStdinDiff) {
       setOldContent(null);
       setNewContent(null);
       return;
@@ -111,7 +112,16 @@ export function useFileLevelTokens({
     return () => {
       cancelled = true;
     };
-  }, [enabled, file.path, file.oldPath, file.status, baseCommitish, targetCommitish, reloadKey]);
+  }, [
+    enabled,
+    file.path,
+    file.oldPath,
+    file.status,
+    baseCommitish,
+    targetCommitish,
+    reloadKey,
+    isStdinDiff,
+  ]);
 
   const oldTokens = useMemo<Token[][] | null>(() => {
     if (!enabled || !grammarReady || oldContent == null) return null;

--- a/src/server/git-diff.test.ts
+++ b/src/server/git-diff.test.ts
@@ -939,6 +939,31 @@ index 0000000..1234567
       });
     });
 
+    it('normalizes CRLF in plain unified diff output', () => {
+      const diffContent = [
+        '--- old.txt',
+        '+++ new.txt',
+        '@@ -1 +1 @@',
+        '-old content',
+        '+new content',
+      ].join('\r\n');
+
+      const result = parser.parseStdinDiff(diffContent);
+
+      expect(result.files).toHaveLength(1);
+      expect(result.files[0]).toMatchObject({
+        path: 'new.txt',
+        chunks: [
+          {
+            lines: [
+              { type: 'delete', content: 'old content' },
+              { type: 'add', content: 'new content' },
+            ],
+          },
+        ],
+      });
+    });
+
     it('parses multiple concatenated plain unified diffs', () => {
       const diffContent = `--- first-old.txt
 +++ first-new.txt

--- a/src/server/git-diff.test.ts
+++ b/src/server/git-diff.test.ts
@@ -914,6 +914,106 @@ index 0000000..1234567
       });
     });
 
+    it('parses plain unified diff output without git headers', () => {
+      const diffContent = `--- file1.txt\t2026-07-11 12:00:00
++++ file2.txt\t2026-07-11 12:00:01
+@@ -1,2 +1,2 @@
+ unchanged
+-old content
++new content`;
+
+      const result = parser.parseStdinDiff(diffContent);
+
+      expect(result).toMatchObject({
+        commit: 'stdin diff',
+        isEmpty: false,
+        files: [
+          {
+            path: 'file2.txt',
+            status: 'modified',
+            additions: 1,
+            deletions: 1,
+            isGenerated: false,
+          },
+        ],
+      });
+    });
+
+    it('parses multiple concatenated plain unified diffs', () => {
+      const diffContent = `--- first-old.txt
++++ first-new.txt
+@@ -1 +1 @@
+-before
++after
+--- second-old.txt
++++ second-new.txt
+@@ -1 +1,2 @@
+ existing
++added`;
+
+      const result = parser.parseStdinDiff(diffContent);
+
+      expect(result.files).toMatchObject([
+        {
+          path: 'first-new.txt',
+          status: 'modified',
+          additions: 1,
+          deletions: 1,
+        },
+        {
+          path: 'second-new.txt',
+          status: 'modified',
+          additions: 1,
+          deletions: 0,
+        },
+      ]);
+    });
+
+    it('does not treat header-like hunk content as another plain diff', () => {
+      const diffContent = `--- old.txt
++++ new.txt
+@@ -1,2 +1,2 @@
+--- deleted content
++++ added content`;
+
+      const result = parser.parseStdinDiff(diffContent);
+
+      expect(result.files).toHaveLength(1);
+      expect(result.files[0]).toMatchObject({
+        path: 'new.txt',
+        additions: 1,
+        deletions: 1,
+      });
+    });
+
+    it('detects added and deleted files in plain unified diffs', () => {
+      const diffContent = `--- /dev/null
++++ added.txt
+@@ -0,0 +1 @@
++added
+--- deleted.txt
++++ /dev/null
+@@ -1 +0,0 @@
+-deleted`;
+
+      const result = parser.parseStdinDiff(diffContent);
+
+      expect(result.files).toMatchObject([
+        {
+          path: 'added.txt',
+          status: 'added',
+          additions: 1,
+          deletions: 0,
+        },
+        {
+          path: 'deleted.txt',
+          status: 'deleted',
+          additions: 0,
+          deletions: 1,
+        },
+      ]);
+    });
+
     it('should handle deleted files', async () => {
       const diffContent = `diff --git a/deleted.txt b/deleted.txt
 deleted file mode 100644

--- a/src/server/git-diff.ts
+++ b/src/server/git-diff.ts
@@ -170,7 +170,7 @@ export class GitDiffParser {
   }
 
   private splitPlainUnifiedDiff(diffText: string): string[] {
-    const lines = diffText.split('\n');
+    const lines = diffText.split(/\r?\n/);
     const blocks: string[] = [];
     let blockStart: number | null = null;
     let remainingOldLines = 0;

--- a/src/server/git-diff.ts
+++ b/src/server/git-diff.ts
@@ -147,15 +147,75 @@ export class GitDiffParser {
     const files: DiffFile[] = [];
     const fileBlocks = diffText.split(/^diff --git /m).slice(1);
 
-    for (const fileBlock of fileBlocks) {
-      const block = `diff --git ${fileBlock}`;
-      const file = this.parseFileBlock(block);
+    if (fileBlocks.length > 0) {
+      for (const fileBlock of fileBlocks) {
+        const block = `diff --git ${fileBlock}`;
+        const file = this.parseFileBlock(block);
+        if (file) {
+          files.push(file);
+        }
+      }
+
+      return files;
+    }
+
+    for (const fileBlock of this.splitPlainUnifiedDiff(diffText)) {
+      const file = this.parseFileBlock(fileBlock, 'plain');
       if (file) {
         files.push(file);
       }
     }
 
     return files;
+  }
+
+  private splitPlainUnifiedDiff(diffText: string): string[] {
+    const lines = diffText.split('\n');
+    const blocks: string[] = [];
+    let blockStart: number | null = null;
+    let remainingOldLines = 0;
+    let remainingNewLines = 0;
+
+    for (let index = 0; index < lines.length; index++) {
+      const line = lines[index];
+
+      if (blockStart !== null && line.startsWith('@@')) {
+        const match = line.match(/@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/);
+        if (match) {
+          remainingOldLines = parseInt(match[2] ?? '1');
+          remainingNewLines = parseInt(match[4] ?? '1');
+        }
+        continue;
+      }
+
+      if (blockStart !== null && (remainingOldLines > 0 || remainingNewLines > 0)) {
+        if (line.startsWith('\\')) {
+          continue;
+        }
+        if (line.startsWith('+')) {
+          remainingNewLines--;
+        } else if (line.startsWith('-')) {
+          remainingOldLines--;
+        } else if (line.startsWith(' ')) {
+          remainingOldLines--;
+          remainingNewLines--;
+        }
+        continue;
+      }
+
+      if (line.startsWith('--- ') && lines[index + 1]?.startsWith('+++ ')) {
+        if (blockStart !== null) {
+          blocks.push(lines.slice(blockStart, index).join('\n'));
+        }
+        blockStart = index;
+      }
+    }
+
+    if (blockStart !== null) {
+      blocks.push(lines.slice(blockStart).join('\n'));
+    }
+
+    return blocks;
   }
 
   private getGitattributesSourceArgs(ref: string): string[] {
@@ -237,26 +297,30 @@ export class GitDiffParser {
     );
   }
 
-  private decodeGitPath(rawPath: string | undefined): string | undefined {
+  private decodeGitPath(
+    rawPath: string | undefined,
+    stripGitPrefix: boolean = true,
+  ): string | undefined {
     if (typeof rawPath !== 'string') {
       return undefined;
     }
 
+    const tabIndex = rawPath.indexOf('\t');
+    const pathWithoutTimestamp = tabIndex === -1 ? rawPath : rawPath.slice(0, tabIndex);
     const trimmed =
-      rawPath.startsWith('"') && rawPath.endsWith('"') ? rawPath.slice(1, -1) : rawPath;
+      pathWithoutTimestamp.startsWith('"') && pathWithoutTimestamp.endsWith('"')
+        ? pathWithoutTimestamp.slice(1, -1)
+        : pathWithoutTimestamp;
 
     const gitPrefixes = ['a/', 'b/', 'c/', 'i/', 'w/'];
     let withoutPrefix = trimmed;
-    for (const prefix of gitPrefixes) {
-      if (withoutPrefix.startsWith(prefix)) {
-        withoutPrefix = withoutPrefix.slice(prefix.length);
-        break;
+    if (stripGitPrefix) {
+      for (const prefix of gitPrefixes) {
+        if (withoutPrefix.startsWith(prefix)) {
+          withoutPrefix = withoutPrefix.slice(prefix.length);
+          break;
+        }
       }
-    }
-
-    const tabIndex = withoutPrefix.indexOf('\t');
-    if (tabIndex !== -1) {
-      withoutPrefix = withoutPrefix.slice(0, tabIndex);
     }
 
     if (withoutPrefix === '/dev/null') {
@@ -333,12 +397,16 @@ export class GitDiffParser {
     return Buffer.from(bytes).toString('utf8');
   }
 
-  private extractPathFromLine(line: string | undefined, prefix: string): string | undefined {
+  private extractPathFromLine(
+    line: string | undefined,
+    prefix: string,
+    stripGitPrefix: boolean = true,
+  ): string | undefined {
     if (!line?.startsWith(prefix)) {
       return undefined;
     }
 
-    return this.decodeGitPath(line.slice(prefix.length));
+    return this.decodeGitPath(line.slice(prefix.length), stripGitPrefix);
   }
 
   private parseDiffHeaderPaths(
@@ -389,7 +457,7 @@ export class GitDiffParser {
     };
   }
 
-  private parseFileBlock(block: string): DiffFile | null {
+  private parseFileBlock(block: string, format: 'git' | 'plain' | null = 'git'): DiffFile | null {
     const lines = block.split('\n');
     const headerLine = lines[0];
     const headerPaths = this.parseDiffHeaderPaths(headerLine);
@@ -399,12 +467,15 @@ export class GitDiffParser {
     const renameFromLine = lines.find((line) => line.startsWith('rename from '));
     const renameToLine = lines.find((line) => line.startsWith('rename to '));
 
-    const plusPath = this.extractPathFromLine(plusLine, '+++ ');
-    const minusPath = this.extractPathFromLine(minusLine, '--- ');
+    const stripGitPrefix = format !== 'plain';
+    const plusPath = this.extractPathFromLine(plusLine, '+++ ', stripGitPrefix);
+    const minusPath = this.extractPathFromLine(minusLine, '--- ', stripGitPrefix);
     const renameFromPath = this.extractPathFromLine(renameFromLine, 'rename from ');
     const renameToPath = this.extractPathFromLine(renameToLine, 'rename to ');
-    const newPath = renameToPath ?? plusPath ?? headerPaths?.newPath;
-    const oldPath = renameFromPath ?? minusPath ?? headerPaths?.oldPath ?? newPath;
+    const parsedNewPath = renameToPath ?? plusPath ?? headerPaths?.newPath;
+    const parsedOldPath = renameFromPath ?? minusPath ?? headerPaths?.oldPath;
+    const newPath = parsedNewPath ?? parsedOldPath;
+    const oldPath = parsedOldPath ?? newPath;
 
     if (!newPath) {
       return null;
@@ -423,7 +494,7 @@ export class GitDiffParser {
       status = 'added';
     } else if (deletedFileMode || plusLine?.includes('/dev/null')) {
       status = 'deleted';
-    } else if (oldPath !== newPath) {
+    } else if (format !== 'plain' && oldPath !== newPath) {
       status = 'renamed';
     }
 


### PR DESCRIPTION
## Summary

- parse traditional unified diffs from tools such as `diff -u` when stdin does not contain Git patch headers
- preserve the existing Git patch parser unchanged as the primary path
- avoid unavailable blob and line-count requests while reviewing stdin diffs

## Root cause

The stdin parser split input exclusively on `diff --git` headers. README examples using `diff -u file1 file2 | difit` therefore started successfully but produced an empty review.

## Compatibility

Git-format patches continue through the existing parser. The new plain-unified-diff parser is only used when no `diff --git` header exists. Existing Git patch tests, including paths, binary files, renames, additions, and deletions, continue to pass.

## Verification

- `pnpm format`
- `pnpm check`
- `pnpm test` (732 passed, 3 skipped)
- `pnpm build`
- `pnpm knip`
- manual integration: `diff -u README.md README.ja.md | node dist/cli/index.js - --no-open`, verified as a non-empty parsed diff
