### PR TITLE
feat(client): show an always-visible inline reply box on comment threads

### DIFF
--- a/src/client/components/CommentThreadCard.test.tsx
+++ b/src/client/components/CommentThreadCard.test.tsx
@@ -250,6 +250,70 @@ describe('CommentThreadCard', () => {
     expect(screen.queryByLabelText('Outdated comment')).not.toBeInTheDocument();
   });
 
+  it('always shows an inline reply trigger below the last message', () => {
+    render(
+      <CommentThreadCard
+        thread={mockThread}
+        onGeneratePrompt={() => 'thread prompt'}
+        onRemoveThread={vi.fn()}
+        onReplyToThread={vi.fn().mockResolvedValue(undefined)}
+        onRemoveMessage={vi.fn()}
+        onUpdateMessage={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Write a reply...' })).toBeInTheDocument();
+  });
+
+  it('expands the reply trigger into a reply form and submits a reply', async () => {
+    const user = userEvent.setup();
+    const onReplyToThread = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <CommentThreadCard
+        thread={mockThread}
+        onGeneratePrompt={() => 'thread prompt'}
+        onRemoveThread={vi.fn()}
+        onReplyToThread={onReplyToThread}
+        onRemoveMessage={vi.fn()}
+        onUpdateMessage={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Write a reply...' }));
+
+    const textarea = screen.getByPlaceholderText('Write a reply...');
+    expect(textarea).toHaveFocus();
+
+    await user.type(textarea, 'A new reply');
+    await user.click(screen.getByRole('button', { name: 'Reply' }));
+
+    expect(onReplyToThread).toHaveBeenCalledWith('thread-1', 'A new reply');
+    // Collapses back to the trigger after submitting
+    expect(screen.getByRole('button', { name: 'Write a reply...' })).toBeInTheDocument();
+  });
+
+  it('collapses the reply form back to the trigger on cancel', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <CommentThreadCard
+        thread={mockThread}
+        onGeneratePrompt={() => 'thread prompt'}
+        onRemoveThread={vi.fn()}
+        onReplyToThread={vi.fn().mockResolvedValue(undefined)}
+        onRemoveMessage={vi.fn()}
+        onUpdateMessage={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Write a reply...' }));
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(screen.queryByPlaceholderText('Write a reply...')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Write a reply...' })).toBeInTheDocument();
+  });
+
   it('shows an inline confirmation before deleting a user-authored reply', async () => {
     const user = userEvent.setup();
     const onRemoveMessage = vi.fn();

--- a/src/client/components/CommentThreadCard.tsx
+++ b/src/client/components/CommentThreadCard.tsx
@@ -1,4 +1,4 @@
-import { Check, Copy, Edit2, MessageSquareReply, Trash2 } from 'lucide-react';
+import { Check, Copy, Edit2, Trash2 } from 'lucide-react';
 import React, { useEffect, useRef, useState } from 'react';
 
 import { type CommentThread, type DiffCommentMessage } from '../../types/diff';
@@ -279,18 +279,6 @@ export function CommentThreadCard({
               {isCopied ? 'Copied!' : 'Copy Prompt'}
             </span>
           </button>
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              setIsReplying((prev) => !prev);
-            }}
-            aria-label="Reply"
-            className="rounded border border-github-border bg-github-bg-tertiary p-1.5 text-github-text-primary transition-all hover:bg-github-bg-primary"
-            title="Reply to thread"
-          >
-            <MessageSquareReply size={14} />
-          </button>
         </div>
       </div>
 
@@ -324,11 +312,11 @@ export function CommentThreadCard({
           </div>
         ))}
 
-        {isReplying && (
-          <div
-            className="ml-4 border-l border-github-border pl-3"
-            onClick={(e) => e.stopPropagation()}
-          >
+        <div
+          className="ml-4 border-l border-github-border pl-3"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {isReplying ? (
             <CommentForm
               onSubmit={async (body) => {
                 await onReplyToThread(thread.id, body);
@@ -343,8 +331,18 @@ export function CommentThreadCard({
               submitLabel="Reply"
               placeholder="Write a reply..."
             />
-          </div>
-        )}
+          ) : (
+            <button
+              type="button"
+              data-reply-trigger="true"
+              onFocus={() => setIsReplying(true)}
+              onClick={() => setIsReplying(true)}
+              className="w-full cursor-text rounded border border-github-border bg-github-bg-secondary px-3 py-1.5 text-left text-sm text-github-text-muted transition-colors hover:border-github-text-secondary"
+            >
+              Write a reply...
+            </button>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/client/components/CommentsListModal.test.tsx
+++ b/src/client/components/CommentsListModal.test.tsx
@@ -190,7 +190,7 @@ describe('CommentsListModal', () => {
       { wrapper },
     );
 
-    await user.click(screen.getAllByRole('button', { name: 'Reply' })[0]!);
+    await user.click(screen.getAllByRole('button', { name: 'Write a reply...' })[0]!);
     await user.click(screen.getByPlaceholderText('Write a reply...'));
 
     expect(screen.getByText('Reply to thread')).toBeInTheDocument();


### PR DESCRIPTION
## Summary

Implements suggestion 1 from #432: replace the Reply toggle button with an always-visible inline reply box, similar to GitHub.

- The header Reply icon button is removed.
- A "Write a reply..." trigger is now always shown below the last message of a thread.
- Clicking (or focusing) the trigger expands it into the full reply form with the textarea focused, so replying is a single click.
- The form collapses back to the trigger after submitting, cancelling, pressing Escape, or clicking outside while empty (via the existing empty-form auto-close handling).

## Before / After

Before: Reply required 3 steps (click **Comment** → click the text field → type).
After: click the always-visible reply box → type.

## Test plan

- [x] Unit tests for the trigger rendering, expand + submit, and cancel collapse
- [x] Existing CommentThreadCard / CommentsListModal tests updated and passing
- [x] Verified in the browser with `pnpm run dev`: trigger renders below the thread, expands on click with focus, reply submits and collapses back

Part of #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)