### PR TITLE
fix(server): keep /api/diff selection state intact when diff parsing fails

### DIFF
--- a/src/server/server.test.ts
+++ b/src/server/server.test.ts
@@ -462,6 +462,31 @@ describe('Server Integration Tests', () => {
       expect(data).toHaveProperty('requestedTargetCommitish', 'HEAD');
     });
 
+    it('GET /api/diff returns a JSON 500 on parse failure and does not poison subsequent requests', async () => {
+      const parser = parserInstances.at(-1);
+      parser?.parseDiff.mockClear();
+      parser?.parseDiff.mockRejectedValueOnce(
+        new Error('Failed to parse diff for nonexistent vs HEAD: unknown revision'),
+      );
+
+      const errorResponse = await fetch(`http://localhost:${port}/api/diff?target=nonexistent`);
+      expect(errorResponse.status).toBe(500);
+      expect(errorResponse.headers.get('content-type')).toContain('application/json');
+      const errorBody = (await errorResponse.json()) as any;
+      expect(typeof errorBody.error).toBe('string');
+
+      const recoveredResponse = await fetch(
+        `http://localhost:${port}/api/diff?ignoreWhitespace=true`,
+      );
+      expect(recoveredResponse.status).toBe(200);
+
+      expect(parser?.parseDiff).toHaveBeenLastCalledWith(
+        { targetCommitish: 'HEAD', baseCommitish: 'HEAD^' },
+        true,
+        undefined,
+      );
+    });
+
     it('GET /api/diff?ignoreWhitespace=true handles whitespace ignore', async () => {
       const response = await fetch(`http://localhost:${port}/api/diff?ignoreWhitespace=true`);
       const data = (await response.json()) as any;
@@ -1258,12 +1283,6 @@ describe('Server Integration Tests', () => {
   });
 
   describe('Error handling', () => {
-    it.skip('handles invalid commit gracefully', async () => {
-      // This test is skipped due to mocking complexity
-      // The validation happens during server startup and is hard to mock properly
-      expect(true).toBe(true);
-    });
-
     it('handles malformed comment data', async () => {
       const result = await startServer({
         selection: { targetCommitish: 'HEAD', baseCommitish: 'HEAD^' },

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -306,7 +306,6 @@ export async function startServer(
     const shouldIncludeCommentImports =
       initialCommentImports.length > 0 &&
       (Boolean(options.stdinDiff) || diffSelectionsEqual(requestedSelection, initialSelection));
-    currentSelection = requestedSelection;
 
     let responseDiffData = initialDiffData;
     if (!options.stdinDiff) {
@@ -315,15 +314,25 @@ export async function startServer(
       if (cached) {
         responseDiffData = cached;
       } else {
-        responseDiffData = await parser.parseDiff(
-          requestedSelection,
-          ignoreWhitespace,
-          options.contextLines,
-        );
+        try {
+          responseDiffData = await parser.parseDiff(
+            requestedSelection,
+            ignoreWhitespace,
+            options.contextLines,
+          );
+        } catch (error) {
+          console.error('Error fetching diff:', error);
+          res.status(500).json({
+            error: error instanceof Error ? error.message : 'Failed to fetch diff',
+          });
+          return;
+        }
         setCachedDiffResponse(diffDataCache, cacheKey, responseDiffData);
         generatedStatusCache.clear();
       }
     }
+
+    currentSelection = requestedSelection;
 
     currentCommentSelection = createResolvedCommentSelection(
       responseDiffData,


### PR DESCRIPTION
## Summary

- move the `currentSelection` update in the `/api/diff` handler to after the diff is successfully resolved, so a request with an invalid ref no longer poisons the server state used as the fallback for subsequent requests
- return a JSON 500 error when diff parsing fails, matching the error handling pattern of the other API endpoints (previously Express's default HTML stack trace was returned)
- add a regression test covering both behaviors, replacing the previously skipped `handles invalid commit gracefully` placeholder

## Root cause

In the `/api/diff` handler, `currentSelection = requestedSelection;` ran **before** `parser.parseDiff()`. When a request contained an invalid ref (e.g. `/api/diff?target=deleted-branch` — a branch deleted while switching revisions, or a hand-edited URL), the parse failed but the invalid selection had already overwritten `currentSelection`. Every subsequent parameter-less request (such as the initial fetch on page reload) then fell back to the poisoned selection and kept returning 500 until the server was restarted. The handler also had no try/catch, so the failure surfaced as Express's default HTML error page instead of JSON.

## Reproduction (before this fix)

```bash
difit HEAD --no-open --port 4901 &
curl "http://localhost:4901/api/diff?target=nonexistent-branch"  # → 500 (HTML stack trace)
curl "http://localhost:4901/api/diff"                            # → 500 forever, until restart
```

## Verification

- `pnpm check` / `pnpm format` / `pnpm knip` / `pnpm test` / `pnpm build` all pass
- confirmed the new regression test fails against the unfixed handler and passes with the fix
- manually verified with the built CLI: the first request now returns a JSON 500, and the following parameter-less request recovers with 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)