### PR TITLE
feat(client): add a search box to the revision selector

### DIFF
--- a/src/client/components/DiffQuickMenu.test.ts
+++ b/src/client/components/DiffQuickMenu.test.ts
@@ -78,7 +78,9 @@ describe('DiffQuickMenu', () => {
     fireEvent.click(screen.getByRole('button', { name: /Revision menu:/ }));
     fireEvent.click(screen.getByRole('button', { name: 'Pick Commit...' }));
 
-    const commitButtons = await screen.findAllByRole('button', { name: /1f23cd1/ });
+    const commitButtons = await screen.findAllByRole('button', {
+      name: /1f23cd1/,
+    });
     const highlightedCommitButton = commitButtons.find((button) =>
       button.className.includes('border-l-diff-selected-border'),
     );
@@ -104,7 +106,9 @@ describe('DiffQuickMenu', () => {
       screen.getByRole('button', { name: 'main...Uncommitted (merge-base)' }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: 'origin/main...Uncommitted (merge-base)' }),
+      screen.getByRole('button', {
+        name: 'origin/main...Uncommitted (merge-base)',
+      }),
     ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'HEAD' })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'HEAD...Staging' })).not.toBeInTheDocument();
@@ -163,7 +167,11 @@ describe('DiffQuickMenu', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: /Revision menu:/ }));
-    fireEvent.click(screen.getByRole('button', { name: 'origin/main...Uncommitted (merge-base)' }));
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'origin/main...Uncommitted (merge-base)',
+      }),
+    );
 
     expect(onSelectDiff).toHaveBeenCalledWith({
       baseCommitish: 'origin/main',
@@ -172,11 +180,130 @@ describe('DiffQuickMenu', () => {
     });
   });
 
+  it('filters the menu down to matching commits when typing in the search box', () => {
+    render(
+      createElement(DiffQuickMenu, {
+        options,
+        selection: { baseCommitish: 'HEAD', targetCommitish: '.' },
+        onSelectDiff: vi.fn(),
+        onOpenAdvanced: vi.fn(),
+      }),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Revision menu:/ }));
+    fireEvent.change(screen.getByPlaceholderText('Filter branches and commits...'), {
+      target: { value: 'release' },
+    });
+
+    expect(screen.getByRole('button', { name: /1f23cd1/ })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'HEAD' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Pick Commit...' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Detailed...' })).not.toBeInTheDocument();
+  });
+
+  it('selects commit^...commit when a filtered commit is clicked', () => {
+    const onSelectDiff = vi.fn();
+    render(
+      createElement(DiffQuickMenu, {
+        options,
+        selection: { baseCommitish: 'HEAD', targetCommitish: '.' },
+        onSelectDiff,
+        onOpenAdvanced: vi.fn(),
+      }),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Revision menu:/ }));
+    fireEvent.change(screen.getByPlaceholderText('Filter branches and commits...'), {
+      target: { value: 'release' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /1f23cd1/ }));
+
+    expect(onSelectDiff).toHaveBeenCalledWith({
+      baseCommitish: '1f23cd1^',
+      targetCommitish: '1f23cd1',
+    });
+  });
+
+  it('selects branch...Uncommitted (merge-base) when a filtered branch is clicked', () => {
+    const onSelectDiff = vi.fn();
+    render(
+      createElement(DiffQuickMenu, {
+        options,
+        selection: { baseCommitish: 'HEAD', targetCommitish: '.' },
+        onSelectDiff,
+        onOpenAdvanced: vi.fn(),
+      }),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Revision menu:/ }));
+    fireEvent.change(screen.getByPlaceholderText('Filter branches and commits...'), {
+      target: { value: 'main' },
+    });
+
+    const branchesSection = screen.getByText('Branches').parentElement;
+    expect(branchesSection).not.toBeNull();
+    fireEvent.click(
+      within(branchesSection!).getByRole('button', {
+        name: /main \(current\)/,
+      }),
+    );
+
+    expect(onSelectDiff).toHaveBeenCalledWith({
+      baseCommitish: 'main',
+      targetCommitish: '.',
+      baseMode: 'merge-base',
+    });
+  });
+
+  it('selects the first match when pressing Enter in the search box', () => {
+    const onSelectDiff = vi.fn();
+    render(
+      createElement(DiffQuickMenu, {
+        options,
+        selection: { baseCommitish: 'HEAD', targetCommitish: '.' },
+        onSelectDiff,
+        onOpenAdvanced: vi.fn(),
+      }),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Revision menu:/ }));
+    const searchInput = screen.getByPlaceholderText('Filter branches and commits...');
+    fireEvent.change(searchInput, { target: { value: 'v3.1.5' } });
+    fireEvent.keyDown(searchInput, { key: 'Enter' });
+
+    expect(onSelectDiff).toHaveBeenCalledWith({
+      baseCommitish: '1f23cd1^',
+      targetCommitish: '1f23cd1',
+    });
+  });
+
+  it('shows an empty state when nothing matches the search query', () => {
+    render(
+      createElement(DiffQuickMenu, {
+        options,
+        selection: { baseCommitish: 'HEAD', targetCommitish: '.' },
+        onSelectDiff: vi.fn(),
+        onOpenAdvanced: vi.fn(),
+      }),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Revision menu:/ }));
+    fireEvent.change(screen.getByPlaceholderText('Filter branches and commits...'), {
+      target: { value: 'does-not-exist' },
+    });
+
+    expect(screen.getByText('No matching branches or commits')).toBeInTheDocument();
+  });
+
   it('shows merge-base in the current label', () => {
     render(
       createElement(DiffQuickMenu, {
         options,
-        selection: { baseCommitish: 'origin/main', targetCommitish: '.', baseMode: 'merge-base' },
+        selection: {
+          baseCommitish: 'origin/main',
+          targetCommitish: '.',
+          baseMode: 'merge-base',
+        },
         onSelectDiff: vi.fn(),
         onOpenAdvanced: vi.fn(),
       }),

--- a/src/client/components/DiffQuickMenu.tsx
+++ b/src/client/components/DiffQuickMenu.tsx
@@ -12,8 +12,8 @@ import {
   FloatingPortal,
   safePolygon,
 } from '@floating-ui/react';
-import { ChevronDown, ChevronLeft, GitBranch } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { ChevronDown, ChevronLeft, GitBranch, Search } from 'lucide-react';
+import { useEffect, useMemo, useState, type KeyboardEvent } from 'react';
 
 import { type CommitInfo, type DiffSelection, type RevisionsResponse } from '../../types/diff';
 import {
@@ -113,6 +113,7 @@ export function DiffQuickMenu({
 }: DiffQuickMenuProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [isCommitMenuOpen, setIsCommitMenuOpen] = useState(false);
+  const [query, setQuery] = useState('');
   const isCompact = compact;
 
   const { refs, floatingStyles, context } = useFloating({
@@ -120,6 +121,7 @@ export function DiffQuickMenu({
     onOpenChange: (open) => {
       if (!open && isCommitMenuOpen) return;
       setIsOpen(open);
+      if (!open) setQuery('');
     },
     placement: 'bottom-end',
     middleware: [offset(6), flip(), shift({ padding: 8 })],
@@ -221,12 +223,99 @@ export function DiffQuickMenu({
     onSelectDiff(nextSelection);
     setIsCommitMenuOpen(false);
     setIsOpen(false);
+    setQuery('');
   };
 
   const handleOpenAdvanced = () => {
     setIsCommitMenuOpen(false);
     setIsOpen(false);
+    setQuery('');
     onOpenAdvanced();
+  };
+
+  const presetItems = useMemo(() => {
+    const items: Array<{
+      key: string;
+      label: string;
+      selection: DiffSelection;
+    }> = [
+      { key: 'head', label: 'HEAD', selection: headPreset },
+      {
+        key: 'head-uncommitted',
+        label: 'HEAD...Uncommitted (merge-base)',
+        selection: headUncommittedPreset,
+      },
+    ];
+    if (mainBranch && mainUncommittedPreset) {
+      items.push({
+        key: 'main-uncommitted',
+        label: `${mainBranch.name}...Uncommitted (merge-base)`,
+        selection: mainUncommittedPreset,
+      });
+    }
+    if (originDefaultBranch && originUncommittedPreset) {
+      items.push({
+        key: 'origin-uncommitted',
+        label: `${originDefaultBranch}...Uncommitted (merge-base)`,
+        selection: originUncommittedPreset,
+      });
+    }
+    items.push({
+      key: 'previous',
+      label: 'Previous commit',
+      selection: previousCommitPreset,
+    });
+    return items;
+  }, [
+    headPreset,
+    headUncommittedPreset,
+    mainBranch,
+    mainUncommittedPreset,
+    originDefaultBranch,
+    originUncommittedPreset,
+    previousCommitPreset,
+  ]);
+
+  const normalizedQuery = query.trim().toLowerCase();
+  const isFiltering = normalizedQuery.length > 0;
+  const matchesQuery = (...texts: string[]) =>
+    texts.some((text) => text.toLowerCase().includes(normalizedQuery));
+
+  const filteredPresets = isFiltering
+    ? presetItems.filter((item) => matchesQuery(item.label))
+    : presetItems;
+  const filteredCommits = isFiltering
+    ? options.commits.filter((commit) =>
+        matchesQuery(commit.shortHash, commit.hash, commit.message),
+      )
+    : [];
+  const filteredBranches = isFiltering
+    ? options.branches.filter((branch) => matchesQuery(branch.name))
+    : [];
+
+  const hasNoMatches =
+    isFiltering &&
+    filteredPresets.length === 0 &&
+    filteredCommits.length === 0 &&
+    filteredBranches.length === 0;
+
+  const branchSelection = (branchName: string) =>
+    createDiffSelection(branchName, '.', 'merge-base');
+
+  // Select the first match when pressing Enter in the search box
+  const handleSearchKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key !== 'Enter' || !isFiltering) return;
+    event.preventDefault();
+
+    const firstMatch =
+      filteredPresets[0]?.selection ??
+      (filteredCommits[0]
+        ? createDiffSelection(`${filteredCommits[0].shortHash}^`, filteredCommits[0].shortHash)
+        : undefined) ??
+      (filteredBranches[0] ? branchSelection(filteredBranches[0].name) : undefined);
+    if (firstMatch) {
+      handleSelect(firstMatch);
+    }
   };
 
   const getItemClasses = (highlighted: boolean, disabled: boolean) => {
@@ -294,79 +383,163 @@ export function DiffQuickMenu({
           <div
             ref={refs.setFloating}
             style={floatingStyles}
-            className="bg-github-bg-secondary border border-github-border rounded shadow-lg z-50 w-[260px] max-h-[360px] overflow-y-auto"
+            className="bg-github-bg-secondary border border-github-border rounded shadow-lg z-50 w-[320px] max-h-[400px] overflow-y-auto"
             {...getFloatingProps()}
           >
-            <div className="border-b border-github-border">
-              <div className="px-3 py-2 text-xs font-semibold text-github-text-secondary bg-github-bg-tertiary">
-                Quick Diffs
+            {/* Search box */}
+            <div className="sticky top-0 z-10 border-b border-github-border bg-github-bg-secondary p-2">
+              <div className="flex items-center gap-2 rounded border border-github-border bg-github-bg-primary px-2 py-1.5 focus-within:border-blue-600">
+                <Search size={12} className="shrink-0 text-github-text-secondary" />
+                <input
+                  type="text"
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  onKeyDown={handleSearchKeyDown}
+                  placeholder="Filter branches and commits..."
+                  aria-label="Filter branches and commits"
+                  className="w-full bg-transparent text-xs text-github-text-primary placeholder:text-github-text-muted focus:outline-none"
+                />
               </div>
-              <button
-                onClick={() => handleSelect(headPreset)}
-                className={getItemClasses(isPresetActive(headPreset), false)}
-              >
-                HEAD
-              </button>
-              <button
-                onClick={() => handleSelect(headUncommittedPreset)}
-                className={getItemClasses(isPresetActive(headUncommittedPreset), false)}
-              >
-                HEAD...Uncommitted (merge-base)
-              </button>
-              {mainBranch && mainUncommittedPreset && (
-                <>
-                  <button
-                    onClick={() => handleSelect(mainUncommittedPreset)}
-                    className={getItemClasses(isPresetActive(mainUncommittedPreset), false)}
-                  >
-                    {mainBranch.name}...Uncommitted (merge-base)
-                  </button>
-                </>
-              )}
-              {originDefaultBranch && originUncommittedPreset && (
-                <button
-                  onClick={() => handleSelect(originUncommittedPreset)}
-                  className={getItemClasses(isPresetActive(originUncommittedPreset), false)}
-                >
-                  {originDefaultBranch}...Uncommitted (merge-base)
-                </button>
-              )}
             </div>
 
-            <div className="border-b border-github-border">
-              <button
-                onClick={() => handleSelect(previousCommitPreset)}
-                className={getItemClasses(isPresetActive(previousCommitPreset), false)}
-                type="button"
-              >
-                Previous commit
-              </button>
-            </div>
+            {isFiltering ? (
+              <>
+                {filteredPresets.length > 0 && (
+                  <div className="border-b border-github-border">
+                    <div className="px-3 py-2 text-xs font-semibold text-github-text-secondary bg-github-bg-tertiary">
+                      Quick Diffs
+                    </div>
+                    {filteredPresets.map((item) => (
+                      <button
+                        key={item.key}
+                        onClick={() => handleSelect(item.selection)}
+                        className={getItemClasses(isPresetActive(item.selection), false)}
+                        type="button"
+                      >
+                        {item.label}
+                      </button>
+                    ))}
+                  </div>
+                )}
 
-            <div className="border-b border-github-border">
-              <button
-                ref={options.commits.length > 0 ? commitRefs.setReference : undefined}
-                className={getItemClasses(false, options.commits.length === 0)}
-                {...(options.commits.length > 0 ? getCommitReferenceProps() : {})}
-                disabled={options.commits.length === 0}
-                type="button"
-              >
-                <div className="flex items-center gap-2">
-                  <ChevronLeft size={12} className="text-github-text-secondary" />
-                  <span>Pick Commit...</span>
+                {filteredCommits.length > 0 && (
+                  <div className="border-b border-github-border">
+                    <div className="px-3 py-2 text-xs font-semibold text-github-text-secondary bg-github-bg-tertiary">
+                      Commits
+                    </div>
+                    {filteredCommits.map((commit) => (
+                      <button
+                        key={commit.hash}
+                        onClick={() =>
+                          handleSelect(
+                            createDiffSelection(`${commit.shortHash}^`, commit.shortHash),
+                          )
+                        }
+                        className={getItemClasses(isCommitActive(commit), false)}
+                        type="button"
+                      >
+                        <div className="flex items-start gap-2">
+                          <code className="text-xs text-github-text-primary font-mono whitespace-nowrap">
+                            {commit.shortHash}
+                          </code>
+                          <span className="text-xs text-github-text-secondary flex-1 break-words">
+                            {commit.message}
+                          </span>
+                        </div>
+                      </button>
+                    ))}
+                  </div>
+                )}
+
+                {filteredBranches.length > 0 && (
+                  <div className="border-b border-github-border">
+                    <div className="px-3 py-2 text-xs font-semibold text-github-text-secondary bg-github-bg-tertiary">
+                      Branches
+                    </div>
+                    {filteredBranches.map((branch) => (
+                      <button
+                        key={branch.name}
+                        onClick={() => handleSelect(branchSelection(branch.name))}
+                        className={getItemClasses(
+                          isPresetActive(branchSelection(branch.name)),
+                          false,
+                        )}
+                        type="button"
+                        title={`${branch.name}...Uncommitted (merge-base)`}
+                      >
+                        <div className="flex items-center gap-2">
+                          <span className="text-github-text-primary">{branch.name}</span>
+                          {branch.current && (
+                            <span className="text-xs text-github-text-muted">(current)</span>
+                          )}
+                        </div>
+                      </button>
+                    ))}
+                  </div>
+                )}
+
+                {hasNoMatches && (
+                  <div className="px-3 py-4 text-center text-xs text-github-text-muted">
+                    No matching branches or commits
+                  </div>
+                )}
+              </>
+            ) : (
+              <>
+                <div className="border-b border-github-border">
+                  <div className="px-3 py-2 text-xs font-semibold text-github-text-secondary bg-github-bg-tertiary">
+                    Quick Diffs
+                  </div>
+                  {presetItems
+                    .filter((item) => item.key !== 'previous')
+                    .map((item) => (
+                      <button
+                        key={item.key}
+                        onClick={() => handleSelect(item.selection)}
+                        className={getItemClasses(isPresetActive(item.selection), false)}
+                        type="button"
+                      >
+                        {item.label}
+                      </button>
+                    ))}
                 </div>
-              </button>
-            </div>
 
-            <div>
-              <button
-                onClick={handleOpenAdvanced}
-                className={getItemClasses(false, false)}
-                type="button"
-              >
-                Detailed...
-              </button>
-            </div>
+                <div className="border-b border-github-border">
+                  <button
+                    onClick={() => handleSelect(previousCommitPreset)}
+                    className={getItemClasses(isPresetActive(previousCommitPreset), false)}
+                    type="button"
+                  >
+                    Previous commit
+                  </button>
+                </div>
+
+                <div className="border-b border-github-border">
+                  <button
+                    ref={options.commits.length > 0 ? commitRefs.setReference : undefined}
+                    className={getItemClasses(false, options.commits.length === 0)}
+                    {...(options.commits.length > 0 ? getCommitReferenceProps() : {})}
+                    disabled={options.commits.length === 0}
+                    type="button"
+                  >
+                    <div className="flex items-center gap-2">
+                      <ChevronLeft size={12} className="text-github-text-secondary" />
+                      <span>Pick Commit...</span>
+                    </div>
+                  </button>
+                </div>
+
+                <div>
+                  <button
+                    onClick={handleOpenAdvanced}
+                    className={getItemClasses(false, false)}
+                    type="button"
+                  >
+                    Detailed...
+                  </button>
+                </div>
+              </>
+            )}
           </div>
         </FloatingPortal>
       )}

--- a/src/client/components/RevisionSelector.test.tsx
+++ b/src/client/components/RevisionSelector.test.tsx
@@ -9,6 +9,11 @@ vi.mock('lucide-react', () => ({
       ChevronDown
     </div>
   ),
+  Search: ({ size, className }: { size: number; className: string }) => (
+    <div data-testid="search-icon" data-size={size} className={className}>
+      Search
+    </div>
+  ),
 }));
 
 describe('RevisionSelector', () => {
@@ -35,7 +40,9 @@ describe('RevisionSelector', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /Base:/ }));
 
-    const workingOption = screen.getByRole('button', { name: 'Working Directory' });
+    const workingOption = screen.getByRole('button', {
+      name: 'Working Directory',
+    });
     expect(workingOption).toBeDisabled();
   });
 
@@ -57,6 +64,77 @@ describe('RevisionSelector', () => {
 
     expect(branchButton).toHaveClass('border-l-diff-selected-border');
     expect(commitButton).toHaveClass('border-l-diff-selected-border');
+  });
+
+  it('filters options by the search query', () => {
+    render(<RevisionSelector label="Base" value="main" onChange={vi.fn()} options={options} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Base:/ }));
+
+    const searchInput = screen.getByPlaceholderText('Filter branches and commits...');
+    fireEvent.change(searchInput, { target: { value: 'staging' } });
+
+    expect(screen.getByRole('button', { name: 'Staging Area' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Working Directory' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'main' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Commit A/ })).not.toBeInTheDocument();
+  });
+
+  it('filters commits by hash and message', () => {
+    render(<RevisionSelector label="Base" value="main" onChange={vi.fn()} options={options} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Base:/ }));
+
+    const searchInput = screen.getByPlaceholderText('Filter branches and commits...');
+    fireEvent.change(searchInput, { target: { value: 'commit a' } });
+
+    expect(screen.getByRole('button', { name: /abc1234/ })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'main' })).not.toBeInTheDocument();
+  });
+
+  it('shows an empty state when nothing matches the query', () => {
+    render(<RevisionSelector label="Base" value="main" onChange={vi.fn()} options={options} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Base:/ }));
+
+    const searchInput = screen.getByPlaceholderText('Filter branches and commits...');
+    fireEvent.change(searchInput, { target: { value: 'does-not-exist' } });
+
+    expect(screen.getByText('No matching branches or commits')).toBeInTheDocument();
+  });
+
+  it('selects the first enabled match when pressing Enter in the search box', () => {
+    const onChange = vi.fn();
+    render(<RevisionSelector label="Base" value="main" onChange={onChange} options={options} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Base:/ }));
+
+    const searchInput = screen.getByPlaceholderText('Filter branches and commits...');
+    fireEvent.change(searchInput, { target: { value: 'commit a' } });
+    fireEvent.keyDown(searchInput, { key: 'Enter' });
+
+    expect(onChange).toHaveBeenCalledWith('abc1234');
+  });
+
+  it('skips disabled options when selecting with Enter', () => {
+    const onChange = vi.fn();
+    render(
+      <RevisionSelector
+        label="Base"
+        value="main"
+        onChange={onChange}
+        options={options}
+        disabledValues={['working']}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Base:/ }));
+
+    const searchInput = screen.getByPlaceholderText('Filter branches and commits...');
+    fireEvent.change(searchInput, { target: { value: 'working' } });
+    fireEvent.keyDown(searchInput, { key: 'Enter' });
+
+    expect(onChange).not.toHaveBeenCalled();
   });
 
   it('hides reserved quick preset values from the special options list', () => {

--- a/src/client/components/RevisionSelector.tsx
+++ b/src/client/components/RevisionSelector.tsx
@@ -4,6 +4,7 @@ import {
   offset,
   flip,
   shift,
+  size,
   useHover,
   useClick,
   useFocus,
@@ -14,8 +15,8 @@ import {
   FloatingPortal,
   safePolygon,
 } from '@floating-ui/react';
-import { ChevronDown } from 'lucide-react';
-import { useState } from 'react';
+import { ChevronDown, Search } from 'lucide-react';
+import { useRef, useState, type KeyboardEvent } from 'react';
 
 import { type RevisionsResponse } from '../../types/diff';
 
@@ -40,11 +41,28 @@ export function RevisionSelector({
   disabledValues = EMPTY_DISABLED_VALUES,
 }: RevisionSelectorProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const searchInputRef = useRef<HTMLInputElement>(null);
 
   const { refs, floatingStyles, context } = useFloating({
     open: isOpen,
-    onOpenChange: setIsOpen,
-    middleware: [offset(4), flip(), shift({ padding: 8 })],
+    onOpenChange: (open) => {
+      setIsOpen(open);
+      if (!open) setQuery('');
+    },
+    middleware: [
+      offset(4),
+      flip(),
+      shift({ padding: 8 }),
+      // Cap the dropdown height to the space actually available so the sticky
+      // search box is never pushed out of the viewport.
+      size({
+        padding: 8,
+        apply({ availableHeight, elements }) {
+          elements.floating.style.maxHeight = `${Math.min(400, availableHeight)}px`;
+        },
+      }),
+    ],
     whileElementsMounted: autoUpdate,
   });
 
@@ -92,6 +110,43 @@ export function RevisionSelector({
   const handleSelect = (newValue: string) => {
     onChange(newValue);
     setIsOpen(false);
+    setQuery('');
+  };
+
+  const normalizedQuery = query.trim().toLowerCase();
+  const matchesQuery = (...texts: string[]) =>
+    normalizedQuery.length === 0 ||
+    texts.some((text) => text.toLowerCase().includes(normalizedQuery));
+
+  const filteredSpecialOptions = visibleSpecialOptions.filter((opt) =>
+    matchesQuery(opt.label, opt.value),
+  );
+  const filteredCommits = isWorkingStagedMode
+    ? []
+    : options.commits.filter((commit) =>
+        matchesQuery(commit.shortHash, commit.hash, commit.message),
+      );
+  const filteredBranches = isWorkingStagedMode
+    ? []
+    : options.branches.filter((branch) => matchesQuery(branch.name));
+
+  const hasNoMatches =
+    filteredSpecialOptions.length === 0 &&
+    filteredCommits.length === 0 &&
+    filteredBranches.length === 0;
+
+  // Select the first enabled match when pressing Enter in the search box
+  const handleSearchKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key !== 'Enter') return;
+    event.preventDefault();
+
+    const firstMatch =
+      filteredSpecialOptions.find((opt) => !isDisabled(opt.value))?.value ??
+      filteredCommits.find((commit) => !isDisabled(commit.shortHash))?.shortHash ??
+      filteredBranches.find((branch) => !isDisabled(branch.name))?.name;
+    if (firstMatch !== undefined) {
+      handleSelect(firstMatch);
+    }
   };
 
   // Check if a value is disabled
@@ -122,35 +177,6 @@ export function RevisionSelector({
     return shortHash === resolvedValue || hash === resolvedValue;
   };
 
-  // Calculate initial focus index for the current value
-  const getInitialFocusIndex = (): number => {
-    let index = 0;
-
-    // Check special options
-    const specialIndex = visibleSpecialOptions.findIndex((opt) => opt.value === value);
-    if (specialIndex !== -1) {
-      return specialIndex;
-    }
-    index += visibleSpecialOptions.length;
-
-    // Check commits (only if not in working/staged mode)
-    if (!isWorkingStagedMode) {
-      const commitIndex = options.commits.findIndex((c) => c.shortHash === value);
-      if (commitIndex !== -1) {
-        return index + commitIndex;
-      }
-      index += options.commits.length;
-
-      // Check branches
-      const branchIndex = options.branches.findIndex((b) => b.name === value);
-      if (branchIndex !== -1) {
-        return index + branchIndex;
-      }
-    }
-
-    return 0; // Default to first item
-  };
-
   return (
     <>
       <button
@@ -175,24 +201,37 @@ export function RevisionSelector({
 
       {isOpen && (
         <FloatingPortal>
-          <FloatingFocusManager
-            context={context}
-            modal={false}
-            initialFocus={getInitialFocusIndex()}
-          >
+          <FloatingFocusManager context={context} modal={false} initialFocus={searchInputRef}>
             <div
               ref={refs.setFloating}
               style={floatingStyles}
-              className="bg-github-bg-secondary border border-github-border rounded shadow-lg z-50 w-[360px] max-h-[400px] overflow-y-auto"
+              className="bg-github-bg-secondary border border-github-border rounded shadow-lg z-50 w-[360px] overflow-y-auto"
               {...getFloatingProps()}
             >
+              {/* Search box */}
+              <div className="sticky top-0 z-10 border-b border-github-border bg-github-bg-secondary p-2">
+                <div className="flex items-center gap-2 rounded border border-github-border bg-github-bg-primary px-2 py-1.5 focus-within:border-blue-600">
+                  <Search size={12} className="shrink-0 text-github-text-secondary" />
+                  <input
+                    ref={searchInputRef}
+                    type="text"
+                    value={query}
+                    onChange={(e) => setQuery(e.target.value)}
+                    onKeyDown={handleSearchKeyDown}
+                    placeholder="Filter branches and commits..."
+                    aria-label="Filter branches and commits"
+                    className="w-full bg-transparent text-xs text-github-text-primary placeholder:text-github-text-muted focus:outline-none"
+                  />
+                </div>
+              </div>
+
               {/* Special Options */}
-              {visibleSpecialOptions.length > 0 && (
+              {filteredSpecialOptions.length > 0 && (
                 <div className="border-b border-github-border">
                   <div className="px-3 py-2 text-xs font-semibold text-github-text-secondary bg-github-bg-tertiary">
                     Special
                   </div>
-                  {visibleSpecialOptions.map((opt) => (
+                  {filteredSpecialOptions.map((opt) => (
                     <button
                       key={opt.value}
                       onClick={() => handleSelect(opt.value)}
@@ -206,12 +245,12 @@ export function RevisionSelector({
               )}
 
               {/* Recent Commits - hide in working/staged mode */}
-              {!isWorkingStagedMode && options.commits.length > 0 && (
+              {filteredCommits.length > 0 && (
                 <div className="border-b border-github-border">
                   <div className="px-3 py-2 text-xs font-semibold text-github-text-secondary bg-github-bg-tertiary">
                     Recent Commits
                   </div>
-                  {options.commits.map((commit) => (
+                  {filteredCommits.map((commit) => (
                     <button
                       key={commit.hash}
                       onClick={() => handleSelect(commit.shortHash)}
@@ -235,12 +274,12 @@ export function RevisionSelector({
               )}
 
               {/* Branches - hide in working/staged mode */}
-              {!isWorkingStagedMode && options.branches.length > 0 && (
+              {filteredBranches.length > 0 && (
                 <div>
                   <div className="px-3 py-2 text-xs font-semibold text-github-text-secondary bg-github-bg-tertiary">
                     Branches
                   </div>
-                  {options.branches.map((branch) => (
+                  {filteredBranches.map((branch) => (
                     <button
                       key={branch.name}
                       onClick={() => handleSelect(branch.name)}
@@ -255,6 +294,13 @@ export function RevisionSelector({
                       </div>
                     </button>
                   ))}
+                </div>
+              )}
+
+              {/* Empty state when the query matches nothing */}
+              {hasNoMatches && (
+                <div className="px-3 py-4 text-center text-xs text-github-text-muted">
+                  No matching branches or commits
                 </div>
               )}
             </div>


### PR DESCRIPTION
## Summary

Implements suggestion 2 from #432: a searchable branch/commit picker.

### Quick menu (main dropdown)

- A sticky filter input now sits at the top of the revision quick menu, above the **Quick Diffs** section.
- Typing filters across:
  - **Quick Diff presets** (HEAD, HEAD...Uncommitted, main...Uncommitted, Previous commit, ...)
  - **Recent commits** — selecting one shows `commit^...commit`
  - **Branches** — selecting one shows `branch...Uncommitted (merge-base)`, consistent with the existing presets
- Pressing Enter selects the first match; an empty state is shown when nothing matches. The query resets when the menu closes.

### Detailed Diff selector

- The Base/Target revision dropdowns in the Detailed Diff modal get the same filter input (focused on open, Enter selects the first enabled match).
- The dropdown height is now capped with floating-ui's `size` middleware so the list always fits inside the viewport. Previously it could overflow off-screen when it flipped upward.

## Test plan

- [x] Unit tests for quick menu filtering (presets/commits/branches), commit and branch selection semantics, Enter-selects-first-match, empty state
- [x] Unit tests for the Detailed selector filtering
- [x] Verified in the browser with `pnpm run dev`: typing `inline` in the quick menu narrows to the matching commit and the `feat/inline-reply-box` branch

Part of #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)