### PR TITLE
feat(client): render YAML frontmatter in markdown preview (full/diff)

### DIFF
--- a/docs/syntax-sample/frontmatter-array-after.md
+++ b/docs/syntax-sample/frontmatter-array-after.md
@@ -1,0 +1,18 @@
+---
+title: 'Release Notes'
+tags:
+  - release
+  - v1.2.0
+authors:
+  - Alice
+  - Bob
+categories:
+  - update
+  - guide
+---
+
+## v1.2.0
+
+This release includes minor bug fixes and performance improvements.
+
+See the changelog for full details and migration notes.

--- a/docs/syntax-sample/frontmatter-array-before.md
+++ b/docs/syntax-sample/frontmatter-array-before.md
@@ -1,0 +1,17 @@
+---
+title: 'Release Notes'
+tags: []
+authors:
+  - Alice
+  - Carol
+categories:
+  - guide
+  - update
+  - legacy
+---
+
+## v1.2.0
+
+This release includes minor bug fixes.
+
+See the changelog for full details.

--- a/docs/syntax-sample/frontmatter-nested-1-after.md
+++ b/docs/syntax-sample/frontmatter-nested-1-after.md
@@ -1,0 +1,16 @@
+---
+title: 'About the Team'
+seo:
+  title: 'About Us | Difit'
+  description: 'Learn about our team, mission, and values.'
+  noindex: false
+author:
+  name: 'Jane Smith'
+  email: 'jane@example.com'
+---
+
+## Our Story
+
+We started as a small group of enthusiasts back in 2020.
+
+Today we are a growing team dedicated to open source software.

--- a/docs/syntax-sample/frontmatter-nested-1-before.md
+++ b/docs/syntax-sample/frontmatter-nested-1-before.md
@@ -1,0 +1,16 @@
+---
+title: 'About the Team'
+seo:
+  title: 'About Us'
+  description: 'Learn about our team and mission.'
+author:
+  name: 'Jane Doe'
+  email: 'jane@example.com'
+  bio: 'Loves open source.'
+---
+
+## Our Story
+
+We started as a small group of enthusiasts.
+
+Today we are a growing team dedicated to open source.

--- a/docs/syntax-sample/frontmatter-nested-deep-after.md
+++ b/docs/syntax-sample/frontmatter-nested-deep-after.md
@@ -1,0 +1,18 @@
+---
+title: 'Site Configuration'
+site:
+  name: 'Difit Docs'
+  seo:
+    meta:
+      title: 'Difit Documentation | Guides'
+      description: 'Official documentation for difit.'
+      og:
+        image: '/images/og-cover.png'
+        type: 'website'
+---
+
+## Configuration Overview
+
+This page describes the site-wide configuration options available to maintainers.
+
+Update these values when rebranding or relaunching the documentation site.

--- a/docs/syntax-sample/frontmatter-nested-deep-before.md
+++ b/docs/syntax-sample/frontmatter-nested-deep-before.md
@@ -1,0 +1,16 @@
+---
+title: 'Site Configuration'
+site:
+  name: 'Difit Docs'
+  seo:
+    meta:
+      title: 'Difit Documentation'
+      og:
+        image: '/images/og-default.png'
+---
+
+## Configuration Overview
+
+This page describes the site-wide configuration options.
+
+Update these values when rebranding the documentation site.

--- a/docs/syntax-sample/frontmatter-scalar-after.md
+++ b/docs/syntax-sample/frontmatter-scalar-after.md
@@ -1,0 +1,14 @@
+---
+date: 2026-01-15
+weight: 10
+published: false
+title: 'Getting Started Guide'
+category: 'tutorial'
+description: 'A short guide for new users.'
+---
+
+## Introduction
+
+This guide walks you through the basic setup process.
+
+Follow the steps below to get your development environment ready before diving into advanced topics.

--- a/docs/syntax-sample/frontmatter-scalar-before.md
+++ b/docs/syntax-sample/frontmatter-scalar-before.md
@@ -1,0 +1,14 @@
+---
+title: 'Getting Started'
+date: '2026-01-10'
+published: true
+draft: false
+weight: '10'
+description: null
+---
+
+## Introduction
+
+This guide walks you through the basic setup process.
+
+Follow the steps below to get your environment ready.

--- a/knip.json
+++ b/knip.json
@@ -1,6 +1,7 @@
 {
   "ignoreBinaries": ["gh"],
   "ignoreDependencies": ["remark-frontmatter", "@types/js-yaml"],
+  "ignoreExportsUsedInFile": true,
   "workspaces": {
     ".": {},
     "packages/vscode": {

--- a/knip.json
+++ b/knip.json
@@ -1,5 +1,6 @@
 {
   "ignoreBinaries": ["gh"],
+  "ignoreDependencies": ["remark-frontmatter", "@types/js-yaml"],
   "workspaces": {
     ".": {},
     "packages/vscode": {

--- a/knip.json
+++ b/knip.json
@@ -1,6 +1,5 @@
 {
   "ignoreBinaries": ["gh"],
-  "ignoreExportsUsedInFile": true,
   "workspaces": {
     ".": {},
     "packages/vscode": {

--- a/knip.json
+++ b/knip.json
@@ -1,6 +1,5 @@
 {
   "ignoreBinaries": ["gh"],
-  "ignoreDependencies": ["remark-frontmatter", "@types/js-yaml"],
   "ignoreExportsUsedInFile": true,
   "workspaces": {
     ".": {},

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "commander": "^15.0.0",
     "diff": "^9.0.0",
     "express": "^5.1.0",
+    "js-yaml": "^5.2.1",
     "lucide-react": "^1.0.0",
     "mermaid": "^11.13.0",
     "open": "^11.0.0",
@@ -80,6 +81,7 @@
     "react-hotkeys-hook": "^5.2.4",
     "react-markdown": "^10.1.0",
     "remark-breaks": "^4.0.0",
+    "remark-frontmatter": "^5.0.0",
     "remark-gfm": "^4.0.1",
     "simple-git": "^3.28.0"
   },
@@ -90,6 +92,7 @@
     "@testing-library/user-event": "^14.6.1",
     "@tsconfig/strictest": "^2.0.5",
     "@types/express": "^5.0.3",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^24.0.8",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "commander": "^15.0.0",
     "diff": "^9.0.0",
     "express": "^5.1.0",
-    "js-yaml": "^5.2.1",
+    "js-yaml": "^4.3.0",
     "lucide-react": "^1.0.0",
     "mermaid": "^11.13.0",
     "open": "^11.0.0",
@@ -81,7 +81,6 @@
     "react-hotkeys-hook": "^5.2.4",
     "react-markdown": "^10.1.0",
     "remark-breaks": "^4.0.0",
-    "remark-frontmatter": "^5.0.0",
     "remark-gfm": "^4.0.1",
     "simple-git": "^3.28.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^5.1.0
         version: 5.2.1
       js-yaml:
-        specifier: ^5.2.1
-        version: 5.2.1
+        specifier: ^4.3.0
+        version: 4.3.0
       lucide-react:
         specifier: ^1.0.0
         version: 1.20.0(react@19.2.7)
@@ -59,9 +59,6 @@ importers:
       remark-breaks:
         specifier: ^4.0.0
         version: 4.0.0
-      remark-frontmatter:
-        specifier: ^5.0.0
-        version: 5.0.0
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -2549,9 +2546,6 @@ packages:
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
-  fault@2.0.1:
-    resolution: {integrity: sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==}
-
   fd-package-json@2.0.0:
     resolution: {integrity: sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==}
 
@@ -2590,10 +2584,6 @@ packages:
   form-data@4.0.6:
     resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
-
-  format@0.2.2:
-    resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
-    engines: {node: '>=0.4.x'}
 
   formatly@0.3.0:
     resolution: {integrity: sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==}
@@ -2868,10 +2858,6 @@ packages:
 
   js-yaml@4.3.0:
     resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
-    hasBin: true
-
-  js-yaml@5.2.1:
-    resolution: {integrity: sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -3163,9 +3149,6 @@ packages:
   mdast-util-from-markdown@2.0.2:
     resolution: {integrity: sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==}
 
-  mdast-util-frontmatter@2.0.1:
-    resolution: {integrity: sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==}
-
   mdast-util-gfm-autolink-literal@2.0.1:
     resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
 
@@ -3228,9 +3211,6 @@ packages:
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
-
-  micromark-extension-frontmatter@2.0.0:
-    resolution: {integrity: sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==}
 
   micromark-extension-gfm-autolink-literal@2.1.0:
     resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
@@ -3699,9 +3679,6 @@ packages:
 
   remark-breaks@4.0.0:
     resolution: {integrity: sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==}
-
-  remark-frontmatter@5.0.0:
-    resolution: {integrity: sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==}
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
@@ -6539,10 +6516,6 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
-  fault@2.0.1:
-    dependencies:
-      format: 0.2.2
-
   fd-package-json@2.0.0:
     dependencies:
       walk-up-path: 4.0.0
@@ -6589,8 +6562,6 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.4
       mime-types: 2.1.35
-
-  format@0.2.2: {}
 
   formatly@0.3.0:
     dependencies:
@@ -6869,10 +6840,6 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  js-yaml@5.2.1:
-    dependencies:
-      argparse: 2.0.1
-
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
@@ -7145,17 +7112,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-frontmatter@2.0.1:
-    dependencies:
-      '@types/mdast': 4.0.4
-      devlop: 1.1.0
-      escape-string-regexp: 5.0.0
-      mdast-util-from-markdown: 2.0.2
-      mdast-util-to-markdown: 2.1.2
-      micromark-extension-frontmatter: 2.0.0
-    transitivePeerDependencies:
-      - supports-color
-
   mdast-util-gfm-autolink-literal@2.0.1:
     dependencies:
       '@types/mdast': 4.0.4
@@ -7338,13 +7294,6 @@ snapshots:
       micromark-util-normalize-identifier: 2.0.1
       micromark-util-resolve-all: 2.0.1
       micromark-util-subtokenize: 2.1.0
-      micromark-util-symbol: 2.0.1
-      micromark-util-types: 2.0.2
-
-  micromark-extension-frontmatter@2.0.0:
-    dependencies:
-      fault: 2.0.1
-      micromark-util-character: 2.1.1
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
 
@@ -7993,15 +7942,6 @@ snapshots:
       '@types/mdast': 4.0.4
       mdast-util-newline-to-break: 2.0.0
       unified: 11.0.5
-
-  remark-frontmatter@5.0.0:
-    dependencies:
-      '@types/mdast': 4.0.4
-      mdast-util-frontmatter: 2.0.1
-      micromark-extension-frontmatter: 2.0.0
-      unified: 11.0.5
-    transitivePeerDependencies:
-      - supports-color
 
   remark-gfm@4.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       express:
         specifier: ^5.1.0
         version: 5.2.1
+      js-yaml:
+        specifier: ^5.2.1
+        version: 5.2.1
       lucide-react:
         specifier: ^1.0.0
         version: 1.20.0(react@19.2.7)
@@ -56,6 +59,9 @@ importers:
       remark-breaks:
         specifier: ^4.0.0
         version: 4.0.0
+      remark-frontmatter:
+        specifier: ^5.0.0
+        version: 5.0.0
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -81,6 +87,9 @@ importers:
       '@types/express':
         specifier: ^5.0.3
         version: 5.0.6
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
       '@types/node':
         specifier: ^24.0.8
         version: 24.13.2
@@ -1656,6 +1665,9 @@ packages:
   '@types/http-errors@2.0.5':
     resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
+  '@types/js-yaml@4.0.9':
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -2537,6 +2549,9 @@ packages:
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
+  fault@2.0.1:
+    resolution: {integrity: sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==}
+
   fd-package-json@2.0.0:
     resolution: {integrity: sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==}
 
@@ -2575,6 +2590,10 @@ packages:
   form-data@4.0.6:
     resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
+
+  format@0.2.2:
+    resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
+    engines: {node: '>=0.4.x'}
 
   formatly@0.3.0:
     resolution: {integrity: sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==}
@@ -2847,12 +2866,12 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
-    hasBin: true
-
   js-yaml@4.3.0:
     resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+    hasBin: true
+
+  js-yaml@5.2.1:
+    resolution: {integrity: sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -3144,6 +3163,9 @@ packages:
   mdast-util-from-markdown@2.0.2:
     resolution: {integrity: sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==}
 
+  mdast-util-frontmatter@2.0.1:
+    resolution: {integrity: sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==}
+
   mdast-util-gfm-autolink-literal@2.0.1:
     resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
 
@@ -3206,6 +3228,9 @@ packages:
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-frontmatter@2.0.0:
+    resolution: {integrity: sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==}
 
   micromark-extension-gfm-autolink-literal@2.1.0:
     resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
@@ -3674,6 +3699,9 @@ packages:
 
   remark-breaks@4.0.0:
     resolution: {integrity: sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==}
+
+  remark-frontmatter@5.0.0:
+    resolution: {integrity: sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==}
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
@@ -5336,7 +5364,7 @@ snapshots:
       '@textlint/types': 15.7.1
       chalk: 4.1.2
       debug: 4.4.3
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       lodash: 4.18.1
       pluralize: 2.0.0
       string-width: 4.2.3
@@ -5533,6 +5561,8 @@ snapshots:
       '@types/unist': 3.0.3
 
   '@types/http-errors@2.0.5': {}
+
+  '@types/js-yaml@4.0.9': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -6509,6 +6539,10 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
+  fault@2.0.1:
+    dependencies:
+      format: 0.2.2
+
   fd-package-json@2.0.0:
     dependencies:
       walk-up-path: 4.0.0
@@ -6555,6 +6589,8 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.4
       mime-types: 2.1.35
+
+  format@0.2.2: {}
 
   formatly@0.3.0:
     dependencies:
@@ -6829,11 +6865,11 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
-  js-yaml@4.3.0:
+  js-yaml@5.2.1:
     dependencies:
       argparse: 2.0.1
 
@@ -7109,6 +7145,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mdast-util-frontmatter@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      escape-string-regexp: 5.0.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+      micromark-extension-frontmatter: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   mdast-util-gfm-autolink-literal@2.0.1:
     dependencies:
       '@types/mdast': 4.0.4
@@ -7291,6 +7338,13 @@ snapshots:
       micromark-util-normalize-identifier: 2.0.1
       micromark-util-resolve-all: 2.0.1
       micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-frontmatter@2.0.0:
+    dependencies:
+      fault: 2.0.1
+      micromark-util-character: 2.1.1
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
 
@@ -7864,7 +7918,7 @@ snapshots:
   rc-config-loader@4.1.4:
     dependencies:
       debug: 4.4.3
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       json5: 2.2.3
       require-from-string: 2.0.2
     transitivePeerDependencies:
@@ -7939,6 +7993,15 @@ snapshots:
       '@types/mdast': 4.0.4
       mdast-util-newline-to-break: 2.0.0
       unified: 11.0.5
+
+  remark-frontmatter@5.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-frontmatter: 2.0.1
+      micromark-extension-frontmatter: 2.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
 
   remark-gfm@4.0.1:
     dependencies:

--- a/src/client/components/FrontmatterTable.test.tsx
+++ b/src/client/components/FrontmatterTable.test.tsx
@@ -69,3 +69,125 @@ describe('FrontmatterTable', () => {
     expect(screen.getByText('Before')).toBeInTheDocument();
   });
 });
+
+describe('FrontmatterTable diff mode', () => {
+  it('renders nothing when entries is empty', () => {
+    const { container } = render(<FrontmatterTable mode="diff" entries={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders unchanged entries without decoration', () => {
+    const { container } = render(
+      <FrontmatterTable
+        mode="diff"
+        entries={[{ key: 'title', status: 'unchanged', oldValue: 'X', newValue: 'X' }]}
+      />,
+    );
+
+    expect(screen.getByText('title')).toBeInTheDocument();
+    expect(screen.getAllByText('X')).toHaveLength(2); // same value shown in both Before and After
+    expect(container.querySelector('.bg-diff-addition-bg')).toBeNull();
+    expect(container.querySelector('.bg-diff-deletion-bg')).toBeNull();
+  });
+
+  it('renders added entries with an empty before cell and a styled after cell', () => {
+    render(
+      <FrontmatterTable
+        mode="diff"
+        entries={[{ key: 'new_key', status: 'added', oldValue: undefined, newValue: 'V' }]}
+      />,
+    );
+
+    expect(screen.getByText('new_key')).toBeInTheDocument();
+    expect(screen.getAllByText('new_key')).toHaveLength(1);
+    expect(screen.getByText('V')).toBeInTheDocument();
+
+    const row = screen.getByText('new_key').closest('tr');
+    expect(row).not.toBeNull();
+    const cells = row!.querySelectorAll('td');
+    expect(cells).toHaveLength(3);
+    expect(cells[1]!).not.toHaveClass('bg-diff-addition-bg');
+    expect(cells[1]!).not.toHaveClass('bg-diff-deletion-bg');
+    expect(cells[1]!.textContent).toBe('');
+    expect(cells[2]!).toHaveClass('bg-diff-addition-bg');
+    expect(cells[2]!.textContent).toBe('V');
+  });
+
+  it('renders removed entries with a styled before cell and an empty after cell', () => {
+    const { container } = render(
+      <FrontmatterTable
+        mode="diff"
+        entries={[{ key: 'old_key', status: 'removed', oldValue: 'V', newValue: undefined }]}
+      />,
+    );
+
+    expect(screen.getByText('old_key')).toBeInTheDocument();
+    expect(screen.getByText('V')).toBeInTheDocument();
+
+    const row = screen.getByText('old_key').closest('tr');
+    expect(row).not.toBeNull();
+    const cells = row!.querySelectorAll('td');
+    expect(cells).toHaveLength(3);
+    expect(cells[1]!).toHaveClass('bg-diff-deletion-bg');
+    expect(cells[1]!.textContent).toBe('V');
+    expect(cells[2]!).not.toHaveClass('bg-diff-addition-bg');
+    expect(cells[2]!).not.toHaveClass('bg-diff-deletion-bg');
+    expect(cells[2]!.textContent).toBe('');
+    expect(container.querySelector('td.bg-diff-deletion-bg')).not.toBeNull();
+  });
+
+  it('renders modified entries as a single row with a Before cell and an After cell', () => {
+    render(
+      <FrontmatterTable
+        mode="diff"
+        entries={[{ key: 'title', status: 'modified', oldValue: 'A', newValue: 'B' }]}
+      />,
+    );
+
+    expect(screen.getByText('A')).toBeInTheDocument();
+    expect(screen.getByText('B')).toBeInTheDocument();
+    expect(screen.getAllByText('title')).toHaveLength(1);
+
+    const row = screen.getByText('title').closest('tr');
+    expect(row).not.toBeNull();
+    const cells = row!.querySelectorAll('td');
+    expect(cells).toHaveLength(3);
+    expect(cells[1]!).toHaveClass('bg-diff-deletion-bg');
+    expect(cells[1]!.textContent).toBe('A');
+    expect(cells[2]!).toHaveClass('bg-diff-addition-bg');
+    expect(cells[2]!.textContent).toBe('B');
+  });
+
+  it('renders the label when provided', () => {
+    render(
+      <FrontmatterTable
+        mode="diff"
+        entries={[{ key: 'title', status: 'unchanged', oldValue: 'X', newValue: 'X' }]}
+        label="Diff"
+      />,
+    );
+
+    expect(screen.getByText('Diff')).toBeInTheDocument();
+  });
+
+  it('reuses the nested renderValue rendering for object values', () => {
+    const { container } = render(
+      <FrontmatterTable
+        mode="diff"
+        entries={[
+          {
+            key: 'seo',
+            status: 'modified',
+            oldValue: { title: 'A' },
+            newValue: { title: 'B' },
+          },
+        ]}
+      />,
+    );
+
+    const nestedTables = container.querySelectorAll('table table');
+    expect(nestedTables.length).toBe(2);
+    expect(screen.getByText('A')).toBeInTheDocument();
+    expect(screen.getByText('B')).toBeInTheDocument();
+  });
+});

--- a/src/client/components/FrontmatterTable.test.tsx
+++ b/src/client/components/FrontmatterTable.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { FrontmatterTable } from './FrontmatterTable';
+
+describe('FrontmatterTable', () => {
+  it('renders nothing when data is null', () => {
+    const { container } = render(<FrontmatterTable mode="snapshot" data={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when data is an empty object', () => {
+    const { container } = render(<FrontmatterTable mode="snapshot" data={{}} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders scalar values in the key/value table', () => {
+    render(
+      <FrontmatterTable
+        mode="snapshot"
+        data={{ title: 'Hello', published: true, weight: 3, description: null }}
+      />,
+    );
+
+    expect(screen.getByText('title')).toBeInTheDocument();
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+    expect(screen.getByText('published')).toBeInTheDocument();
+    expect(screen.getByText('true')).toBeInTheDocument();
+    expect(screen.getByText('weight')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('description')).toBeInTheDocument();
+    expect(screen.getByText('null')).toBeInTheDocument();
+  });
+
+  it('renders a nested sub-table for a one-level nested object', () => {
+    render(
+      <FrontmatterTable
+        mode="snapshot"
+        data={{ seo: { title: 'SEO title', description: 'SEO desc' } }}
+      />,
+    );
+
+    expect(screen.getByText('seo')).toBeInTheDocument();
+    expect(screen.getByText('title')).toBeInTheDocument();
+    expect(screen.getByText('SEO title')).toBeInTheDocument();
+    expect(screen.getByText('description')).toBeInTheDocument();
+    expect(screen.getByText('SEO desc')).toBeInTheDocument();
+  });
+
+  it('falls back to JSON formatting for objects nested two or more levels deep', () => {
+    render(<FrontmatterTable mode="snapshot" data={{ site: { seo: { meta: { title: 'X' } } } }} />);
+
+    const pre = document.querySelector('pre');
+    expect(pre).not.toBeNull();
+    expect(pre?.textContent).toContain(JSON.stringify({ meta: { title: 'X' } }, null, 2));
+  });
+
+  it('renders arrays as JSON on a single line', () => {
+    render(<FrontmatterTable mode="snapshot" data={{ tags: ['a', 'b', 'c'] }} />);
+
+    const pre = document.querySelector('pre');
+    expect(pre).not.toBeNull();
+    expect(pre?.textContent).toContain('["a","b","c"]');
+  });
+
+  it('renders the label when provided', () => {
+    render(<FrontmatterTable mode="snapshot" data={{ title: 'Hello' }} label="Before" />);
+
+    expect(screen.getByText('Before')).toBeInTheDocument();
+  });
+});

--- a/src/client/components/FrontmatterTable.tsx
+++ b/src/client/components/FrontmatterTable.tsx
@@ -1,0 +1,99 @@
+import type { ReactNode } from 'react';
+
+export type FrontmatterSnapshotProps = {
+  mode: 'snapshot';
+  data: Record<string, unknown> | null;
+  label?: string;
+};
+
+export type FrontmatterTableProps = FrontmatterSnapshotProps;
+
+export function renderValue(value: unknown, depth: number): ReactNode {
+  if (value === null) {
+    return <span className="text-github-text-muted italic">null</span>;
+  }
+  if (value === undefined) {
+    return <span className="text-github-text-muted italic">undefined</span>;
+  }
+  if (typeof value === 'string') {
+    if (value === '') {
+      return <span className="text-github-text-muted italic">&quot;&quot;</span>;
+    }
+    return <span>{value}</span>;
+  }
+  if (typeof value === 'boolean' || typeof value === 'number') {
+    return <span>{String(value)}</span>;
+  }
+  if (value instanceof Date) {
+    return <span>{value.toISOString()}</span>;
+  }
+  if (Array.isArray(value)) {
+    return <pre className="whitespace-pre-wrap text-xs font-mono">{JSON.stringify(value)}</pre>;
+  }
+  if (typeof value === 'object') {
+    if (depth === 0) {
+      const entries = Object.entries(value as Record<string, unknown>);
+      return (
+        <table className="w-full border-collapse text-xs border border-github-border">
+          <tbody>
+            {entries.map(([k, v]) => (
+              <tr key={k} className="border-b border-github-border">
+                <td className="px-2 py-1 border border-github-border font-mono w-1/3">{k}</td>
+                <td className="px-2 py-1 border border-github-border">
+                  {renderValue(v, depth + 1)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      );
+    }
+    return (
+      <pre className="whitespace-pre-wrap text-xs font-mono">{JSON.stringify(value, null, 2)}</pre>
+    );
+  }
+  return <span>{String(value)}</span>;
+}
+
+function KeyValueRow({ keyName, value }: { keyName: string; value: unknown }) {
+  return (
+    <tr className="border-b border-github-border">
+      <td className="px-3 py-2 border border-github-border font-mono align-top">{keyName}</td>
+      <td className="px-3 py-2 border border-github-border">{renderValue(value, 0)}</td>
+    </tr>
+  );
+}
+
+export function FrontmatterTable(props: FrontmatterTableProps): React.JSX.Element | null {
+  const { data, label } = props;
+
+  if (data === null) {
+    return null;
+  }
+
+  const entries = Object.entries(data);
+  if (entries.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="overflow-x-auto mb-4">
+      {label && <div className="text-sm text-github-text-muted mb-1">{label}</div>}
+      <table className="w-full border-collapse text-sm border border-github-border">
+        <thead className="bg-github-bg-secondary">
+          <tr className="border-b border-github-border">
+            <th className="px-3 py-2 text-left font-semibold border border-github-border w-1/3">
+              Key
+            </th>
+            <th className="px-3 py-2 text-left font-semibold border border-github-border">Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map(([key, value]) => (
+            <KeyValueRow key={key} keyName={key} value={value} />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/client/components/FrontmatterTable.tsx
+++ b/src/client/components/FrontmatterTable.tsx
@@ -1,14 +1,22 @@
-import type { ReactNode } from 'react';
+import { type ReactNode } from 'react';
 
-export type FrontmatterSnapshotProps = {
+import type { FrontmatterDiffEntry } from '../utils/frontmatterDiff';
+
+type FrontmatterSnapshotProps = {
   mode: 'snapshot';
   data: Record<string, unknown> | null;
   label?: string;
 };
 
-export type FrontmatterTableProps = FrontmatterSnapshotProps;
+type FrontmatterDiffProps = {
+  mode: 'diff';
+  entries: FrontmatterDiffEntry[];
+  label?: string;
+};
 
-export function renderValue(value: unknown, depth: number): ReactNode {
+export type FrontmatterTableProps = FrontmatterSnapshotProps | FrontmatterDiffProps;
+
+function renderValue(value: unknown, depth: number): ReactNode {
   if (value === null) {
     return <span className="text-github-text-muted italic">null</span>;
   }
@@ -64,9 +72,26 @@ function KeyValueRow({ keyName, value }: { keyName: string; value: unknown }) {
   );
 }
 
-export function FrontmatterTable(props: FrontmatterTableProps): React.JSX.Element | null {
-  const { data, label } = props;
+function KeyDiffRow({ entry }: { entry: FrontmatterDiffEntry }) {
+  const beforeCellClass =
+    entry.status === 'removed' || entry.status === 'modified' ? 'bg-diff-deletion-bg' : '';
+  const afterCellClass =
+    entry.status === 'added' || entry.status === 'modified' ? 'bg-diff-addition-bg' : '';
 
+  return (
+    <tr className="border-b border-github-border">
+      <td className="px-3 py-2 border border-github-border font-mono align-top">{entry.key}</td>
+      <td className={`px-3 py-2 border border-github-border align-top ${beforeCellClass}`}>
+        {entry.status !== 'added' ? renderValue(entry.oldValue, 0) : null}
+      </td>
+      <td className={`px-3 py-2 border border-github-border align-top ${afterCellClass}`}>
+        {entry.status !== 'removed' ? renderValue(entry.newValue, 0) : null}
+      </td>
+    </tr>
+  );
+}
+
+function SnapshotView({ data, label }: { data: Record<string, unknown> | null; label?: string }) {
   if (data === null) {
     return null;
   }
@@ -96,4 +121,41 @@ export function FrontmatterTable(props: FrontmatterTableProps): React.JSX.Elemen
       </table>
     </div>
   );
+}
+
+function DiffView({ entries, label }: { entries: FrontmatterDiffEntry[]; label?: string }) {
+  if (entries.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="overflow-x-auto mb-4">
+      {label && <div className="text-sm text-github-text-muted mb-1">{label}</div>}
+      <table className="w-full border-collapse text-sm border border-github-border">
+        <thead className="bg-github-bg-secondary">
+          <tr className="border-b border-github-border">
+            <th className="px-3 py-2 text-left font-semibold border border-github-border w-1/5">
+              Key
+            </th>
+            <th className="px-3 py-2 text-left font-semibold border border-github-border">
+              Before
+            </th>
+            <th className="px-3 py-2 text-left font-semibold border border-github-border">After</th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map((entry) => (
+            <KeyDiffRow key={entry.key} entry={entry} />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function FrontmatterTable(props: FrontmatterTableProps): React.JSX.Element | null {
+  if (props.mode === 'snapshot') {
+    return <SnapshotView data={props.data} label={props.label} />;
+  }
+  return <DiffView entries={props.entries} label={props.label} />;
 }

--- a/src/client/utils/frontmatter.test.ts
+++ b/src/client/utils/frontmatter.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+
+import { extractFrontmatter } from './frontmatter';
+
+describe('extractFrontmatter', () => {
+  it('returns null data when there is no frontmatter', () => {
+    const text = '# Hello\n\nJust a regular markdown document.';
+    expect(extractFrontmatter(text)).toEqual({ data: null, content: text });
+  });
+
+  it('returns null data with stripped content for empty frontmatter', () => {
+    const text = '---\n---\nBody text.';
+    expect(extractFrontmatter(text)).toEqual({ data: null, content: 'Body text.' });
+  });
+
+  it('parses valid scalar YAML frontmatter', () => {
+    const text = '---\ntitle: Hello\npublished: true\n---\nBody text.';
+    const result = extractFrontmatter(text);
+    expect(result.data).toEqual({ title: 'Hello', published: true });
+    expect(typeof result.data?.title).toBe('string');
+    expect(typeof result.data?.published).toBe('boolean');
+    expect(result.content).toBe('Body text.');
+  });
+
+  it('falls back to the original text on YAML syntax errors', () => {
+    const text = '---\n[unclosed\n---\nBody text.';
+    expect(extractFrontmatter(text)).toEqual({ data: null, content: text });
+  });
+
+  it('returns null data when the top-level YAML value is not an object', () => {
+    const text = '---\n42\n---\nBody text.';
+    expect(extractFrontmatter(text)).toEqual({ data: null, content: 'Body text.' });
+  });
+
+  it('returns empty content when the body is empty', () => {
+    const text = '---\ntitle: X\n---\n';
+    expect(extractFrontmatter(text)).toEqual({ data: { title: 'X' }, content: '' });
+  });
+});

--- a/src/client/utils/frontmatter.test.ts
+++ b/src/client/utils/frontmatter.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { extractFrontmatter } from './frontmatter';
+import { extractFrontmatter, getFrontmatterLines } from './frontmatter';
 
 describe('extractFrontmatter', () => {
   it('returns null data when there is no frontmatter', () => {
@@ -35,5 +35,29 @@ describe('extractFrontmatter', () => {
   it('returns empty content when the body is empty', () => {
     const text = '---\ntitle: X\n---\n';
     expect(extractFrontmatter(text)).toEqual({ data: { title: 'X' }, content: '' });
+  });
+});
+
+describe('getFrontmatterLines', () => {
+  it('returns an empty array when there is no frontmatter', () => {
+    expect(getFrontmatterLines('# Hello\n\nBody.')).toEqual([]);
+  });
+
+  it('returns the delimiter and body lines of the frontmatter block', () => {
+    const text = '---\ntitle: Hello\npublished: true\n---\nBody text.';
+    expect(getFrontmatterLines(text)).toEqual(['---', 'title: Hello', 'published: true', '---']);
+  });
+
+  it('includes both delimiters for empty frontmatter', () => {
+    expect(getFrontmatterLines('---\n---\nBody.')).toEqual(['---', '---']);
+  });
+
+  it('handles frontmatter at end of file without a trailing newline', () => {
+    expect(getFrontmatterLines('---\ntitle: X\n---')).toEqual(['---', 'title: X', '---']);
+  });
+
+  it('strips carriage returns from CRLF frontmatter', () => {
+    const text = '---\r\ntitle: X\r\n---\r\nBody.';
+    expect(getFrontmatterLines(text)).toEqual(['---', 'title: X', '---']);
   });
 });

--- a/src/client/utils/frontmatter.ts
+++ b/src/client/utils/frontmatter.ts
@@ -1,0 +1,30 @@
+import { load } from 'js-yaml';
+
+const FRONTMATTER_PATTERN = /^---\r?\n(?:([\s\S]*?)\r?\n)?---\r?\n?/;
+
+export function extractFrontmatter(text: string): {
+  data: Record<string, unknown> | null;
+  content: string;
+} {
+  const match = text.match(FRONTMATTER_PATTERN);
+  if (!match) {
+    return { data: null, content: text };
+  }
+
+  const content = text.slice(match[0].length);
+  const yamlSource = match[1];
+
+  if (yamlSource === undefined) {
+    return { data: null, content };
+  }
+
+  try {
+    const parsed: unknown = load(yamlSource);
+    if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return { data: parsed as Record<string, unknown>, content };
+    }
+    return { data: null, content };
+  } catch {
+    return { data: null, content: text };
+  }
+}

--- a/src/client/utils/frontmatter.ts
+++ b/src/client/utils/frontmatter.ts
@@ -28,3 +28,19 @@ export function extractFrontmatter(text: string): {
     return { data: null, content: text };
   }
 }
+
+/**
+ * Returns the individual lines occupied by the leading YAML frontmatter block,
+ * including the enclosing `---` delimiters. Returns an empty array when the text
+ * has no frontmatter. Trailing carriage returns are stripped so the values can
+ * be compared directly against diff line content.
+ */
+export function getFrontmatterLines(text: string): string[] {
+  const match = text.match(FRONTMATTER_PATTERN);
+  if (!match) {
+    return [];
+  }
+
+  const matched = match[0].replace(/\r?\n$/, '');
+  return matched.split('\n').map((line) => line.replace(/\r$/, ''));
+}

--- a/src/client/utils/frontmatterDiff.test.ts
+++ b/src/client/utils/frontmatterDiff.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+
+import { computeFrontmatterDiff } from './frontmatterDiff';
+
+describe('computeFrontmatterDiff', () => {
+  it('treats key order changes as unchanged (canonical stringify)', () => {
+    const old = { a: 1, b: 2 };
+    const new_ = { b: 2, a: 1 };
+    expect(computeFrontmatterDiff(old, new_)).toEqual([
+      { key: 'b', status: 'unchanged', oldValue: 2, newValue: 2 },
+      { key: 'a', status: 'unchanged', oldValue: 1, newValue: 1 },
+    ]);
+  });
+
+  it('detects type conversions as modified', () => {
+    const old = { published: 'true' };
+    const new_ = { published: true };
+    expect(computeFrontmatterDiff(old, new_)).toEqual([
+      { key: 'published', status: 'modified', oldValue: 'true', newValue: true },
+    ]);
+  });
+
+  it('treats nested object key order changes as unchanged', () => {
+    const old = { seo: { title: 'A', desc: 'X' } };
+    const new_ = { seo: { desc: 'X', title: 'A' } };
+    expect(computeFrontmatterDiff(old, new_)).toEqual([
+      { key: 'seo', status: 'unchanged', oldValue: old.seo, newValue: new_.seo },
+    ]);
+  });
+
+  it('detects nested value changes as modified', () => {
+    const old = { seo: { title: 'A' } };
+    const new_ = { seo: { title: 'B' } };
+    expect(computeFrontmatterDiff(old, new_)).toEqual([
+      { key: 'seo', status: 'modified', oldValue: old.seo, newValue: new_.seo },
+    ]);
+  });
+
+  it('treats identical arrays as unchanged', () => {
+    const old = { tags: ['a', 'b'] };
+    const new_ = { tags: ['a', 'b'] };
+    expect(computeFrontmatterDiff(old, new_)).toEqual([
+      { key: 'tags', status: 'unchanged', oldValue: old.tags, newValue: new_.tags },
+    ]);
+  });
+
+  it('treats array order changes as modified', () => {
+    const old = { tags: ['a', 'b'] };
+    const new_ = { tags: ['b', 'a'] };
+    expect(computeFrontmatterDiff(old, new_)).toEqual([
+      { key: 'tags', status: 'modified', oldValue: old.tags, newValue: new_.tags },
+    ]);
+  });
+
+  it('detects null to value transitions as modified', () => {
+    const old = { x: null };
+    const new_ = { x: 'value' };
+    expect(computeFrontmatterDiff(old, new_)).toEqual([
+      { key: 'x', status: 'modified', oldValue: null, newValue: 'value' },
+    ]);
+  });
+
+  it('treats both-null values as unchanged', () => {
+    const old = { x: null };
+    const new_ = { x: null };
+    expect(computeFrontmatterDiff(old, new_)).toEqual([
+      { key: 'x', status: 'unchanged', oldValue: null, newValue: null },
+    ]);
+  });
+
+  it('returns an empty array when both sides are null', () => {
+    expect(computeFrontmatterDiff(null, null)).toEqual([]);
+  });
+
+  it('returns all keys as added when oldData is null', () => {
+    expect(computeFrontmatterDiff(null, { title: 'X', desc: 'Y' })).toEqual([
+      { key: 'title', status: 'added', oldValue: undefined, newValue: 'X' },
+      { key: 'desc', status: 'added', oldValue: undefined, newValue: 'Y' },
+    ]);
+  });
+
+  it('returns all keys as removed when newData is null', () => {
+    expect(computeFrontmatterDiff({ old_key: 'X' }, null)).toEqual([
+      { key: 'old_key', status: 'removed', oldValue: 'X', newValue: undefined },
+    ]);
+  });
+
+  it('orders entries as new-first then old-only appendix', () => {
+    const old = { common: 'Y', old_only: 'Z' };
+    const new_ = { new_key: 'X', common: 'Y' };
+    expect(computeFrontmatterDiff(old, new_)).toEqual([
+      { key: 'new_key', status: 'added', oldValue: undefined, newValue: 'X' },
+      { key: 'common', status: 'unchanged', oldValue: 'Y', newValue: 'Y' },
+      { key: 'old_only', status: 'removed', oldValue: 'Z', newValue: undefined },
+    ]);
+  });
+
+  it('treats equal Date values as unchanged', () => {
+    const d1 = new Date('2020-01-01T00:00:00Z');
+    const d2 = new Date('2020-01-01T00:00:00Z');
+    expect(computeFrontmatterDiff({ date: d1 }, { date: d2 })).toEqual([
+      { key: 'date', status: 'unchanged', oldValue: d1, newValue: d2 },
+    ]);
+  });
+});

--- a/src/client/utils/frontmatterDiff.ts
+++ b/src/client/utils/frontmatterDiff.ts
@@ -1,4 +1,4 @@
-export type FrontmatterDiffStatus = 'added' | 'removed' | 'modified' | 'unchanged';
+type FrontmatterDiffStatus = 'added' | 'removed' | 'modified' | 'unchanged';
 
 export type FrontmatterDiffEntry = {
   key: string;

--- a/src/client/utils/frontmatterDiff.ts
+++ b/src/client/utils/frontmatterDiff.ts
@@ -1,0 +1,79 @@
+export type FrontmatterDiffStatus = 'added' | 'removed' | 'modified' | 'unchanged';
+
+export type FrontmatterDiffEntry = {
+  key: string;
+  status: FrontmatterDiffStatus;
+  oldValue: unknown;
+  newValue: unknown;
+};
+
+function canonicalize(value: unknown): unknown {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  if (Array.isArray(value)) {
+    return value.map(canonicalize);
+  }
+  const record = value as Record<string, unknown>;
+  const sortedKeys = Object.keys(record).sort();
+  const sorted: Record<string, unknown> = {};
+  for (const k of sortedKeys) {
+    sorted[k] = canonicalize(record[k]);
+  }
+  return sorted;
+}
+
+function canonicalStringify(value: unknown): string {
+  return JSON.stringify(canonicalize(value));
+}
+
+export function computeFrontmatterDiff(
+  oldData: Record<string, unknown> | null,
+  newData: Record<string, unknown> | null,
+): FrontmatterDiffEntry[] {
+  if (newData === null) {
+    if (oldData === null) {
+      return [];
+    }
+    return Object.keys(oldData).map((key) => ({
+      key,
+      status: 'removed',
+      oldValue: oldData[key],
+      newValue: undefined,
+    }));
+  }
+
+  if (oldData === null) {
+    return Object.keys(newData).map((key) => ({
+      key,
+      status: 'added',
+      oldValue: undefined,
+      newValue: newData[key],
+    }));
+  }
+
+  const entries: FrontmatterDiffEntry[] = [];
+
+  for (const key of Object.keys(newData)) {
+    if (!(key in oldData)) {
+      entries.push({ key, status: 'added', oldValue: undefined, newValue: newData[key] });
+      continue;
+    }
+    const oldValue = oldData[key];
+    const newValue = newData[key];
+    const status =
+      canonicalStringify(oldValue) === canonicalStringify(newValue) ? 'unchanged' : 'modified';
+    entries.push({ key, status, oldValue, newValue });
+  }
+
+  for (const key of Object.keys(oldData)) {
+    if (!(key in newData)) {
+      entries.push({ key, status: 'removed', oldValue: oldData[key], newValue: undefined });
+    }
+  }
+
+  return entries;
+}

--- a/src/client/viewers/MarkdownDiffViewer.test.tsx
+++ b/src/client/viewers/MarkdownDiffViewer.test.tsx
@@ -193,7 +193,7 @@ describe('MarkdownDiffViewer', () => {
     renderViewer();
 
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
     });
 
     expect(screen.queryByRole('button', { name: 'Full Preview' })).not.toBeInTheDocument();
@@ -213,7 +213,7 @@ describe('MarkdownDiffViewer', () => {
     fireEvent.click(fullPreviewButton);
 
     expect(await screen.findByText('Prefetched title')).toBeInTheDocument();
-    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledTimes(2);
   });
 
   it('renders Mermaid diagrams in Diff Preview', async () => {
@@ -340,6 +340,66 @@ describe('MarkdownDiffViewer', () => {
       });
       expect(vi.mocked(mermaid.render)).toHaveBeenCalledTimes(2);
     });
+  });
+});
+
+describe('MarkdownDiffViewer two-side fetch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    document.documentElement.removeAttribute('data-theme');
+    setMatchMedia(true);
+  });
+
+  it('fetches both base and target blobs for a modified file', async () => {
+    (global.fetch as any)
+      .mockResolvedValueOnce({ ok: true, text: async () => 'old content' })
+      .mockResolvedValueOnce({ ok: true, text: async () => 'new content' });
+
+    renderViewer();
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith('/api/blob/docs%2Fguide.md?ref=HEAD~1');
+    expect(global.fetch).toHaveBeenCalledWith('/api/blob/docs%2Fguide.md?ref=HEAD');
+  });
+
+  it('fetches only the target blob for an added file', async () => {
+    (global.fetch as any).mockResolvedValue({ ok: true, text: async () => 'new content' });
+
+    renderViewer({ file: createFile({ status: 'added', additions: 5, deletions: 0 }) });
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith('/api/blob/docs%2Fguide.md?ref=HEAD');
+  });
+
+  it('fetches only the base blob for a deleted file', async () => {
+    (global.fetch as any).mockResolvedValue({ ok: true, text: async () => 'old content' });
+
+    renderViewer({
+      file: createFile({ status: 'deleted', additions: 0, deletions: 5, oldPath: 'old.md' }),
+    });
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith('/api/blob/old.md?ref=HEAD~1');
+  });
+
+  it('does not fetch when both refs are stdin', async () => {
+    renderViewer({ baseCommitish: 'stdin', targetCommitish: 'stdin' });
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Full Preview' })).not.toBeInTheDocument();
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(0);
   });
 });
 

--- a/src/client/viewers/MarkdownDiffViewer.test.tsx
+++ b/src/client/viewers/MarkdownDiffViewer.test.tsx
@@ -409,6 +409,24 @@ describe('MarkdownDiffViewer two-side fetch', () => {
     expect(screen.getByText('Base body content.')).toBeInTheDocument();
   });
 
+  it('shows a partial preview label in Diff Preview when only one side fails to fetch', async () => {
+    (global.fetch as any)
+      .mockResolvedValueOnce({ ok: false, statusText: 'Not Found', text: async () => '' })
+      .mockResolvedValueOnce({ ok: true, text: async () => '# Just body\n' });
+
+    renderViewer();
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Diff Preview' }));
+
+    expect(
+      await screen.findByText('Base content unavailable — showing partial preview.'),
+    ).toBeInTheDocument();
+  });
+
   it('does not fetch when both refs are stdin', async () => {
     renderViewer({ baseCommitish: 'stdin', targetCommitish: 'stdin' });
 

--- a/src/client/viewers/MarkdownDiffViewer.test.tsx
+++ b/src/client/viewers/MarkdownDiffViewer.test.tsx
@@ -461,3 +461,136 @@ describe('MarkdownFullPreview integration', () => {
     expect(screen.queryByText('Key')).not.toBeInTheDocument();
   });
 });
+
+describe('MarkdownDiffPreview frontmatter diff', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    document.documentElement.removeAttribute('data-theme');
+    setMatchMedia(true);
+  });
+
+  const goToDiffPreview = () => {
+    fireEvent.click(screen.getByRole('button', { name: 'Diff Preview' }));
+  };
+
+  it('renders a frontmatter diff table for a modified file when both sides have frontmatter', async () => {
+    (global.fetch as any)
+      .mockResolvedValueOnce({
+        ok: true,
+        text: async () => '---\ntitle: Old\npublished: false\n---\n\n# Body\n',
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        text: async () => '---\ntitle: New\npublished: true\n---\n\n# Body\n',
+      });
+
+    renderViewer();
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    goToDiffPreview();
+
+    expect(await screen.findAllByText('title')).toHaveLength(1); // modified → single Before/After row
+    expect(screen.getByText('Old')).toBeInTheDocument();
+    expect(screen.getByText('New')).toBeInTheDocument();
+    expect(screen.getAllByText('published')).toHaveLength(1);
+    expect(screen.getByText('false')).toBeInTheDocument();
+    expect(screen.getByText('true')).toBeInTheDocument();
+  });
+
+  it('renders no frontmatter table when neither side has frontmatter', async () => {
+    (global.fetch as any)
+      .mockResolvedValueOnce({ ok: true, text: async () => '# Just body\n' })
+      .mockResolvedValueOnce({ ok: true, text: async () => '# Just body updated\n' });
+
+    renderViewer();
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    goToDiffPreview();
+
+    expect(screen.queryByText('Key')).not.toBeInTheDocument();
+  });
+
+  it('shows all frontmatter keys as additions for an added file', async () => {
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      text: async () => '---\ntitle: Hello\n---\n\n# Body\n',
+    });
+
+    const { container } = renderViewer({
+      file: createFile({ status: 'added', additions: 5, deletions: 0 }),
+    });
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    goToDiffPreview();
+
+    expect(await screen.findByText('title')).toBeInTheDocument();
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+    expect(container.querySelector('td.bg-diff-addition-bg')).not.toBeNull();
+  });
+
+  it('shows all frontmatter keys as removals for a deleted file', async () => {
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      text: async () => '---\ntitle: Bye\n---\n\n# Body\n',
+    });
+
+    const { container } = renderViewer({
+      file: createFile({ status: 'deleted', additions: 0, deletions: 5, oldPath: 'old.md' }),
+    });
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    goToDiffPreview();
+
+    expect(await screen.findByText('title')).toBeInTheDocument();
+    expect(screen.getByText('Bye')).toBeInTheDocument();
+    expect(container.querySelector('td.bg-diff-deletion-bg')).not.toBeNull();
+  });
+
+  it('falls back to a snapshot label when the base fetch fails on a modified file', async () => {
+    (global.fetch as any)
+      .mockResolvedValueOnce({ ok: false, statusText: 'Not Found', text: async () => '' })
+      .mockResolvedValueOnce({
+        ok: true,
+        text: async () => '---\ntitle: OnlyTarget\n---\n\n# Body\n',
+      });
+
+    renderViewer();
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    goToDiffPreview();
+
+    expect(await screen.findByText(/target only/i)).toBeInTheDocument();
+    expect(screen.getByText('title')).toBeInTheDocument();
+    expect(screen.getByText('OnlyTarget')).toBeInTheDocument();
+  });
+
+  it('renders no frontmatter table for stdin (no fetch performed)', async () => {
+    renderViewer({ baseCommitish: 'stdin', targetCommitish: 'stdin' });
+
+    // wait a tick so any pending state settles
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(0);
+    });
+
+    goToDiffPreview();
+
+    expect(screen.queryByText('title')).not.toBeInTheDocument();
+    expect(screen.queryByText(/frontmatter/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/client/viewers/MarkdownDiffViewer.test.tsx
+++ b/src/client/viewers/MarkdownDiffViewer.test.tsx
@@ -342,3 +342,62 @@ describe('MarkdownDiffViewer', () => {
     });
   });
 });
+
+describe('MarkdownFullPreview integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    document.documentElement.removeAttribute('data-theme');
+    setMatchMedia(true);
+  });
+
+  it('renders content without a frontmatter table when there is no frontmatter', async () => {
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      text: async () => '# Hello\n\nBody paragraph.\n',
+    });
+
+    renderViewer();
+
+    const fullPreviewButton = await screen.findByRole('button', { name: 'Full Preview' });
+    fireEvent.click(fullPreviewButton);
+
+    expect(await screen.findByText('Hello')).toBeInTheDocument();
+    expect(screen.getByText('Body paragraph.')).toBeInTheDocument();
+    expect(screen.queryByText('Key')).not.toBeInTheDocument();
+  });
+
+  it('renders a frontmatter table above the body when frontmatter is present', async () => {
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      text: async () => '---\ntitle: Hello\npublished: true\n---\n\n# Body\n\nText.\n',
+    });
+
+    renderViewer();
+
+    const fullPreviewButton = await screen.findByRole('button', { name: 'Full Preview' });
+    fireEvent.click(fullPreviewButton);
+
+    expect(await screen.findByText('title')).toBeInTheDocument();
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+    expect(screen.getByText('published')).toBeInTheDocument();
+    expect(screen.getByText('true')).toBeInTheDocument();
+    expect(screen.getByText('Body')).toBeInTheDocument();
+    expect(screen.queryByText('---')).not.toBeInTheDocument();
+  });
+
+  it('falls back to rendering the raw body when frontmatter YAML is invalid', async () => {
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      text: async () => '---\n[unclosed\n---\n\n# Body\n\nText.\n',
+    });
+
+    renderViewer();
+
+    const fullPreviewButton = await screen.findByRole('button', { name: 'Full Preview' });
+    fireEvent.click(fullPreviewButton);
+
+    expect(await screen.findByText('Body')).toBeInTheDocument();
+    expect(screen.queryByText('Key')).not.toBeInTheDocument();
+  });
+});

--- a/src/client/viewers/MarkdownDiffViewer.test.tsx
+++ b/src/client/viewers/MarkdownDiffViewer.test.tsx
@@ -392,6 +392,23 @@ describe('MarkdownDiffViewer two-side fetch', () => {
     expect(global.fetch).toHaveBeenCalledWith('/api/blob/old.md?ref=HEAD~1');
   });
 
+  it('shows the Full Preview tab and renders base content for a deleted file', async () => {
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      text: async () => '# Deleted doc\n\nBase body content.\n',
+    });
+
+    renderViewer({
+      file: createFile({ status: 'deleted', additions: 0, deletions: 5, oldPath: 'old.md' }),
+    });
+
+    const fullPreviewButton = await screen.findByRole('button', { name: 'Full Preview' });
+    fireEvent.click(fullPreviewButton);
+
+    expect(await screen.findByText('Deleted doc')).toBeInTheDocument();
+    expect(screen.getByText('Base body content.')).toBeInTheDocument();
+  });
+
   it('does not fetch when both refs are stdin', async () => {
     renderViewer({ baseCommitish: 'stdin', targetCommitish: 'stdin' });
 

--- a/src/client/viewers/MarkdownDiffViewer.test.tsx
+++ b/src/client/viewers/MarkdownDiffViewer.test.tsx
@@ -146,6 +146,47 @@ const codeFenceDiffChunks: MergedChunk[] = [
   },
 ];
 
+const frontmatterChangedChunks: MergedChunk[] = [
+  {
+    header: '@@ -1,5 +1,5 @@',
+    oldStart: 1,
+    oldLines: 5,
+    newStart: 1,
+    newLines: 5,
+    lines: [
+      { type: 'context', content: '---', oldLineNumber: 1, newLineNumber: 1 },
+      { type: 'delete', content: 'title: Old', oldLineNumber: 2, newLineNumber: undefined },
+      { type: 'add', content: 'title: New', oldLineNumber: undefined, newLineNumber: 2 },
+      { type: 'context', content: '---', oldLineNumber: 3, newLineNumber: 3 },
+      { type: 'context', content: '', oldLineNumber: 4, newLineNumber: 4 },
+      { type: 'context', content: '# Heading', oldLineNumber: 5, newLineNumber: 5 },
+      { type: 'context', content: 'Body text here.', oldLineNumber: 6, newLineNumber: 6 },
+    ],
+    originalIndices: [0, 1, 2, 3, 4, 5, 6],
+    hiddenLinesBefore: 0,
+    hiddenLinesAfter: 0,
+  },
+];
+
+const bodyOnlyChangeChunks: MergedChunk[] = [
+  {
+    header: '@@ -5,4 +5,4 @@',
+    oldStart: 5,
+    oldLines: 4,
+    newStart: 5,
+    newLines: 4,
+    lines: [
+      { type: 'context', content: '# Heading', oldLineNumber: 5, newLineNumber: 5 },
+      { type: 'context', content: '', oldLineNumber: 6, newLineNumber: 6 },
+      { type: 'delete', content: 'Old body text.', oldLineNumber: 7, newLineNumber: undefined },
+      { type: 'add', content: 'New body text.', oldLineNumber: undefined, newLineNumber: 7 },
+    ],
+    originalIndices: [0, 1, 2, 3],
+    hiddenLinesBefore: 4,
+    hiddenLinesAfter: 0,
+  },
+];
+
 const setMatchMedia = (matches: boolean) => {
   Object.defineProperty(window, 'matchMedia', {
     configurable: true,
@@ -534,6 +575,65 @@ describe('MarkdownDiffPreview frontmatter diff', () => {
     expect(screen.getAllByText('published')).toHaveLength(1);
     expect(screen.getByText('false')).toBeInTheDocument();
     expect(screen.getByText('true')).toBeInTheDocument();
+  });
+
+  it('does not render the changed frontmatter lines as markdown below the table', async () => {
+    (global.fetch as any)
+      .mockResolvedValueOnce({
+        ok: true,
+        text: async () => '---\ntitle: Old\n---\n\n# Heading\nBody text here.\n',
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        text: async () => '---\ntitle: New\n---\n\n# Heading\nBody text here.\n',
+      });
+
+    const { container } = renderViewer({ mergedChunks: frontmatterChangedChunks });
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    goToDiffPreview();
+
+    // Frontmatter change is shown in the structured table…
+    expect(await screen.findByText('Old')).toBeInTheDocument();
+    expect(screen.getByText('New')).toBeInTheDocument();
+    expect(screen.getByText('title')).toBeInTheDocument();
+
+    // …and the raw frontmatter delimiters are stripped from the preview blocks,
+    // so no stray <hr> is rendered from the `---` lines.
+    expect(container.querySelector('hr')).toBeNull();
+
+    // Body content following the frontmatter is still rendered.
+    expect(screen.getByText('Heading')).toBeInTheDocument();
+    expect(screen.getByText('Body text here.')).toBeInTheDocument();
+  });
+
+  it('keeps body content when the diff starts below unchanged frontmatter', async () => {
+    (global.fetch as any)
+      .mockResolvedValueOnce({
+        ok: true,
+        text: async () => '---\ntitle: Same\n---\n\n# Heading\n\nOld body text.\n',
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        text: async () => '---\ntitle: Same\n---\n\n# Heading\n\nNew body text.\n',
+      });
+
+    renderViewer({ mergedChunks: bodyOnlyChangeChunks });
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    goToDiffPreview();
+
+    // Unchanged frontmatter yields no diff table, and the leading body lines of
+    // the hunk must not be mistaken for frontmatter and stripped away.
+    expect(await screen.findByText('Heading')).toBeInTheDocument();
+    expect(screen.getByText('Old body text.')).toBeInTheDocument();
+    expect(screen.getByText('New body text.')).toBeInTheDocument();
   });
 
   it('renders no frontmatter table when neither side has frontmatter', async () => {

--- a/src/client/viewers/MarkdownDiffViewer.tsx
+++ b/src/client/viewers/MarkdownDiffViewer.tsx
@@ -648,7 +648,9 @@ export function MarkdownDiffViewer(props: DiffViewerBodyProps) {
       setIsPreviewLoading(false);
     };
 
-    if (previewSourcesKey !== loadedSourcesKey || contents.target === null) {
+    const relevantContent = file.status === 'deleted' ? contents.base : contents.target;
+
+    if (previewSourcesKey !== loadedSourcesKey || relevantContent === null) {
       void run();
     } else {
       setIsPreviewLoading(false);
@@ -657,11 +659,23 @@ export function MarkdownDiffViewer(props: DiffViewerBodyProps) {
     return () => {
       isCanceled = true;
     };
-  }, [contents.target, loadedSourcesKey, previewSources, previewSourcesKey]);
+  }, [
+    contents.base,
+    contents.target,
+    file.status,
+    loadedSourcesKey,
+    previewSources,
+    previewSourcesKey,
+  ]);
+
+  const fullPreviewContent = useMemo(
+    () => (file.status === 'deleted' ? contents.base : contents.target),
+    [contents.base, contents.target, file.status],
+  );
 
   const hasFullPreview = useMemo(
-    () => previewSourcesKey === loadedSourcesKey && contents.target !== null,
-    [contents.target, loadedSourcesKey, previewSourcesKey],
+    () => previewSourcesKey === loadedSourcesKey && fullPreviewContent !== null,
+    [fullPreviewContent, loadedSourcesKey, previewSourcesKey],
   );
 
   useEffect(() => {
@@ -696,10 +710,10 @@ export function MarkdownDiffViewer(props: DiffViewerBodyProps) {
             <div className="text-sm text-github-text-muted mb-3">Loading preview...</div>
           )}
           {previewError && <div className="text-sm text-github-danger mb-3">{previewError}</div>}
-          {!isPreviewLoading && !previewError && contents.target !== null && (
-            <MarkdownFullPreview content={contents.target} syntaxTheme={syntaxTheme} />
+          {!isPreviewLoading && !previewError && fullPreviewContent !== null && (
+            <MarkdownFullPreview content={fullPreviewContent} syntaxTheme={syntaxTheme} />
           )}
-          {!isPreviewLoading && !previewError && contents.target === null && (
+          {!isPreviewLoading && !previewError && fullPreviewContent === null && (
             <div className="text-sm text-github-text-muted">Preview unavailable.</div>
           )}
         </div>

--- a/src/client/viewers/MarkdownDiffViewer.tsx
+++ b/src/client/viewers/MarkdownDiffViewer.tsx
@@ -47,6 +47,18 @@ type FenceInfo = {
 
 const isFetchableRef = (ref?: string) => Boolean(ref && ref !== 'stdin');
 
+type PreviewSource = { path: string; ref: string } | null;
+
+type PreviewSourcePair = {
+  base: PreviewSource;
+  target: PreviewSource;
+};
+
+type PreviewContents = {
+  base: string | null;
+  target: string | null;
+};
+
 const headingStyles = [
   'text-[26px] font-semibold',
   'text-[22px] font-semibold',
@@ -467,38 +479,52 @@ const MarkdownFullPreview = ({
 export function MarkdownDiffViewer(props: DiffViewerBodyProps) {
   const { file, baseCommitish, targetCommitish, mergedChunks, syntaxTheme } = props;
   const [mode, setMode] = useState<PreviewMode>('diff');
-  const [fullContent, setFullContent] = useState<string | null>(null);
+  const [contents, setContents] = useState<PreviewContents>({ base: null, target: null });
   const [isPreviewLoading, setIsPreviewLoading] = useState(false);
   const [previewError, setPreviewError] = useState<string | null>(null);
-  const [loadedSourceKey, setLoadedSourceKey] = useState<string | null>(null);
+  const [loadedSourcesKey, setLoadedSourcesKey] = useState<string | null>(null);
   const previewBlocks = useMemo(() => buildPreviewBlocks(mergedChunks), [mergedChunks]);
-  const previewSource = useMemo(() => {
-    if (!baseCommitish && !targetCommitish) return null;
 
-    if (file.status === 'added') {
-      return targetCommitish ? { path: file.path, ref: targetCommitish } : null;
-    }
+  const previewSources = useMemo<PreviewSourcePair>(() => {
+    const target: PreviewSource =
+      file.status === 'deleted'
+        ? null
+        : targetCommitish
+          ? { path: file.path, ref: targetCommitish }
+          : null;
 
-    if (file.status === 'deleted') {
-      return baseCommitish ? { path: file.oldPath || file.path, ref: baseCommitish } : null;
-    }
+    const base: PreviewSource =
+      file.status === 'added'
+        ? null
+        : baseCommitish
+          ? { path: file.oldPath || file.path, ref: baseCommitish }
+          : null;
 
-    if (targetCommitish) {
-      return { path: file.path, ref: targetCommitish };
-    }
-
-    return baseCommitish ? { path: file.oldPath || file.path, ref: baseCommitish } : null;
+    return { base, target };
   }, [baseCommitish, targetCommitish, file.path, file.oldPath, file.status]);
 
-  const previewSourceKey = useMemo(
-    () => (previewSource ? `${previewSource.ref}:${previewSource.path}` : null),
-    [previewSource],
-  );
+  const previewSourcesKey = useMemo(() => {
+    const baseKey = previewSources.base
+      ? `${previewSources.base.ref}:${previewSources.base.path}`
+      : '';
+    const targetKey = previewSources.target
+      ? `${previewSources.target.ref}:${previewSources.target.path}`
+      : '';
+    if (!baseKey && !targetKey) return null;
+    return `${baseKey}|${targetKey}`;
+  }, [previewSources]);
 
   useEffect(() => {
-    if (!previewSource || !previewSourceKey || !isFetchableRef(previewSource.ref)) {
-      setFullContent(null);
-      setLoadedSourceKey(null);
+    const baseSource =
+      previewSources.base && isFetchableRef(previewSources.base.ref) ? previewSources.base : null;
+    const targetSource =
+      previewSources.target && isFetchableRef(previewSources.target.ref)
+        ? previewSources.target
+        : null;
+
+    if (!previewSourcesKey || (!baseSource && !targetSource)) {
+      setContents({ base: null, target: null });
+      setLoadedSourcesKey(null);
       setPreviewError(null);
       setIsPreviewLoading(false);
       return;
@@ -506,50 +532,77 @@ export function MarkdownDiffViewer(props: DiffViewerBodyProps) {
 
     let isCanceled = false;
 
-    const fetchContent = async () => {
-      if (previewSourceKey !== loadedSourceKey) {
-        setFullContent(null);
+    const fetchBlob = async (source: PreviewSource): Promise<string | null> => {
+      if (!source) return null;
+      const encodedPath = encodeURIComponent(source.path);
+      const response = await fetch(
+        `/api/blob/${encodedPath}?ref=${encodeURIComponent(source.ref)}`,
+      );
+      if (!response.ok) {
+        throw new Error(`Failed to fetch preview: ${response.statusText}`);
+      }
+      return response.text();
+    };
+
+    const run = async () => {
+      if (previewSourcesKey !== loadedSourcesKey) {
+        setContents({ base: null, target: null });
       }
       setIsPreviewLoading(true);
       setPreviewError(null);
-      try {
-        const encodedPath = encodeURIComponent(previewSource.path);
-        const response = await fetch(
-          `/api/blob/${encodedPath}?ref=${encodeURIComponent(previewSource.ref)}`,
+
+      const [baseResult, targetResult] = await Promise.allSettled([
+        fetchBlob(baseSource),
+        fetchBlob(targetSource),
+      ]);
+
+      if (isCanceled) return;
+
+      const nextBase = baseResult.status === 'fulfilled' ? baseResult.value : null;
+      const nextTarget = targetResult.status === 'fulfilled' ? targetResult.value : null;
+
+      const failures: string[] = [];
+      if (baseSource && baseResult.status === 'rejected') {
+        failures.push(
+          baseResult.reason instanceof Error ? baseResult.reason.message : 'base fetch failed',
         );
-        if (!response.ok) {
-          throw new Error(`Failed to fetch preview: ${response.statusText}`);
-        }
-        const text = await response.text();
-        if (!isCanceled) {
-          setFullContent(text);
-          setLoadedSourceKey(previewSourceKey);
-        }
-      } catch (error) {
-        if (!isCanceled) {
-          setFullContent(null);
-          setLoadedSourceKey(null);
-          setPreviewError(error instanceof Error ? error.message : 'Failed to load preview');
-        }
-      } finally {
-        if (!isCanceled) {
-          setIsPreviewLoading(false);
-        }
       }
+      if (targetSource && targetResult.status === 'rejected') {
+        failures.push(
+          targetResult.reason instanceof Error
+            ? targetResult.reason.message
+            : 'target fetch failed',
+        );
+      }
+
+      setContents({ base: nextBase, target: nextTarget });
+      setLoadedSourcesKey(previewSourcesKey);
+
+      const baseFailed = baseSource !== null && baseResult.status === 'rejected';
+      const targetFailed = targetSource !== null && targetResult.status === 'rejected';
+      const allFailed =
+        (baseSource ? baseFailed : true) &&
+        (targetSource ? targetFailed : true) &&
+        failures.length > 0;
+
+      setPreviewError(allFailed ? failures.join('; ') : null);
+      setIsPreviewLoading(false);
     };
 
-    if (previewSourceKey !== loadedSourceKey || fullContent === null) {
-      void fetchContent();
+    if (previewSourcesKey !== loadedSourcesKey || contents.target === null) {
+      void run();
+    } else {
+      setIsPreviewLoading(false);
     }
 
     return () => {
       isCanceled = true;
     };
-  }, [fullContent, loadedSourceKey, previewSource, previewSourceKey]);
+  }, [contents.target, loadedSourcesKey, previewSources, previewSourcesKey]);
 
   const hasFullPreview = useMemo(
-    () => previewSourceKey === loadedSourceKey && fullContent !== null,
-    [fullContent, loadedSourceKey, previewSourceKey],
+    () => previewSourcesKey === loadedSourcesKey && contents.target !== null,
+    [contents.target, loadedSourcesKey, previewSourcesKey],
   );
 
   useEffect(() => {
@@ -578,10 +631,10 @@ export function MarkdownDiffViewer(props: DiffViewerBodyProps) {
             <div className="text-sm text-github-text-muted mb-3">Loading preview...</div>
           )}
           {previewError && <div className="text-sm text-github-danger mb-3">{previewError}</div>}
-          {!isPreviewLoading && !previewError && fullContent !== null && (
-            <MarkdownFullPreview content={fullContent} syntaxTheme={syntaxTheme} />
+          {!isPreviewLoading && !previewError && contents.target !== null && (
+            <MarkdownFullPreview content={contents.target} syntaxTheme={syntaxTheme} />
           )}
-          {!isPreviewLoading && !previewError && fullContent === null && (
+          {!isPreviewLoading && !previewError && contents.target === null && (
             <div className="text-sm text-github-text-muted">Preview unavailable.</div>
           )}
         </div>

--- a/src/client/viewers/MarkdownDiffViewer.tsx
+++ b/src/client/viewers/MarkdownDiffViewer.tsx
@@ -541,6 +541,7 @@ export function MarkdownDiffViewer(props: DiffViewerBodyProps) {
   const [contents, setContents] = useState<PreviewContents>({ base: null, target: null });
   const [isPreviewLoading, setIsPreviewLoading] = useState(false);
   const [previewError, setPreviewError] = useState<string | null>(null);
+  const [partialFailureLabel, setPartialFailureLabel] = useState<string | null>(null);
   const [loadedSourcesKey, setLoadedSourcesKey] = useState<string | null>(null);
   const previewBlocks = useMemo(() => buildPreviewBlocks(mergedChunks), [mergedChunks]);
 
@@ -585,6 +586,7 @@ export function MarkdownDiffViewer(props: DiffViewerBodyProps) {
       setContents({ base: null, target: null });
       setLoadedSourcesKey(null);
       setPreviewError(null);
+      setPartialFailureLabel(null);
       setIsPreviewLoading(false);
       return;
     }
@@ -645,6 +647,17 @@ export function MarkdownDiffViewer(props: DiffViewerBodyProps) {
         failures.length > 0;
 
       setPreviewError(allFailed ? failures.join('; ') : null);
+
+      if (allFailed) {
+        setPartialFailureLabel(null);
+      } else if (baseFailed) {
+        setPartialFailureLabel('Base content unavailable — showing partial preview.');
+      } else if (targetFailed) {
+        setPartialFailureLabel('Target content unavailable — showing partial preview.');
+      } else {
+        setPartialFailureLabel(null);
+      }
+
       setIsPreviewLoading(false);
     };
 
@@ -694,6 +707,9 @@ export function MarkdownDiffViewer(props: DiffViewerBodyProps) {
 
       {mode === 'diff-preview' && (
         <div className="p-4">
+          {partialFailureLabel && (
+            <div className="text-sm text-github-text-muted mb-3">{partialFailureLabel}</div>
+          )}
           <MarkdownDiffPreview
             blocks={previewBlocks}
             syntaxTheme={syntaxTheme}
@@ -710,6 +726,9 @@ export function MarkdownDiffViewer(props: DiffViewerBodyProps) {
             <div className="text-sm text-github-text-muted mb-3">Loading preview...</div>
           )}
           {previewError && <div className="text-sm text-github-danger mb-3">{previewError}</div>}
+          {partialFailureLabel && (
+            <div className="text-sm text-github-text-muted mb-3">{partialFailureLabel}</div>
+          )}
           {!isPreviewLoading && !previewError && fullPreviewContent !== null && (
             <MarkdownFullPreview content={fullPreviewContent} syntaxTheme={syntaxTheme} />
           )}

--- a/src/client/viewers/MarkdownDiffViewer.tsx
+++ b/src/client/viewers/MarkdownDiffViewer.tsx
@@ -2,12 +2,13 @@ import React, { useEffect, useMemo, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
-import type { DiffLine } from '../../types/diff';
+import type { DiffFile, DiffLine } from '../../types/diff';
 import { FrontmatterTable } from '../components/FrontmatterTable';
 import { MermaidDiagram } from '../components/MermaidDiagram';
 import { PrismSyntaxHighlighter } from '../components/PrismSyntaxHighlighter';
 import type { MergedChunk } from '../hooks/useExpandedLines';
 import { extractFrontmatter } from '../utils/frontmatter';
+import { computeFrontmatterDiff } from '../utils/frontmatterDiff';
 import { extractMarkdownText, isElementWithCodeProps, isSafeUrl } from '../utils/markdownUtils';
 
 import { PreviewModeTabs, type PreviewMode } from './PreviewModeTabs';
@@ -396,15 +397,73 @@ const getCodeLineClass = (type: PreviewBlockType) => {
 const MarkdownDiffPreview = ({
   blocks,
   syntaxTheme,
+  baseContent,
+  targetContent,
+  fileStatus,
 }: {
   blocks: PreviewBlock[];
   syntaxTheme?: DiffViewerBodyProps['syntaxTheme'];
+  baseContent: string | null;
+  targetContent: string | null;
+  fileStatus: DiffFile['status'];
 }) => {
   const components = useMemo(() => getMarkdownComponents(syntaxTheme), [syntaxTheme]);
   const renderBlocks = useMemo(() => buildRenderBlocks(blocks), [blocks]);
 
+  const frontmatterView = useMemo(() => {
+    const baseData = baseContent !== null ? extractFrontmatter(baseContent).data : null;
+    const targetData = targetContent !== null ? extractFrontmatter(targetContent).data : null;
+
+    const baseAvailable = baseContent !== null;
+    const targetAvailable = targetContent !== null;
+
+    if (fileStatus === 'added') {
+      if (!targetAvailable) return null;
+      const entries = computeFrontmatterDiff(null, targetData);
+      if (entries.length === 0) return null;
+      return <FrontmatterTable mode="diff" entries={entries} label="Frontmatter" />;
+    }
+
+    if (fileStatus === 'deleted') {
+      if (!baseAvailable) return null;
+      const entries = computeFrontmatterDiff(baseData, null);
+      if (entries.length === 0) return null;
+      return <FrontmatterTable mode="diff" entries={entries} label="Frontmatter" />;
+    }
+
+    // modified / renamed
+    if (baseAvailable && targetAvailable) {
+      const entries = computeFrontmatterDiff(baseData, targetData);
+      if (entries.length === 0) return null;
+      return <FrontmatterTable mode="diff" entries={entries} label="Frontmatter" />;
+    }
+
+    // partial fetch failure or stdin — snapshot fallback with explanatory label
+    if (targetAvailable && targetData !== null) {
+      return (
+        <FrontmatterTable
+          mode="snapshot"
+          data={targetData}
+          label="Frontmatter (target only — base unavailable)"
+        />
+      );
+    }
+    if (baseAvailable && baseData !== null) {
+      return (
+        <FrontmatterTable
+          mode="snapshot"
+          data={baseData}
+          label="Frontmatter (base only — target unavailable)"
+        />
+      );
+    }
+
+    return null;
+  }, [baseContent, targetContent, fileStatus]);
+
   return (
     <div className="space-y-4">
+      {frontmatterView}
       {renderBlocks.map((block, index) => {
         if (block.kind === 'fenced-code') {
           return (
@@ -621,7 +680,13 @@ export function MarkdownDiffViewer(props: DiffViewerBodyProps) {
 
       {mode === 'diff-preview' && (
         <div className="p-4">
-          <MarkdownDiffPreview blocks={previewBlocks} syntaxTheme={syntaxTheme} />
+          <MarkdownDiffPreview
+            blocks={previewBlocks}
+            syntaxTheme={syntaxTheme}
+            baseContent={contents.base}
+            targetContent={contents.target}
+            fileStatus={file.status}
+          />
         </div>
       )}
 

--- a/src/client/viewers/MarkdownDiffViewer.tsx
+++ b/src/client/viewers/MarkdownDiffViewer.tsx
@@ -3,9 +3,11 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
 import type { DiffLine } from '../../types/diff';
+import { FrontmatterTable } from '../components/FrontmatterTable';
 import { MermaidDiagram } from '../components/MermaidDiagram';
 import { PrismSyntaxHighlighter } from '../components/PrismSyntaxHighlighter';
 import type { MergedChunk } from '../hooks/useExpandedLines';
+import { extractFrontmatter } from '../utils/frontmatter';
 import { extractMarkdownText, isElementWithCodeProps, isSafeUrl } from '../utils/markdownUtils';
 
 import { PreviewModeTabs, type PreviewMode } from './PreviewModeTabs';
@@ -443,15 +445,20 @@ const MarkdownFullPreview = ({
   syntaxTheme?: DiffViewerBodyProps['syntaxTheme'];
 }) => {
   const components = useMemo(() => getMarkdownComponents(syntaxTheme), [syntaxTheme]);
+  const { data: frontmatter, content: body } = useMemo(
+    () => extractFrontmatter(content),
+    [content],
+  );
 
   return (
     <div className="space-y-4">
+      <FrontmatterTable mode="snapshot" data={frontmatter} />
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         urlTransform={(url) => (isSafeUrl(url) ? url : '')}
         components={components}
       >
-        {content}
+        {body}
       </ReactMarkdown>
     </div>
   );

--- a/src/client/viewers/MarkdownDiffViewer.tsx
+++ b/src/client/viewers/MarkdownDiffViewer.tsx
@@ -7,7 +7,7 @@ import { FrontmatterTable } from '../components/FrontmatterTable';
 import { MermaidDiagram } from '../components/MermaidDiagram';
 import { PrismSyntaxHighlighter } from '../components/PrismSyntaxHighlighter';
 import type { MergedChunk } from '../hooks/useExpandedLines';
-import { extractFrontmatter } from '../utils/frontmatter';
+import { extractFrontmatter, getFrontmatterLines } from '../utils/frontmatter';
 import { computeFrontmatterDiff } from '../utils/frontmatterDiff';
 import { extractMarkdownText, isElementWithCodeProps, isSafeUrl } from '../utils/markdownUtils';
 
@@ -122,6 +122,87 @@ const buildPreviewBlocks = (chunks: MergedChunk[]): PreviewBlock[] => {
   });
 
   return blocks;
+};
+
+const stripCarriageReturn = (line: string) => line.replace(/\r$/, '');
+
+/**
+ * Removes the leading YAML frontmatter lines from the diff preview blocks so the
+ * `---` delimiters and raw YAML are not rendered as markdown below the dedicated
+ * frontmatter table. Deleted lines are matched against the base frontmatter,
+ * added/changed lines against the target frontmatter, and context lines against
+ * both. Matching is content-verified: as soon as a line no longer matches the
+ * expected frontmatter (e.g. the diff starts below the frontmatter, so the first
+ * lines are body content), stripping stops and the remaining blocks are kept
+ * untouched.
+ */
+const stripFrontmatterBlocks = (
+  blocks: PreviewBlock[],
+  baseLines: string[],
+  targetLines: string[],
+): PreviewBlock[] => {
+  if (baseLines.length === 0 && targetLines.length === 0) {
+    return blocks;
+  }
+
+  let baseIndex = 0;
+  let targetIndex = 0;
+  let stripping = true;
+  const result: PreviewBlock[] = [];
+
+  for (const block of blocks) {
+    if (!stripping) {
+      result.push(block);
+      continue;
+    }
+
+    const keptLines: string[] = [];
+
+    for (const rawLine of block.lines) {
+      if (!stripping) {
+        keptLines.push(rawLine);
+        continue;
+      }
+
+      const line = stripCarriageReturn(rawLine);
+      const baseMatches = baseIndex < baseLines.length && baseLines[baseIndex] === line;
+      const targetMatches = targetIndex < targetLines.length && targetLines[targetIndex] === line;
+
+      let matched = false;
+      if (block.type === 'delete') {
+        matched = baseMatches;
+        if (matched) baseIndex += 1;
+      } else if (block.type === 'add' || block.type === 'change') {
+        matched = targetMatches;
+        if (matched) targetIndex += 1;
+      } else {
+        // context: the line is unchanged, so it must sit within the frontmatter
+        // on every side that actually has frontmatter.
+        matched =
+          (baseLines.length === 0 || baseMatches) && (targetLines.length === 0 || targetMatches);
+        if (matched) {
+          if (baseMatches) baseIndex += 1;
+          if (targetMatches) targetIndex += 1;
+        }
+      }
+
+      if (!matched) {
+        stripping = false;
+        keptLines.push(rawLine);
+        continue;
+      }
+
+      if (baseIndex >= baseLines.length && targetIndex >= targetLines.length) {
+        stripping = false;
+      }
+    }
+
+    if (keptLines.length > 0) {
+      result.push({ type: block.type, lines: keptLines });
+    }
+  }
+
+  return result;
 };
 
 const getMarkdownComponents = (syntaxTheme?: DiffViewerBodyProps['syntaxTheme']) => ({
@@ -408,62 +489,83 @@ const MarkdownDiffPreview = ({
   fileStatus: DiffFile['status'];
 }) => {
   const components = useMemo(() => getMarkdownComponents(syntaxTheme), [syntaxTheme]);
-  const renderBlocks = useMemo(() => buildRenderBlocks(blocks), [blocks]);
 
   const frontmatterView = useMemo(() => {
-    const baseData = baseContent !== null ? extractFrontmatter(baseContent).data : null;
-    const targetData = targetContent !== null ? extractFrontmatter(targetContent).data : null;
-
     const baseAvailable = baseContent !== null;
     const targetAvailable = targetContent !== null;
+    const baseData = baseAvailable ? extractFrontmatter(baseContent).data : null;
+    const targetData = targetAvailable ? extractFrontmatter(targetContent).data : null;
 
-    if (fileStatus === 'added') {
-      if (!targetAvailable) return null;
-      const entries = computeFrontmatterDiff(null, targetData);
-      if (entries.length === 0) return null;
-      return <FrontmatterTable mode="diff" entries={entries} label="Frontmatter" />;
+    // When both sides needed for the diff are available we render a structured
+    // table and strip the raw frontmatter lines from the preview blocks below.
+    const canDiff =
+      fileStatus === 'added'
+        ? targetAvailable
+        : fileStatus === 'deleted'
+          ? baseAvailable
+          : baseAvailable && targetAvailable;
+
+    if (canDiff) {
+      const stripBaseLines = fileStatus === 'added' ? [] : getFrontmatterLines(baseContent ?? '');
+      const stripTargetLines =
+        fileStatus === 'deleted' ? [] : getFrontmatterLines(targetContent ?? '');
+      const baseInput = fileStatus === 'added' ? null : baseData;
+      const targetInput = fileStatus === 'deleted' ? null : targetData;
+      const entries = computeFrontmatterDiff(baseInput, targetInput);
+      const view =
+        entries.length > 0 ? (
+          <FrontmatterTable mode="diff" entries={entries} label="Frontmatter" />
+        ) : null;
+      return { view, stripBaseLines, stripTargetLines };
     }
 
-    if (fileStatus === 'deleted') {
-      if (!baseAvailable) return null;
-      const entries = computeFrontmatterDiff(baseData, null);
-      if (entries.length === 0) return null;
-      return <FrontmatterTable mode="diff" entries={entries} label="Frontmatter" />;
-    }
-
-    // modified / renamed
-    if (baseAvailable && targetAvailable) {
-      const entries = computeFrontmatterDiff(baseData, targetData);
-      if (entries.length === 0) return null;
-      return <FrontmatterTable mode="diff" entries={entries} label="Frontmatter" />;
-    }
-
-    // partial fetch failure or stdin — snapshot fallback with explanatory label
+    // partial fetch failure or stdin — snapshot fallback with explanatory label.
+    // The raw frontmatter lines are retained in the preview blocks.
     if (targetAvailable && targetData !== null) {
-      return (
-        <FrontmatterTable
-          mode="snapshot"
-          data={targetData}
-          label="Frontmatter (target only — base unavailable)"
-        />
-      );
+      return {
+        view: (
+          <FrontmatterTable
+            mode="snapshot"
+            data={targetData}
+            label="Frontmatter (target only — base unavailable)"
+          />
+        ),
+        stripBaseLines: [] as string[],
+        stripTargetLines: [] as string[],
+      };
     }
     if (baseAvailable && baseData !== null) {
-      return (
-        <FrontmatterTable
-          mode="snapshot"
-          data={baseData}
-          label="Frontmatter (base only — target unavailable)"
-        />
-      );
+      return {
+        view: (
+          <FrontmatterTable
+            mode="snapshot"
+            data={baseData}
+            label="Frontmatter (base only — target unavailable)"
+          />
+        ),
+        stripBaseLines: [] as string[],
+        stripTargetLines: [] as string[],
+      };
     }
 
-    return null;
+    return { view: null, stripBaseLines: [] as string[], stripTargetLines: [] as string[] };
   }, [baseContent, targetContent, fileStatus]);
+
+  const renderBlocks = useMemo(
+    () =>
+      buildRenderBlocks(
+        stripFrontmatterBlocks(
+          blocks,
+          frontmatterView.stripBaseLines,
+          frontmatterView.stripTargetLines,
+        ),
+      ),
+    [blocks, frontmatterView.stripBaseLines, frontmatterView.stripTargetLines],
+  );
 
   return (
     <div className="space-y-4">
-      {frontmatterView}
+      {frontmatterView.view}
       {renderBlocks.map((block, index) => {
         if (block.kind === 'fenced-code') {
           return (


### PR DESCRIPTION
Closes #441

## Summary
Render YAML frontmatter as a structured key/value table in both `full-preview` (snapshot) and `diff-preview` (key-level diff) tabs of the markdown preview.

## Design

**Parser**: `js-yaml` v4 (safe `load()` default) behind a standalone `extractFrontmatter(text)` helper that regex-splits the leading `---...---` block.

- The original proposal considered `remark-frontmatter` as a unified plugin, but the final UI renders frontmatter as a **separate `FrontmatterTable` component** — independent of the react-markdown body pipeline. Wiring frontmatter through unified would only add an AST-traverse step to pull the data back out for the table, so the regex + js-yaml direct path is both simpler and matches the actual data flow.
- js-yaml is pinned to `^4.3.0` so pnpm dedupes to a single version (transitive consumers like eslint/secretlint stay on v4). The v4 `load()` safety default (no `!!js/function`) is preserved.

**Rendering**:
- `FrontmatterTable` with `mode: 'snapshot' | 'diff'` and `label?` props.
- Diff mode reuses existing diff Tailwind classes (`bg-diff-addition-bg`, etc.).
- Modifications rendered as a single Key / Before / After row per field, with only the changed cell(s) colored — a horizontal, field-level comparison rather than GitHub's line-diff style. Reviewer feedback found the original two-row (before/after) layout scattered the same key across non-adjacent rows and hurt scanability; the 3-column layout keeps a field's old and new value side by side, closer to how CMS-style frontmatter editors present diffs.
- Nested values: one level of recursive indent, `JSON.stringify` fallback for deeper structures.

**Diff computation**:
- `computeFrontmatterDiff(old, new)` pure function.
- Canonical `JSON.stringify` (recursive key sort) to avoid false positives from key-order changes.
- Arrays preserve original order (order changes → modifications). Dates normalized via `toISOString`.

**Two-side fetch (diff-preview)**:
- Parallel `Promise.allSettled` on the existing `/api/blob/${path}?ref=${ref}` API.
- Per-`file.status`: added / deleted / renamed / modified handled explicitly.
- stdin: snapshot fallback with an explicit label.
- Partial fetch failure surfaces a plain-text banner in both Diff Preview and Full Preview, independent of whether frontmatter is present.

**full-preview**: snapshot only, preserving the "read vs. diff" semantic separation. Deleted files continue to render the base-side content, matching the pre-refactor behavior.

## Screenshots

### Diff Preview (frontmatter diff — Key / Before / After 3-column layout)
<img width="1568" height="699" alt="screenshot-1784351416530-1" src="https://github.com/user-attachments/assets/787e6f5f-def5-4ea7-8e46-9ac70c02d7ac" />


### Full Preview (frontmatter snapshot + rendered body)
<img width="1568" height="699" alt="screenshot-1784351441321-2" src="https://github.com/user-attachments/assets/76120a9c-4d4f-4024-939a-411a29b957ec" />


### Diff (existing line-diff for reference)
<img width="1568" height="699" alt="screenshot-1784351402574-0" src="https://github.com/user-attachments/assets/111a1f1d-96fc-4ce0-9168-00840a7cb868" />


## Test plan
- [x] Existing markdown files without frontmatter render identically (no regression)
- [x] `full-preview` renders the frontmatter table before the body when present
- [x] `full-preview` tab appears for deleted files and renders the base-side content
- [x] `diff-preview` renders a Key / Before / After diff table with additions / deletions / modifications for the 4 `file.status` variants
- [x] stdin mode falls back to snapshot with a clear label
- [x] Partial fetch failure shows a plain-text banner independent of frontmatter presence
- [x] `computeFrontmatterDiff` unit tests: key-order-change (no false positive), type change, nested, array, null
- [x] `pnpm build`, `pnpm check`, `pnpm test` pass (791 passed / 3 skipped), `pnpm run knip` clean
- [x] Bundle-size increase: 735.71 kB → 785.83 kB (+48.39 kB raw / +13.61 kB gzip)
- [x] `pnpm why js-yaml` resolves to a single v4.x version (v4.3.0)