### PR TITLE
feat: add Groovy language support

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -196,7 +196,7 @@ npx skills add yoshiko-pg/difit
 - **JavaScript/TypeScript**：`.js`, `.jsx`, `.ts`, `.tsx`, `.svelte`
 - **Web技術**：HTML, CSS, JSON, XML, Markdown
 - **シェルスクリプト**：`.sh`, `.bash`, `.zsh`, `.fish`
-- **バックエンド言語**：PHP, SQL, Ruby, Java, Scala, Perl, Elixir, Haskell, Clojure, Groovy
+- **バックエンド言語**：PHP, SQL, Ruby, Java, Groovy, Scala, Perl, Elixir, Haskell, Clojure
 - **システム言語**：C, C++, C#, Rust, Go
 - **モバイル言語**：Swift, Kotlin, Dart
 - **IaC**：Terraform (HCL), Nix

--- a/README.ja.md
+++ b/README.ja.md
@@ -196,7 +196,7 @@ npx skills add yoshiko-pg/difit
 - **JavaScript/TypeScript**：`.js`, `.jsx`, `.ts`, `.tsx`, `.svelte`
 - **Web技術**：HTML, CSS, JSON, XML, Markdown
 - **シェルスクリプト**：`.sh`, `.bash`, `.zsh`, `.fish`
-- **バックエンド言語**：PHP, SQL, Ruby, Java, Scala, Perl, Elixir, Haskell, Clojure
+- **バックエンド言語**：PHP, SQL, Ruby, Java, Scala, Perl, Elixir, Haskell, Clojure, Groovy
 - **システム言語**：C, C++, C#, Rust, Go
 - **モバイル言語**：Swift, Kotlin, Dart
 - **IaC**：Terraform (HCL), Nix

--- a/README.ko.md
+++ b/README.ko.md
@@ -196,7 +196,7 @@ npx skills add yoshiko-pg/difit
 - **JavaScript/TypeScript**: `.js`, `.jsx`, `.ts`, `.tsx`, `.svelte`
 - **웹 기술**: HTML, CSS, JSON, XML, Markdown
 - **셸 스크립트**: `.sh`, `.bash`, `.zsh`, `.fish`
-- **백엔드 언어**: PHP, SQL, Ruby, Java, Scala, Perl, Elixir, Haskell, Clojure
+- **백엔드 언어**: PHP, SQL, Ruby, Java, Scala, Perl, Elixir, Haskell, Clojure, Groovy
 - **시스템 언어**: C, C++, C#, Rust, Go
 - **모바일 언어**: Swift, Kotlin, Dart
 - **인프라 코드**: Terraform (HCL), Nix

--- a/README.ko.md
+++ b/README.ko.md
@@ -196,7 +196,7 @@ npx skills add yoshiko-pg/difit
 - **JavaScript/TypeScript**: `.js`, `.jsx`, `.ts`, `.tsx`, `.svelte`
 - **웹 기술**: HTML, CSS, JSON, XML, Markdown
 - **셸 스크립트**: `.sh`, `.bash`, `.zsh`, `.fish`
-- **백엔드 언어**: PHP, SQL, Ruby, Java, Scala, Perl, Elixir, Haskell, Clojure, Groovy
+- **백엔드 언어**: PHP, SQL, Ruby, Java, Groovy, Scala, Perl, Elixir, Haskell, Clojure
 - **시스템 언어**: C, C++, C#, Rust, Go
 - **모바일 언어**: Swift, Kotlin, Dart
 - **인프라 코드**: Terraform (HCL), Nix

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ After code edits or automated review, the agent can start the difit server with 
 - **JavaScript/TypeScript**: `.js`, `.jsx`, `.ts`, `.tsx`, `.svelte`
 - **Web Technologies**: HTML, CSS, JSON, XML, Markdown
 - **Shell Scripts**: `.sh`, `.bash`, `.zsh`, `.fish`
-- **Backend Languages**: PHP, SQL, Ruby, Java, Scala, Perl, Elixir, Haskell, Clojure
+- **Backend Languages**: PHP, SQL, Ruby, Java, Scala, Perl, Elixir, Haskell, Clojure, Groovy
 - **Systems Languages**: C, C++, C#, Rust, Go
 - **Mobile Languages**: Swift, Kotlin, Dart
 - **Infrastructure as Code**: Terraform (HCL), Nix

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ After code edits or automated review, the agent can start the difit server with 
 - **JavaScript/TypeScript**: `.js`, `.jsx`, `.ts`, `.tsx`, `.svelte`
 - **Web Technologies**: HTML, CSS, JSON, XML, Markdown
 - **Shell Scripts**: `.sh`, `.bash`, `.zsh`, `.fish`
-- **Backend Languages**: PHP, SQL, Ruby, Java, Scala, Perl, Elixir, Haskell, Clojure, Groovy
+- **Backend Languages**: PHP, SQL, Ruby, Java, Groovy, Scala, Perl, Elixir, Haskell, Clojure
 - **Systems Languages**: C, C++, C#, Rust, Go
 - **Mobile Languages**: Swift, Kotlin, Dart
 - **Infrastructure as Code**: Terraform (HCL), Nix

--- a/README.zh.md
+++ b/README.zh.md
@@ -196,7 +196,7 @@ npx skills add yoshiko-pg/difit
 - **JavaScript/TypeScript**：`.js`, `.jsx`, `.ts`, `.tsx`, `.svelte`
 - **Web 技术**：HTML, CSS, JSON, XML, Markdown
 - **Shell 脚本**：`.sh`, `.bash`, `.zsh`, `.fish`
-- **后端语言**：PHP, SQL, Ruby, Java, Scala, Perl, Elixir, Haskell, Clojure
+- **后端语言**：PHP, SQL, Ruby, Java, Scala, Perl, Elixir, Haskell, Clojure, Groovy
 - **系统语言**：C, C++, C#, Rust, Go
 - **移动语言**：Swift, Kotlin, Dart
 - **基础设施即代码**：Terraform (HCL), Nix

--- a/README.zh.md
+++ b/README.zh.md
@@ -196,7 +196,7 @@ npx skills add yoshiko-pg/difit
 - **JavaScript/TypeScript**：`.js`, `.jsx`, `.ts`, `.tsx`, `.svelte`
 - **Web 技术**：HTML, CSS, JSON, XML, Markdown
 - **Shell 脚本**：`.sh`, `.bash`, `.zsh`, `.fish`
-- **后端语言**：PHP, SQL, Ruby, Java, Scala, Perl, Elixir, Haskell, Clojure, Groovy
+- **后端语言**：PHP, SQL, Ruby, Java, Groovy, Scala, Perl, Elixir, Haskell, Clojure
 - **系统语言**：C, C++, C#, Rust, Go
 - **移动语言**：Swift, Kotlin, Dart
 - **基础设施即代码**：Terraform (HCL), Nix

--- a/src/client/utils/languageDetection.ts
+++ b/src/client/utils/languageDetection.ts
@@ -53,6 +53,11 @@ const DIFF_EXTENSION_LANGUAGE_MAP: Record<string, string> = {
   cljc: 'clojure',
   edn: 'clojure',
   gd: 'gdscript',
+  groovy: 'groovy',
+  gvy: 'groovy',
+  gy: 'groovy',
+  gsh: 'groovy',
+  gradle: 'groovy',
 };
 
 // Prism syntax highlighting: use Prism language IDs (e.g. tsx -> tsx, scss -> css).
@@ -122,6 +127,11 @@ const PRISM_EXTENSION_LANGUAGE_MAP: Record<string, string> = {
   cljc: 'clojure',
   edn: 'clojure',
   gd: 'gdscript',
+  groovy: 'groovy',
+  gvy: 'groovy',
+  gy: 'groovy',
+  gsh: 'groovy',
+  gradle: 'groovy',
 };
 
 const PRISM_FILENAME_LANGUAGE_MAP: Record<string, string> = {

--- a/src/client/utils/languageLoader.ts
+++ b/src/client/utils/languageLoader.ts
@@ -36,10 +36,8 @@ export function loadPrismLanguage(lang: string): Promise<void> {
       haskell: () => import('prismjs/components/prism-haskell.js'),
       clojure: () => import('prismjs/components/prism-clojure.js'),
       gdscript: () => import('prismjs/components/prism-gdscript.js'),
-      // Svelte grammar ships as a third-party plugin (not in prismjs core);
-      // it extends markup and embeds js/css, all available by default.
-      svelte: () => import('prism-svelte'),
       groovy: () => import('prismjs/components/prism-groovy.js'),
+      svelte: () => import('prism-svelte'),
     };
 
     const importFn = languageImports[lang];

--- a/src/client/utils/languageLoader.ts
+++ b/src/client/utils/languageLoader.ts
@@ -37,6 +37,8 @@ export function loadPrismLanguage(lang: string): Promise<void> {
       clojure: () => import('prismjs/components/prism-clojure.js'),
       gdscript: () => import('prismjs/components/prism-gdscript.js'),
       groovy: () => import('prismjs/components/prism-groovy.js'),
+      // Svelte grammar ships as a third-party plugin (not in prismjs core);
+      // it extends markup and embeds js/css, all available by default.
       svelte: () => import('prism-svelte'),
     };
 

--- a/src/client/utils/languageLoader.ts
+++ b/src/client/utils/languageLoader.ts
@@ -39,6 +39,7 @@ export function loadPrismLanguage(lang: string): Promise<void> {
       // Svelte grammar ships as a third-party plugin (not in prismjs core);
       // it extends markup and embeds js/css, all available by default.
       svelte: () => import('prism-svelte'),
+      groovy: () => import('prismjs/components/prism-groovy.js'),
     };
 
     const importFn = languageImports[lang];


### PR DESCRIPTION
## Summary
- Add Groovy syntax highlighting via PrismJS, following the same pattern used for Clojure (#324) and Elixir (#244)
- Map `.groovy`, `.gvy`, `.gy`, `.gsh`, `.gradle` extensions to the `groovy` language
- Document Groovy in the supported languages list (README, ja/ko/zh)

## Implementation notes
- `src/client/utils/languageLoader.ts`: register a lazy dynamic import for `prismjs/components/prism-groovy.js` (no extra deps needed, same as `java` — `clike` is already bundled by default)
- `src/client/utils/languageDetection.ts`: add extension mappings to both `DIFF_EXTENSION_LANGUAGE_MAP` and `PRISM_EXTENSION_LANGUAGE_MAP`

## Test plan
- [x] `pnpm test` — full Vitest suite passes (679 passed / 3 skipped)
- [x] `pnpm check` — oxlint type-aware checks pass
- [x] `pnpm build` — production build succeeds, `prism-groovy` chunk generated