### PR TITLE
feat(client): allow collapsing comment threads into a single line

### DIFF
--- a/src/client/components/CommentThreadCard.test.tsx
+++ b/src/client/components/CommentThreadCard.test.tsx
@@ -217,6 +217,76 @@ describe('CommentThreadCard', () => {
     expect(onRemoveThread).toHaveBeenCalledWith('thread-1');
   });
 
+  it('collapses the thread into a single line and expands it back', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <CommentThreadCard
+        thread={mockThread}
+        onGeneratePrompt={() => 'thread prompt'}
+        onRemoveThread={vi.fn()}
+        onReplyToThread={vi.fn().mockResolvedValue(undefined)}
+        onRemoveMessage={vi.fn()}
+        onUpdateMessage={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Collapse thread' }));
+
+    // Messages and actions are hidden; a one-line summary with the count remains
+    expect(screen.queryByText('Reply comment')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Copy Prompt/)).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Resolve thread')).not.toBeInTheDocument();
+    expect(screen.getByText('Root comment')).toBeInTheDocument();
+    expect(screen.getByLabelText('2 messages in thread')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Expand thread' }));
+
+    expect(screen.getByText('Reply comment')).toBeInTheDocument();
+    expect(screen.getByTitle('Resolve thread')).toBeInTheDocument();
+  });
+
+  it('expands a collapsed thread by clicking the summary line', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <CommentThreadCard
+        thread={mockThread}
+        onGeneratePrompt={() => 'thread prompt'}
+        onRemoveThread={vi.fn()}
+        onReplyToThread={vi.fn().mockResolvedValue(undefined)}
+        onRemoveMessage={vi.fn()}
+        onUpdateMessage={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Collapse thread' }));
+    await user.click(screen.getByText('Root comment'));
+
+    expect(screen.getByText('Reply comment')).toBeInTheDocument();
+  });
+
+  it('does not trigger the card click when toggling collapse', async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+
+    render(
+      <CommentThreadCard
+        thread={mockThread}
+        onGeneratePrompt={() => 'thread prompt'}
+        onRemoveThread={vi.fn()}
+        onReplyToThread={vi.fn().mockResolvedValue(undefined)}
+        onRemoveMessage={vi.fn()}
+        onUpdateMessage={vi.fn()}
+        onClick={onClick}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Collapse thread' }));
+
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
   it('shows the "Outdated" badge when the thread is marked outdated', () => {
     render(
       <CommentThreadCard

--- a/src/client/components/CommentThreadCard.tsx
+++ b/src/client/components/CommentThreadCard.tsx
@@ -1,4 +1,13 @@
-import { Check, Copy, Edit2, MessageSquareReply, Trash2 } from 'lucide-react';
+import {
+  Check,
+  ChevronDown,
+  ChevronRight,
+  Copy,
+  Edit2,
+  MessageSquare,
+  MessageSquareReply,
+  Trash2,
+} from 'lucide-react';
 import React, { useEffect, useRef, useState } from 'react';
 
 import { type CommentThread, type DiffCommentMessage } from '../../types/diff';
@@ -214,9 +223,15 @@ export function CommentThreadCard({
 }: CommentThreadCardProps) {
   const [isCopied, setIsCopied] = useState(false);
   const [isReplying, setIsReplying] = useState(false);
+  const [isCollapsed, setIsCollapsed] = useState(false);
   const lineLabel = Array.isArray(thread.line)
     ? `${thread.line[0]}-${thread.line[1]}`
     : thread.line;
+
+  const toggleCollapsed = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setIsCollapsed((prev) => !prev);
+  };
 
   const handleCopyThread = async (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -241,8 +256,18 @@ export function CommentThreadCard({
       }`}
       onClick={onClick}
     >
-      <div className="mb-3 flex items-center justify-between gap-3">
-        <div className="flex min-w-0 items-center gap-2 text-xs text-github-text-secondary">
+      <div className={`flex items-center justify-between gap-3 ${isCollapsed ? '' : 'mb-3'}`}>
+        <div className="flex min-w-0 flex-1 items-center gap-2 text-xs text-github-text-secondary">
+          <button
+            type="button"
+            onClick={toggleCollapsed}
+            aria-expanded={!isCollapsed}
+            aria-label={isCollapsed ? 'Expand thread' : 'Collapse thread'}
+            title={isCollapsed ? 'Expand thread' : 'Collapse thread'}
+            className="shrink-0 rounded p-0.5 text-github-text-secondary transition-colors hover:bg-github-bg-primary hover:text-github-text-primary"
+          >
+            {isCollapsed ? <ChevronRight size={14} /> : <ChevronDown size={14} />}
+          </button>
           <span
             className="font-mono px-1 py-0.5 rounded overflow-hidden text-ellipsis whitespace-nowrap"
             style={{
@@ -261,91 +286,114 @@ export function CommentThreadCard({
               Outdated
             </span>
           )}
+          {isCollapsed && (
+            <button
+              type="button"
+              onClick={toggleCollapsed}
+              className="flex min-w-0 flex-1 items-center gap-2 text-left"
+              title="Expand thread"
+            >
+              <span className="min-w-0 flex-1 truncate text-github-text-secondary">
+                {rootMessage.body.split('\n')[0]}
+              </span>
+              <span
+                className="inline-flex shrink-0 items-center gap-1 text-github-text-muted"
+                aria-label={`${thread.messages.length} messages in thread`}
+              >
+                <MessageSquare size={12} />
+                {thread.messages.length}
+              </span>
+            </button>
+          )}
         </div>
-        <div className="flex items-center gap-2">
-          <button
-            type="button"
-            onClick={handleCopyThread}
-            className="whitespace-nowrap rounded px-2 py-1 text-xs transition-all"
-            style={{
-              backgroundColor: 'var(--color-yellow-btn-bg)',
-              color: 'var(--color-yellow-btn-text)',
-              border: '1px solid var(--color-yellow-btn-border)',
-            }}
-            title="Copy thread prompt for AI coding agent"
-          >
-            <span className="inline-flex items-center gap-1">
-              <Copy size={12} />
-              {isCopied ? 'Copied!' : 'Copy Prompt'}
-            </span>
-          </button>
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              setIsReplying((prev) => !prev);
-            }}
-            aria-label="Reply"
-            className="rounded border border-github-border bg-github-bg-tertiary p-1.5 text-github-text-primary transition-all hover:bg-github-bg-primary"
-            title="Reply to thread"
-          >
-            <MessageSquareReply size={14} />
-          </button>
-        </div>
-      </div>
-
-      <div className="space-y-3">
-        <ThreadMessageItem
-          message={rootMessage}
-          isRootMessage={true}
-          showAuthorBadge={showAuthorBadges}
-          syntaxTheme={syntaxTheme}
-          filename={thread.file}
-          originalCode={thread.codeContent}
-          onUpdate={(newBody) => onUpdateMessage(thread.id, rootMessage.id, newBody)}
-          onResolveOrDelete={() => onRemoveThread(thread.id)}
-          actionLabel="Resolve thread"
-          confirmPrompt={confirmRootAction ? 'Resolve?' : undefined}
-        />
-
-        {thread.messages.slice(1).map((message) => (
-          <div key={message.id} className="ml-4 border-l border-github-border pl-3">
-            <ThreadMessageItem
-              message={message}
-              showAuthorBadge={showAuthorBadges}
-              syntaxTheme={syntaxTheme}
-              filename={thread.file}
-              originalCode={thread.codeContent}
-              onUpdate={(newBody) => onUpdateMessage(thread.id, message.id, newBody)}
-              onResolveOrDelete={() => onRemoveMessage(thread.id, message.id)}
-              actionLabel="Delete reply"
-              confirmPrompt="Delete?"
-            />
-          </div>
-        ))}
-
-        {isReplying && (
-          <div
-            className="ml-4 border-l border-github-border pl-3"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <CommentForm
-              onSubmit={async (body) => {
-                await onReplyToThread(thread.id, body);
-                setIsReplying(false);
+        {!isCollapsed && (
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={handleCopyThread}
+              className="whitespace-nowrap rounded px-2 py-1 text-xs transition-all"
+              style={{
+                backgroundColor: 'var(--color-yellow-btn-bg)',
+                color: 'var(--color-yellow-btn-text)',
+                border: '1px solid var(--color-yellow-btn-border)',
               }}
-              onCancel={() => setIsReplying(false)}
-              selectedCode={thread.codeContent}
-              syntaxTheme={syntaxTheme}
-              filename={thread.file}
-              embedded={true}
+              title="Copy thread prompt for AI coding agent"
+            >
+              <span className="inline-flex items-center gap-1">
+                <Copy size={12} />
+                {isCopied ? 'Copied!' : 'Copy Prompt'}
+              </span>
+            </button>
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                setIsReplying((prev) => !prev);
+              }}
+              aria-label="Reply"
+              className="rounded border border-github-border bg-github-bg-tertiary p-1.5 text-github-text-primary transition-all hover:bg-github-bg-primary"
               title="Reply to thread"
-              submitLabel="Reply"
-              placeholder="Write a reply..."
-            />
+            >
+              <MessageSquareReply size={14} />
+            </button>
           </div>
         )}
       </div>
+
+      {!isCollapsed && (
+        <div className="space-y-3">
+          <ThreadMessageItem
+            message={rootMessage}
+            isRootMessage={true}
+            showAuthorBadge={showAuthorBadges}
+            syntaxTheme={syntaxTheme}
+            filename={thread.file}
+            originalCode={thread.codeContent}
+            onUpdate={(newBody) => onUpdateMessage(thread.id, rootMessage.id, newBody)}
+            onResolveOrDelete={() => onRemoveThread(thread.id)}
+            actionLabel="Resolve thread"
+            confirmPrompt={confirmRootAction ? 'Resolve?' : undefined}
+          />
+
+          {thread.messages.slice(1).map((message) => (
+            <div key={message.id} className="ml-4 border-l border-github-border pl-3">
+              <ThreadMessageItem
+                message={message}
+                showAuthorBadge={showAuthorBadges}
+                syntaxTheme={syntaxTheme}
+                filename={thread.file}
+                originalCode={thread.codeContent}
+                onUpdate={(newBody) => onUpdateMessage(thread.id, message.id, newBody)}
+                onResolveOrDelete={() => onRemoveMessage(thread.id, message.id)}
+                actionLabel="Delete reply"
+                confirmPrompt="Delete?"
+              />
+            </div>
+          ))}
+
+          {isReplying && (
+            <div
+              className="ml-4 border-l border-github-border pl-3"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <CommentForm
+                onSubmit={async (body) => {
+                  await onReplyToThread(thread.id, body);
+                  setIsReplying(false);
+                }}
+                onCancel={() => setIsReplying(false)}
+                selectedCode={thread.codeContent}
+                syntaxTheme={syntaxTheme}
+                filename={thread.file}
+                embedded={true}
+                title="Reply to thread"
+                submitLabel="Reply"
+                placeholder="Write a reply..."
+              />
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Implements suggestion 4 from #432: collapsible discussion threads.

- A chevron toggle in the thread header collapses the discussion into a compact single line, similar to GitHub.
- The collapsed line shows the file:line chip, the first line of the root comment (truncated), and the number of messages in the thread.
- Clicking the summary line or the chevron expands the thread again.
- Collapse state is per-thread local UI state; it does not affect stored comments or prompts.

This makes large reviews easier to scan while keeping previous discussions available.

## Test plan

- [x] Unit tests: collapse hides messages/actions and shows the summary + count, expand restores them, summary line click expands, toggling does not trigger the card's navigation onClick
- [x] Verified in the browser with `pnpm run dev`: thread collapses to one line and expands back

Part of #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)