### PR TITLE
feat(cli): Add global and local JSON config for CLI defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,21 +141,59 @@ Stdin mode is selected with intent-first rules:
 
 ## ⚙️ CLI Options
 
-| Flag                  | Default         | Description                                                                                             |
-| --------------------- | --------------- | ------------------------------------------------------------------------------------------------------- |
-| `<target>`            | HEAD            | Commit hash, tag, HEAD~n, branch, or special arguments                                                  |
-| `[compare-with]`      | -               | Optional second commit to compare with (shows diff between the two)                                     |
-| `--merge-base`        | false           | Resolve the base revision with `git merge-base` before diffing (Git revision mode only)                 |
-| `--pr <url>`          | -               | GitHub PR URL to review (e.g., https://github.com/owner/repo/pull/123)                                  |
-| `--comment <json>`    | -               | Inject initial comments (repeatable; accepts a JSON object or array)                                    |
-| `--port`              | 4966            | Preferred port; falls back to +1 if occupied                                                            |
-| `--host`              | 127.0.0.1       | Host address to bind server to (use 0.0.0.0 for external access)                                        |
-| `--no-open`           | false           | Don't automatically open browser                                                                        |
-| `--clean`             | false           | Clear all existing comments and viewed files on startup                                                 |
-| `--include-untracked` | false           | Automatically include untracked files in diff (only with `.` or `working`)                              |
-| `--keep-alive`        | false           | Keep server running after browser disconnects (stop manually with Ctrl+C)                               |
-| `--background`        | false           | Keep the server running in the background and output JSON connection info                               |
-| `--context <lines>`   | git default (3) | Limit surrounding context lines per change (`0` shows changes only; not available with `--pr` or stdin) |
+| Flag                  | Config key         | Default         | Description                                                                                             |
+| --------------------- | ------------------ | --------------- | ------------------------------------------------------------------------------------------------------- |
+| `<target>`            | —                  | HEAD            | Commit hash, tag, HEAD~n, branch, or special arguments                                                  |
+| `[compare-with]`      | —                  | -               | Optional second commit to compare with (shows diff between the two)                                     |
+| `--merge-base`        | `mergeBase`        | false           | Resolve the base revision with `git merge-base` before diffing (Git revision mode only)                 |
+| `--pr <url>`          | —                  | -               | GitHub PR URL to review (e.g., https://github.com/owner/repo/pull/123)                                  |
+| `--comment <json>`    | `comment`          | -               | Inject initial comments (repeatable; accepts a JSON object or array)                                    |
+| `--port`              | `port`             | 4966            | Preferred port; falls back to +1 if occupied                                                            |
+| `--host`              | `host`             | 127.0.0.1       | Host address to bind server to (use 0.0.0.0 for external access)                                        |
+| `--no-open`           | `open`             | false           | Don't automatically open browser (use `--open` to override a config default)                            |
+| `--clean`             | `clean`            | false           | Clear all existing comments and viewed files on startup                                                 |
+| `--include-untracked` | `includeUntracked` | false           | Automatically include untracked files in diff (only with `.` or `working`)                              |
+| `--keep-alive`        | `keepAlive`        | false           | Keep server running after browser disconnects (stop manually with Ctrl+C)                               |
+| `--background`        | `background`       | false           | Keep the server running in the background and output JSON connection info                               |
+| `--context <lines>`   | `context`          | git default (3) | Limit surrounding context lines per change (`0` shows changes only; not available with `--pr` or stdin) |
+
+### Configuration file
+
+You can set CLI defaults in JSON config files using the **Config key** values above (`—` means not supported). Values from the command line always override config files. Put CLI defaults under a `server` object.
+
+| Scope  | Path                              |
+| ------ | --------------------------------- |
+| Global | `~/.difit/config.json`            |
+| Local  | `.difitrc` (nearest ancestor dir) |
+
+Precedence: global config → local `.difitrc` → CLI flags.
+
+Example global config (`~/.difit/config.json`):
+
+```json
+{
+  "version": 1,
+  "client": {},
+  "server": {
+    "port": 4966,
+    "open": false,
+    "context": 5
+  }
+}
+```
+
+Example local config (`.difitrc` in your repo):
+
+```json
+{
+  "server": {
+    "includeUntracked": true,
+    "keepAlive": true
+  }
+}
+```
+
+`pnpm run dev` ignores `background` from config files so the local development workflow can start Vite against a foreground CLI server.
 
 ## 💬 Comment System
 

--- a/dev/dev-stdout.js
+++ b/dev/dev-stdout.js
@@ -2,6 +2,19 @@ const CLI_SERVER_URL_PATTERN = /^🚀 difit server started on (https?:\/\/\S+)$/
 const PORT_RETRY_PATTERN = /^Port \d+ is busy, trying \d+\.\.\.$/;
 
 /**
+ * @param {string} line
+ * @returns {string | undefined}
+ */
+function parseBackgroundServerUrl(line) {
+  try {
+    const parsed = /** @type {{ url?: string } | null} */ (JSON.parse(line));
+    return parsed?.url;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * @param {{
  *   onServerUrl: (serverUrl: string) => void;
  *   onOutput: (output: string) => void;
@@ -33,10 +46,12 @@ export function createCliStdoutProxy({ onServerUrl, onOutput }) {
     }
 
     const serverUrlMatch = line.match(CLI_SERVER_URL_PATTERN);
-    const shouldHideServerUrlLine = !detectedServerUrl && serverUrlMatch !== null;
+    const backgroundServerUrl = detectedServerUrl ? undefined : parseBackgroundServerUrl(line);
+    const shouldHideServerUrlLine =
+      !detectedServerUrl && (serverUrlMatch !== null || backgroundServerUrl !== undefined);
 
     if (shouldHideServerUrlLine) {
-      detectedServerUrl = serverUrlMatch[1];
+      detectedServerUrl = serverUrlMatch?.[1] ?? backgroundServerUrl;
       onServerUrl(detectedServerUrl);
     }
 

--- a/dev/dev-stdout.test.ts
+++ b/dev/dev-stdout.test.ts
@@ -3,6 +3,21 @@ import { describe, expect, it, vi } from 'vitest';
 import { createCliStdoutProxy } from './dev-stdout.js';
 
 describe('createCliStdoutProxy', () => {
+  it('detects the CLI server URL from background JSON output', () => {
+    const onServerUrl = vi.fn();
+    const output: string[] = [];
+    const proxy = createCliStdoutProxy({
+      onServerUrl,
+      onOutput: (text: string) => output.push(text),
+    });
+
+    proxy.push('{"port":4966,"url":"http://localhost:4966","pid":12345}\n📋 Reviewing: HEAD\n');
+    proxy.flush();
+
+    expect(onServerUrl).toHaveBeenCalledWith('http://localhost:4966');
+    expect(output).toEqual(['📋 Reviewing: HEAD\n']);
+  });
+
   it('detects the CLI server URL across chunks and hides only that line', () => {
     const onServerUrl = vi.fn();
     const output: string[] = [];

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -40,6 +40,7 @@ function startCliProcess() {
     env: {
       ...process.env,
       NODE_ENV: 'development',
+      DIFIT_DEV: '1',
     },
   });
 

--- a/src/cli/cli-config.test.ts
+++ b/src/cli/cli-config.test.ts
@@ -1,0 +1,108 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { LOCAL_CLI_CONFIG_FILENAME, findLocalCliConfigPath, loadCliConfig } from './cli-config.js';
+
+describe('cli-config', () => {
+  let tempDir: string;
+  let configDir: string;
+  let originalConfigDir: string | undefined;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'difit-cli-config-'));
+    configDir = join(tempDir, 'difit-config');
+    mkdirSync(configDir, { recursive: true });
+    originalConfigDir = process.env.DIFIT_CONFIG_DIR;
+    process.env.DIFIT_CONFIG_DIR = configDir;
+  });
+
+  afterEach(() => {
+    if (originalConfigDir === undefined) {
+      delete process.env.DIFIT_CONFIG_DIR;
+    } else {
+      process.env.DIFIT_CONFIG_DIR = originalConfigDir;
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  describe('findLocalCliConfigPath', () => {
+    it('returns undefined when no local config exists', () => {
+      expect(findLocalCliConfigPath(tempDir)).toBeUndefined();
+    });
+
+    it('finds .difitrc in the start directory', () => {
+      const configPath = join(tempDir, LOCAL_CLI_CONFIG_FILENAME);
+      writeFileSync(configPath, '{}');
+
+      expect(findLocalCliConfigPath(tempDir)).toBe(configPath);
+    });
+
+    it('walks up to the nearest ancestor .difitrc', () => {
+      const rootConfig = join(tempDir, LOCAL_CLI_CONFIG_FILENAME);
+      const nestedDir = join(tempDir, 'packages', 'app');
+      mkdirSync(nestedDir, { recursive: true });
+      writeFileSync(rootConfig, '{"server":{"port":4966}}');
+      writeFileSync(join(nestedDir, LOCAL_CLI_CONFIG_FILENAME), '{"server":{"port":4999}}');
+
+      expect(findLocalCliConfigPath(nestedDir)).toBe(join(nestedDir, LOCAL_CLI_CONFIG_FILENAME));
+    });
+  });
+
+  describe('loadCliConfig', () => {
+    it('returns an empty object when no config files exist', () => {
+      expect(loadCliConfig(tempDir)).toEqual({});
+    });
+
+    it('merges global and local config with local precedence', () => {
+      writeFileSync(
+        join(configDir, 'config.json'),
+        JSON.stringify({
+          version: 1,
+          client: {},
+          server: { port: 4966, open: false },
+        }),
+      );
+      writeFileSync(
+        join(tempDir, LOCAL_CLI_CONFIG_FILENAME),
+        JSON.stringify({ server: { port: 4999, keepAlive: true } }),
+      );
+
+      expect(loadCliConfig(tempDir)).toEqual({
+        port: 4999,
+        open: false,
+        keepAlive: true,
+      });
+    });
+
+    it('ignores background when DIFIT_DEV is set', () => {
+      writeFileSync(
+        join(configDir, 'config.json'),
+        JSON.stringify({
+          version: 1,
+          client: {},
+          server: { background: true, keepAlive: true, port: 4966 },
+        }),
+      );
+
+      const originalDifitDev = process.env.DIFIT_DEV;
+      process.env.DIFIT_DEV = '1';
+
+      try {
+        expect(loadCliConfig(tempDir)).toEqual({
+          keepAlive: true,
+          port: 4966,
+        });
+      } finally {
+        if (originalDifitDev === undefined) {
+          delete process.env.DIFIT_DEV;
+        } else {
+          process.env.DIFIT_DEV = originalDifitDev;
+        }
+      }
+    });
+  });
+});

--- a/src/cli/cli-config.ts
+++ b/src/cli/cli-config.ts
@@ -1,0 +1,63 @@
+import { existsSync } from 'fs';
+import { dirname, join, resolve } from 'path';
+
+import {
+  getUserConfigPath,
+  readServerConfigFile,
+  type ServerConfig,
+} from '../server/user-config.js';
+
+export type CliConfig = ServerConfig;
+
+export const LOCAL_CLI_CONFIG_FILENAME = '.difitrc';
+
+export function findLocalCliConfigPath(startDir: string): string | undefined {
+  let current = resolve(startDir);
+  const { root } = parsePathRoot(current);
+
+  while (true) {
+    const candidate = join(current, LOCAL_CLI_CONFIG_FILENAME);
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+
+    if (current === root) {
+      break;
+    }
+
+    const parent = dirname(current);
+    if (parent === current) {
+      break;
+    }
+    current = parent;
+  }
+
+  return undefined;
+}
+
+function parsePathRoot(current: string): { root: string } {
+  if (current === '/') {
+    return { root: '/' };
+  }
+  const parent = dirname(current);
+  if (parent === current) {
+    return { root: current };
+  }
+  return { root: resolve(current, '/') };
+}
+
+export function loadCliConfig(cwd = process.cwd()): Partial<CliConfig> {
+  const globalPath = getUserConfigPath();
+  const globalConfig = existsSync(globalPath) ? readServerConfigFile(globalPath) : {};
+
+  const localPath = findLocalCliConfigPath(cwd);
+  const localConfig = localPath ? readServerConfigFile(localPath) : {};
+
+  const merged: Partial<CliConfig> = { ...globalConfig, ...localConfig };
+
+  if (process.env.DIFIT_DEV === '1') {
+    delete merged.background;
+  }
+
+  return merged;
+}

--- a/src/cli/comment.test.ts
+++ b/src/cli/comment.test.ts
@@ -19,10 +19,10 @@ describe('createCommentCommand', () => {
   describe('add subcommand', () => {
     const addCommand = command.commands.find((c) => c.name() === 'add')!;
 
-    it('requires --port option', () => {
+    it('has --port option', () => {
       const portOption = addCommand.options.find((o) => o.long === '--port');
       expect(portOption).toBeDefined();
-      expect(portOption?.mandatory).toBe(true);
+      expect(portOption?.mandatory).toBe(false);
     });
 
     it('accepts optional json argument', () => {
@@ -36,10 +36,10 @@ describe('createCommentCommand', () => {
   describe('get subcommand', () => {
     const getCommand = command.commands.find((c) => c.name() === 'get')!;
 
-    it('requires --port option', () => {
+    it('has --port option', () => {
       const portOption = getCommand.options.find((o) => o.long === '--port');
       expect(portOption).toBeDefined();
-      expect(portOption?.mandatory).toBe(true);
+      expect(portOption?.mandatory).toBe(false);
     });
 
     it('has --format option with choices', () => {
@@ -57,10 +57,10 @@ describe('createCommentCommand', () => {
       expect(resolveCommand.aliases()).toContain('remove');
     });
 
-    it('requires --port option', () => {
+    it('has --port option', () => {
       const portOption = resolveCommand.options.find((o) => o.long === '--port');
       expect(portOption).toBeDefined();
-      expect(portOption?.mandatory).toBe(true);
+      expect(portOption?.mandatory).toBe(false);
     });
 
     it('accepts variadic threadIds argument', () => {
@@ -118,6 +118,39 @@ describe('comment subcommand integration', () => {
   });
 
   describe('add', () => {
+    it('uses the configured default port when --port is omitted', async () => {
+      mockFetch.mockResolvedValue(jsonResponse({ success: true, importId: 'abc123', count: 1 }));
+
+      const command = createCommentCommand({ port: 4966 });
+      await command.parseAsync([
+        'node',
+        'difit',
+        'add',
+        '{"type":"thread","filePath":"test.ts","position":{"side":"new","line":1},"body":"Test"}',
+      ]);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:4966/api/comment-imports',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+
+    it('errors when port is missing from both CLI and config', async () => {
+      const command = createCommentCommand();
+      await expect(
+        command.parseAsync([
+          'node',
+          'difit',
+          'add',
+          '{"type":"thread","filePath":"test.ts","position":{"side":"new","line":1},"body":"Test"}',
+        ]),
+      ).rejects.toThrow('--port is required');
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(consoleErrors[0]).toContain('--port is required');
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+
     it('sends comment imports to the server', async () => {
       mockFetch.mockResolvedValue(jsonResponse({ success: true, importId: 'abc123', count: 1 }));
 

--- a/src/cli/comment.ts
+++ b/src/cli/comment.ts
@@ -2,6 +2,7 @@ import { Command, Option } from 'commander';
 
 import { parseCommentImportValue } from '../utils/commentImports.js';
 
+import type { CliConfig } from './cli-config.js';
 import { detectStdinSource, readStdin } from './utils.js';
 
 interface CommentImportResponse {
@@ -11,6 +12,9 @@ interface CommentImportResponse {
   warnings?: string[];
 }
 
+const MISSING_PORT_ERROR =
+  'Error: --port is required (or set "port" in ~/.difit/config.json under "server" or in .difitrc)';
+
 function handleCommandError(error: unknown, port: number): never {
   if (error instanceof TypeError && error.message.includes('fetch failed')) {
     console.error(`Error: Cannot connect to difit server on port ${port}. Is the server running?`);
@@ -18,6 +22,15 @@ function handleCommandError(error: unknown, port: number): never {
     console.error(`Error: ${error instanceof Error ? error.message : 'Unknown error'}`);
   }
   process.exit(1);
+}
+
+function resolvePort(port: number | undefined): number {
+  if (port === undefined || Number.isNaN(port)) {
+    console.error(MISSING_PORT_ERROR);
+    process.exit(1);
+    throw new Error(MISSING_PORT_ERROR);
+  }
+  return port;
 }
 
 async function parseCommentAddInput(json?: string): Promise<string> {
@@ -37,7 +50,21 @@ async function parseCommentAddInput(json?: string): Promise<string> {
   return stdin;
 }
 
-export function createCommentCommand(): Command {
+function parsePort(value: string): number {
+  return Number.parseInt(value, 10);
+}
+
+function createPortOption(fileConfig: Partial<CliConfig>): Option {
+  const option = new Option('--port <port>', 'port of the running difit server').argParser(
+    parsePort,
+  );
+  if (fileConfig.port !== undefined) {
+    option.default(fileConfig.port);
+  }
+  return option;
+}
+
+export function createCommentCommand(fileConfig: Partial<CliConfig> = {}): Command {
   const comment = new Command('comment').description(
     'Add, retrieve, or resolve comments on a running difit server',
   );
@@ -46,13 +73,14 @@ export function createCommentCommand(): Command {
     .command('add')
     .description('Add comments to a running difit server')
     .argument('[json]', 'comment import JSON (object or array)')
-    .requiredOption('--port <port>', 'port of the running difit server', parseInt)
-    .action(async (json: string | undefined, opts: { port: number }) => {
+    .addOption(createPortOption(fileConfig))
+    .action(async (json: string | undefined, opts: { port?: number }) => {
+      const port = resolvePort(opts.port);
       try {
         const input = await parseCommentAddInput(json);
         const imports = parseCommentImportValue(input);
 
-        const response = await fetch(`http://localhost:${opts.port}/api/comment-imports`, {
+        const response = await fetch(`http://localhost:${port}/api/comment-imports`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(imports),
@@ -76,21 +104,22 @@ export function createCommentCommand(): Command {
           }),
         );
       } catch (error) {
-        handleCommandError(error, opts.port);
+        handleCommandError(error, port);
       }
     });
 
   comment
     .command('get')
     .description('Retrieve comments from a running difit server')
-    .requiredOption('--port <port>', 'port of the running difit server', parseInt)
+    .addOption(createPortOption(fileConfig))
     .addOption(
       new Option('--format <format>', 'output format').choices(['text', 'json']).default('text'),
     )
-    .action(async (opts: { port: number; format: string }) => {
+    .action(async (opts: { port?: number; format: string }) => {
+      const port = resolvePort(opts.port);
       try {
         const endpoint = opts.format === 'json' ? '/api/comments-json' : '/api/comments-output';
-        const response = await fetch(`http://localhost:${opts.port}${endpoint}`);
+        const response = await fetch(`http://localhost:${port}${endpoint}`);
 
         if (!response.ok) {
           console.error('Error: Failed to retrieve comments');
@@ -107,7 +136,7 @@ export function createCommentCommand(): Command {
           }
         }
       } catch (error) {
-        handleCommandError(error, opts.port);
+        handleCommandError(error, port);
       }
     });
 
@@ -116,8 +145,9 @@ export function createCommentCommand(): Command {
     .alias('remove')
     .description('Resolve (remove) comment threads on a running difit server')
     .argument('<threadIds...>', 'thread IDs to resolve')
-    .requiredOption('--port <port>', 'port of the running difit server', parseInt)
-    .action(async (threadIds: string[], opts: { port: number }) => {
+    .addOption(createPortOption(fileConfig))
+    .action(async (threadIds: string[], opts: { port?: number }) => {
+      const port = resolvePort(opts.port);
       try {
         const results = await Promise.all(
           threadIds.map(
@@ -129,7 +159,7 @@ export function createCommentCommand(): Command {
               error?: string;
             }> => {
               const response = await fetch(
-                `http://localhost:${opts.port}/api/comments/${encodeURIComponent(threadId)}`,
+                `http://localhost:${port}/api/comments/${encodeURIComponent(threadId)}`,
                 { method: 'DELETE' },
               );
 
@@ -174,7 +204,7 @@ export function createCommentCommand(): Command {
           process.exit(1);
         }
       } catch (error) {
-        handleCommandError(error, opts.port);
+        handleCommandError(error, port);
       }
     });
 

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -1424,4 +1424,48 @@ describe('CLI index.ts', () => {
       );
     });
   });
+
+  describe('configuration file defaults', () => {
+    it('applies file config defaults to startServer when CLI flags are omitted', async () => {
+      const { createProgram } = await import('./index.js');
+      mockFindUntrackedFiles.mockResolvedValue([]);
+
+      const program = createProgram({
+        port: 4999,
+        open: false,
+        keepAlive: true,
+        context: 7,
+      });
+
+      await program.parseAsync(['HEAD'], { from: 'user' });
+
+      expect(mockStartServer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          preferredPort: 4999,
+          openBrowser: false,
+          keepAlive: true,
+          contextLines: 7,
+        }),
+      );
+    });
+
+    it('lets CLI flags override file config defaults', async () => {
+      const { createProgram } = await import('./index.js');
+      mockFindUntrackedFiles.mockResolvedValue([]);
+
+      const program = createProgram({
+        port: 4999,
+        open: false,
+      });
+
+      await program.parseAsync(['--port', '5001', '--open', 'HEAD'], { from: 'user' });
+
+      expect(mockStartServer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          preferredPort: 5001,
+          openBrowser: true,
+        }),
+      );
+    });
+  });
 });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 
 import { spawn } from 'child_process';
-import { Command } from 'commander';
+import { resolve } from 'path';
+import { fileURLToPath } from 'url';
+import { Command, Option } from 'commander';
 import { simpleGit, type SimpleGit } from 'simple-git';
 
 import pkg from '../../package.json' with { type: 'json' };
@@ -20,6 +22,7 @@ import {
   getGitRoot,
   readStdin,
 } from './utils.js';
+import { type CliConfig, loadCliConfig } from './cli-config.js';
 import { createCommentCommand } from './comment.js';
 import { getPrPatch, getPrCommentImports } from './github.js';
 
@@ -171,148 +174,261 @@ interface CliOptions {
 
 const BACKGROUND_CHILD_ENV = 'DIFIT_BACKGROUND_CHILD';
 
-const program = new Command();
+function parsePort(value: string): number {
+  return Number.parseInt(value, 10);
+}
 
-program
-  .name('difit')
-  .description('A lightweight Git diff viewer with GitHub-like interface')
-  .version(pkg.version, '-v, --version', 'output the version number')
-  .enablePositionalOptions()
-  .addCommand(createCommentCommand())
-  .argument(
-    '[commit-ish]',
-    'Git commit, tag, branch, HEAD~n reference, or "working"/"staged"/"."',
-    'HEAD',
-  )
-  .argument(
-    '[compare-with]',
-    'Optional: Compare with this commit/branch (shows diff between commit-ish and compare-with)',
-  )
-  .option('--port <port>', 'preferred port (auto-assigned if occupied)', parseInt)
-  .option('--host <host>', 'host address to bind', '')
-  .option('--no-open', 'do not automatically open browser')
-  .option(
-    '--comment <json>',
-    'inject initial review comments (repeatable, accepts a JSON object or array)',
-    (value: string, previous: string[]) => [...previous, value],
-    [],
-  )
-  .option('--pr <url>', 'GitHub PR URL to review (e.g., https://github.com/owner/repo/pull/123)')
-  .option('--clean', 'start with a clean slate by clearing all existing comments')
-  .option('--include-untracked', 'automatically include untracked files in diff')
-  .option('--keep-alive', 'keep server running even after browser disconnects')
-  .option('--background', 'keep the server running in the background and output JSON info')
-  .option('--context <lines>', 'number of context lines shown around each change', parseInt)
-  .option(
-    '--merge-base',
-    'resolve the base revision with git merge-base before diffing (Git revision mode only)',
-  )
-  .action(async (commitish: string, compareWith: string | undefined, options: CliOptions) => {
-    try {
-      const isBackgroundChild = process.env[BACKGROUND_CHILD_ENV] === '1';
-      const backgroundMode = options.background || isBackgroundChild;
-      let stdinDiff: string | undefined;
-      let stdinReviewLabel = 'diff from stdin';
-      let manualCommentImports: CommentImport[] = [];
-      let commentImports: CommentImport[] = [];
+function parseContextLines(value: string): number {
+  return Number.parseInt(value, 10);
+}
 
-      if (
-        options.context !== undefined &&
-        (!Number.isInteger(options.context) || options.context < 0)
-      ) {
-        console.error('Error: --context must be a non-negative integer');
-        process.exit(1);
-      }
+function createPortOption(fileConfig: Partial<CliConfig>): Option {
+  const option = new Option(
+    '--port <port>',
+    'preferred port (auto-assigned if occupied)',
+  ).argParser(parsePort);
+  if (fileConfig.port !== undefined) {
+    option.default(fileConfig.port);
+  }
+  return option;
+}
 
-      if (options.background && !isBackgroundChild) {
-        await startBackgroundProcess();
-        return;
-      }
+function createContextOption(fileConfig: Partial<CliConfig>): Option {
+  const option = new Option(
+    '--context <lines>',
+    'number of context lines shown around each change',
+  ).argParser(parseContextLines);
+  if (fileConfig.context !== undefined) {
+    option.default(fileConfig.context);
+  }
+  return option;
+}
 
+export function createProgram(fileConfig: Partial<CliConfig>): Command {
+  const program = new Command();
+
+  program
+    .name('difit')
+    .description('A lightweight Git diff viewer with GitHub-like interface')
+    .version(pkg.version, '-v, --version', 'output the version number')
+    .enablePositionalOptions()
+    .addCommand(createCommentCommand(fileConfig))
+    .argument(
+      '[commit-ish]',
+      'Git commit, tag, branch, HEAD~n reference, or "working"/"staged"/"."',
+      'HEAD',
+    )
+    .argument(
+      '[compare-with]',
+      'Optional: Compare with this commit/branch (shows diff between commit-ish and compare-with)',
+    )
+    .addOption(createPortOption(fileConfig))
+    .option('--host <host>', 'host address to bind', fileConfig.host ?? '')
+    .addOption(new Option('--open', 'automatically open browser').default(fileConfig.open ?? true))
+    .addOption(
+      new Option('--no-open', 'do not automatically open browser').default(fileConfig.open ?? true),
+    )
+    .option(
+      '--comment <json>',
+      'inject initial review comments (repeatable, accepts a JSON object or array)',
+      (value: string, previous: string[]) => [...previous, value],
+      fileConfig.comment ?? [],
+    )
+    .option('--pr <url>', 'GitHub PR URL to review (e.g., https://github.com/owner/repo/pull/123)')
+    .addOption(
+      new Option('--clean', 'start with a clean slate by clearing all existing comments').default(
+        fileConfig.clean ?? false,
+      ),
+    )
+    .addOption(
+      new Option('--include-untracked', 'automatically include untracked files in diff').default(
+        fileConfig.includeUntracked ?? false,
+      ),
+    )
+    .addOption(
+      new Option('--keep-alive', 'keep server running even after browser disconnects').default(
+        fileConfig.keepAlive ?? false,
+      ),
+    )
+    .addOption(
+      new Option(
+        '--background',
+        'keep the server running in the background and output JSON info',
+      ).default(fileConfig.background ?? false),
+    )
+    .addOption(createContextOption(fileConfig))
+    .addOption(
+      new Option(
+        '--merge-base',
+        'resolve the base revision with git merge-base before diffing (Git revision mode only)',
+      ).default(fileConfig.mergeBase ?? false),
+    )
+    .action(async (commitish: string, compareWith: string | undefined, options: CliOptions) => {
       try {
-        manualCommentImports = parseCommentOptions(options.comment);
-        commentImports = manualCommentImports;
-      } catch (error) {
-        console.error(
-          `Error: ${error instanceof Error ? error.message : 'Invalid --comment value'}`,
-        );
-        process.exit(1);
-      }
+        const isBackgroundChild = process.env[BACKGROUND_CHILD_ENV] === '1';
+        const backgroundMode = options.background || isBackgroundChild;
+        let stdinDiff: string | undefined;
+        let stdinReviewLabel = 'diff from stdin';
+        let manualCommentImports: CommentImport[] = [];
+        let commentImports: CommentImport[] = [];
 
-      if (backgroundMode) {
-        options.keepAlive = true;
-        options.open = false;
-      }
-
-      if (options.pr) {
-        if (commitish !== 'HEAD' || compareWith) {
-          console.error('Error: --pr option cannot be used with positional arguments');
+        if (
+          options.context !== undefined &&
+          (!Number.isInteger(options.context) || options.context < 0)
+        ) {
+          console.error('Error: --context must be a non-negative integer');
           process.exit(1);
         }
 
-        if (options.mergeBase) {
-          console.error('Error: --merge-base option cannot be used with --pr');
-          process.exit(1);
-        }
-
-        if (options.context !== undefined) {
-          console.error('Error: --context option cannot be used with --pr');
-          process.exit(1);
+        if (options.background && !isBackgroundChild) {
+          await startBackgroundProcess();
+          return;
         }
 
         try {
-          stdinDiff = getPrPatch(options.pr);
-          stdinReviewLabel = options.pr;
+          manualCommentImports = parseCommentOptions(options.comment);
+          commentImports = manualCommentImports;
         } catch (error) {
           console.error(
-            `Error resolving PR: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            `Error: ${error instanceof Error ? error.message : 'Invalid --comment value'}`,
           );
           process.exit(1);
         }
 
-        try {
-          const prCommentImports = await getPrCommentImports(options.pr);
-          commentImports = [...prCommentImports, ...manualCommentImports];
-        } catch (error) {
-          console.warn(
-            `Warning: Failed to load PR review comments: ${error instanceof Error ? error.message : 'Unknown error'}`,
-          );
+        if (backgroundMode) {
+          options.keepAlive = true;
+          options.open = false;
         }
-      } else {
-        // Check if we should read from stdin
-        const readFromStdin = shouldReadStdin({
-          commitish,
-          hasPositionalArgs: program.args.length > 0,
-          hasPrOption: false,
-        });
 
-        if (readFromStdin) {
-          if (options.context !== undefined) {
-            console.error('Error: --context option cannot be used with stdin diff');
+        if (options.pr) {
+          if (commitish !== 'HEAD' || compareWith) {
+            console.error('Error: --pr option cannot be used with positional arguments');
             process.exit(1);
           }
+
           if (options.mergeBase) {
-            console.error('Error: --merge-base option cannot be used with stdin diff');
+            console.error('Error: --merge-base option cannot be used with --pr');
             process.exit(1);
           }
-          // Read unified diff from stdin
-          stdinDiff = await readStdin();
-          if (!stdinDiff.trim()) {
-            console.error('Error: No diff content received from stdin');
+
+          if (options.context !== undefined) {
+            console.error('Error: --context option cannot be used with --pr');
             process.exit(1);
+          }
+
+          try {
+            stdinDiff = getPrPatch(options.pr);
+            stdinReviewLabel = options.pr;
+          } catch (error) {
+            console.error(
+              `Error resolving PR: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            );
+            process.exit(1);
+          }
+
+          try {
+            const prCommentImports = await getPrCommentImports(options.pr);
+            commentImports = [...prCommentImports, ...manualCommentImports];
+          } catch (error) {
+            console.warn(
+              `Warning: Failed to load PR review comments: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            );
+          }
+        } else {
+          // Check if we should read from stdin
+          const readFromStdin = shouldReadStdin({
+            commitish,
+            hasPositionalArgs: program.args.length > 0,
+            hasPrOption: false,
+          });
+
+          if (readFromStdin) {
+            if (options.context !== undefined) {
+              console.error('Error: --context option cannot be used with stdin diff');
+              process.exit(1);
+            }
+            if (options.mergeBase) {
+              console.error('Error: --merge-base option cannot be used with stdin diff');
+              process.exit(1);
+            }
+            // Read unified diff from stdin
+            stdinDiff = await readStdin();
+            if (!stdinDiff.trim()) {
+              console.error('Error: No diff content received from stdin');
+              process.exit(1);
+            }
           }
         }
-      }
 
-      if (stdinDiff) {
-        // Start server with stdin diff (including --pr patch)
-        const { url, port } = await startServer({
-          stdinDiff,
+        if (stdinDiff) {
+          // Start server with stdin diff (including --pr patch)
+          const { url, port } = await startServer({
+            stdinDiff,
+            preferredPort: options.port,
+            host: options.host,
+            openBrowser: options.open,
+            clearComments: options.clean,
+            keepAlive: options.keepAlive,
+            ...(commentImports.length > 0 ? { commentImports } : {}),
+          });
+
+          if (backgroundMode) {
+            console.log(JSON.stringify({ port, url, pid: process.pid }));
+            return;
+          }
+
+          console.log(`\n🚀 difit server started on ${url}`);
+          console.log(`📋 Reviewing: ${stdinReviewLabel}`);
+          if (options.keepAlive) {
+            console.log('🔒 Keep-alive mode: server will stay running after browser disconnects');
+          }
+          console.log('\nPress Ctrl+C to stop the server');
+          return;
+        }
+
+        // Detect git root
+        let repoPath: string | undefined;
+        try {
+          repoPath = getGitRoot();
+        } catch {
+          // If not in a git repository, fall back to process.cwd()
+          repoPath = undefined;
+        }
+
+        const selection = resolveDiffSelection(commitish, compareWith, options.mergeBase);
+
+        if (options.mergeBase && isSpecialArg(selection.baseCommitish)) {
+          console.error(
+            `Error: --merge-base requires a commit-ish base, but resolved base was "${selection.baseCommitish}"`,
+          );
+          process.exit(1);
+        }
+
+        if (selection.targetCommitish === 'working' || selection.targetCommitish === '.') {
+          const git = simpleGit(repoPath);
+          if (isBackgroundChild && !options.includeUntracked) {
+            // Skip interactive prompts in detached background mode.
+          } else {
+            await handleUntrackedFiles(git, options.includeUntracked);
+          }
+        }
+
+        const validation = validateDiffArguments(selection.targetCommitish, compareWith);
+        if (!validation.valid) {
+          console.error(`Error: ${validation.error}`);
+          process.exit(1);
+        }
+
+        const { url, port, isEmpty } = await startServer({
+          selection,
           preferredPort: options.port,
           host: options.host,
           openBrowser: options.open,
           clearComments: options.clean,
           keepAlive: options.keepAlive,
+          contextLines: options.context,
+          diffMode: determineDiffMode(selection, compareWith),
+          repoPath,
           ...(commentImports.length > 0 ? { commentImports } : {}),
         });
 
@@ -322,112 +438,74 @@ program
         }
 
         console.log(`\n🚀 difit server started on ${url}`);
-        console.log(`📋 Reviewing: ${stdinReviewLabel}`);
+        console.log(`📋 Reviewing: ${selection.targetCommitish}`);
+
         if (options.keepAlive) {
           console.log('🔒 Keep-alive mode: server will stay running after browser disconnects');
         }
-        console.log('\nPress Ctrl+C to stop the server');
-        return;
-      }
 
-      // Detect git root
-      let repoPath: string | undefined;
-      try {
-        repoPath = getGitRoot();
-      } catch {
-        // If not in a git repository, fall back to process.cwd()
-        repoPath = undefined;
-      }
+        if (options.clean) {
+          console.log('🧹 Starting with a clean slate - all existing comments will be cleared');
+        }
 
-      const selection = resolveDiffSelection(commitish, compareWith, options.mergeBase);
-
-      if (options.mergeBase && isSpecialArg(selection.baseCommitish)) {
-        console.error(
-          `Error: --merge-base requires a commit-ish base, but resolved base was "${selection.baseCommitish}"`,
-        );
-        process.exit(1);
-      }
-
-      if (selection.targetCommitish === 'working' || selection.targetCommitish === '.') {
-        const git = simpleGit(repoPath);
-        if (isBackgroundChild && !options.includeUntracked) {
-          // Skip interactive prompts in detached background mode.
+        if (isEmpty) {
+          console.log(
+            '\n! \x1b[33mNo differences found. Browser will not open automatically.\x1b[0m',
+          );
+          console.log(`   Server is running at ${url} if you want to check manually.\n`);
+        } else if (options.open) {
+          console.log('🌐 Opening browser...\n');
         } else {
-          await handleUntrackedFiles(git, options.includeUntracked);
+          console.log('💡 Use --open to automatically open browser\n');
         }
-      }
 
-      const validation = validateDiffArguments(selection.targetCommitish, compareWith);
-      if (!validation.valid) {
-        console.error(`Error: ${validation.error}`);
+        process.on('SIGINT', async () => {
+          console.log('\n👋 Shutting down difit server...');
+
+          // Try to fetch comments before shutting down
+          try {
+            const response = await fetch(`http://localhost:${port}/api/comments-output`);
+            if (response.ok) {
+              const data = await response.text();
+              if (data.trim()) {
+                console.log(data);
+              }
+            }
+          } catch {
+            // Silently ignore fetch errors during shutdown
+          }
+
+          process.exit(0);
+        });
+      } catch (error) {
+        console.error('Error:', error instanceof Error ? error.message : 'Unknown error');
         process.exit(1);
       }
+    });
 
-      const { url, port, isEmpty } = await startServer({
-        selection,
-        preferredPort: options.port,
-        host: options.host,
-        openBrowser: options.open,
-        clearComments: options.clean,
-        keepAlive: options.keepAlive,
-        contextLines: options.context,
-        diffMode: determineDiffMode(selection, compareWith),
-        repoPath,
-        ...(commentImports.length > 0 ? { commentImports } : {}),
-      });
+  return program;
+}
 
-      if (backgroundMode) {
-        console.log(JSON.stringify({ port, url, pid: process.pid }));
-        return;
-      }
+async function main(): Promise<void> {
+  let fileConfig: Partial<CliConfig>;
+  try {
+    fileConfig = loadCliConfig();
+  } catch (error) {
+    console.error(`Error: ${error instanceof Error ? error.message : 'Invalid config'}`);
+    process.exit(1);
+  }
 
-      console.log(`\n🚀 difit server started on ${url}`);
-      console.log(`📋 Reviewing: ${selection.targetCommitish}`);
+  const program = createProgram(fileConfig);
+  await program.parseAsync();
+}
 
-      if (options.keepAlive) {
-        console.log('🔒 Keep-alive mode: server will stay running after browser disconnects');
-      }
+const isMainModule =
+  process.argv[1] !== undefined &&
+  resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
 
-      if (options.clean) {
-        console.log('🧹 Starting with a clean slate - all existing comments will be cleared');
-      }
-
-      if (isEmpty) {
-        console.log(
-          '\n! \x1b[33mNo differences found. Browser will not open automatically.\x1b[0m',
-        );
-        console.log(`   Server is running at ${url} if you want to check manually.\n`);
-      } else if (options.open) {
-        console.log('🌐 Opening browser...\n');
-      } else {
-        console.log('💡 Use --open to automatically open browser\n');
-      }
-
-      process.on('SIGINT', async () => {
-        console.log('\n👋 Shutting down difit server...');
-
-        // Try to fetch comments before shutting down
-        try {
-          const response = await fetch(`http://localhost:${port}/api/comments-output`);
-          if (response.ok) {
-            const data = await response.text();
-            if (data.trim()) {
-              console.log(data);
-            }
-          }
-        } catch {
-          // Silently ignore fetch errors during shutdown
-        }
-
-        process.exit(0);
-      });
-    } catch (error) {
-      console.error('Error:', error instanceof Error ? error.message : 'Unknown error');
-      process.exit(1);
-    }
-  });
-
-void program.parseAsync();
+if (isMainModule) {
+  void main();
+}
 
 async function handleUntrackedFiles(git: SimpleGit, addAutomatically?: boolean): Promise<void> {
   const files = await findUntrackedFiles(git);

--- a/src/server/server.test.ts
+++ b/src/server/server.test.ts
@@ -1088,7 +1088,7 @@ describe('Server Integration Tests', () => {
 
         expect(response.ok).toBe(true);
         const data = (await response.json()) as any;
-        expect(data).toEqual({ version: 1, client: {} });
+        expect(data).toEqual({ version: 1, client: {}, server: {} });
       });
 
       it('PUT /api/user-settings merges and persists client settings', async () => {

--- a/src/server/user-config.test.ts
+++ b/src/server/user-config.test.ts
@@ -1,12 +1,13 @@
-import { promises as fs } from 'fs';
+import { promises as fs, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 import {
   getUserConfigPath,
   readUserConfig,
+  readServerConfigFile,
   parseUserSettingsPatch,
   updateUserClientSettings,
   MAX_USER_CONFIG_BYTES,
@@ -50,19 +51,19 @@ describe('user-config', () => {
   describe('readUserConfig', () => {
     it('returns defaults when the file does not exist', async () => {
       const config = await readUserConfig(configPath);
-      expect(config).toEqual({ version: 1, client: {} });
+      expect(config).toEqual({ version: 1, client: {}, server: {} });
     });
 
     it('returns defaults when the file is corrupt', async () => {
       await fs.writeFile(configPath, 'not json', 'utf-8');
       const config = await readUserConfig(configPath);
-      expect(config).toEqual({ version: 1, client: {} });
+      expect(config).toEqual({ version: 1, client: {}, server: {} });
     });
 
     it('returns defaults when client is not an object', async () => {
       await fs.writeFile(configPath, JSON.stringify({ version: 1, client: [1, 2] }), 'utf-8');
       const config = await readUserConfig(configPath);
-      expect(config).toEqual({ version: 1, client: {} });
+      expect(config).toEqual({ version: 1, client: {}, server: {} });
     });
 
     it('reads stored client settings', async () => {
@@ -73,6 +74,82 @@ describe('user-config', () => {
       );
       const config = await readUserConfig(configPath);
       expect(config.client).toEqual({ diffViewMode: 'split' });
+      expect(config.server).toEqual({});
+    });
+
+    it('reads stored server settings', async () => {
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({
+          version: 1,
+          client: { diffViewMode: 'split' },
+          server: { port: 4966, open: false },
+        }),
+        'utf-8',
+      );
+      const config = await readUserConfig(configPath);
+      expect(config.client).toEqual({ diffViewMode: 'split' });
+      expect(config.server).toEqual({ port: 4966, open: false });
+    });
+  });
+
+  describe('readServerConfigFile', () => {
+    it('parses supported keys from the server section', () => {
+      writeFileSync(
+        configPath,
+        JSON.stringify({
+          version: 1,
+          client: {},
+          server: {
+            port: 4966,
+            host: '0.0.0.0',
+            open: false,
+            comment: '{"type":"thread"}',
+            clean: true,
+            includeUntracked: true,
+            keepAlive: true,
+            background: false,
+            context: 5,
+            mergeBase: true,
+          },
+        }),
+      );
+
+      expect(readServerConfigFile(configPath)).toEqual({
+        port: 4966,
+        host: '0.0.0.0',
+        open: false,
+        comment: ['{"type":"thread"}'],
+        clean: true,
+        includeUntracked: true,
+        keepAlive: true,
+        background: false,
+        context: 5,
+        mergeBase: true,
+      });
+    });
+
+    it('returns an empty object when server is missing', () => {
+      writeFileSync(configPath, JSON.stringify({ version: 1, client: {} }));
+      expect(readServerConfigFile(configPath)).toEqual({});
+    });
+
+    it('warns and ignores unknown server keys', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      writeFileSync(
+        configPath,
+        JSON.stringify({
+          version: 1,
+          client: {},
+          server: { pr: 'https://example.com', port: 4966 },
+        }),
+      );
+
+      expect(readServerConfigFile(configPath)).toEqual({ port: 4966 });
+      expect(warnSpy).toHaveBeenCalledWith(
+        `Warning: Ignoring unknown config key "pr" in ${configPath}`,
+      );
+      warnSpy.mockRestore();
     });
   });
 
@@ -81,9 +158,9 @@ describe('user-config', () => {
       const nestedPath = join(configDir, 'nested', 'config.json');
       const config = await updateUserClientSettings({ sidebarOpen: false }, nestedPath);
 
-      expect(config).toEqual({ version: 1, client: { sidebarOpen: false } });
+      expect(config).toEqual({ version: 1, client: { sidebarOpen: false }, server: {} });
       const stored = JSON.parse(await fs.readFile(nestedPath, 'utf-8'));
-      expect(stored).toEqual({ version: 1, client: { sidebarOpen: false } });
+      expect(stored).toEqual({ version: 1, client: { sidebarOpen: false }, server: {} });
     });
 
     it('shallow-merges the patch into existing settings', async () => {
@@ -94,6 +171,25 @@ describe('user-config', () => {
         diffViewMode: 'split',
         sidebarWidth: 400,
       });
+    });
+
+    it('preserves server settings when updating client settings', async () => {
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({
+          version: 1,
+          client: { diffViewMode: 'split' },
+          server: { port: 4966 },
+        }),
+        'utf-8',
+      );
+
+      const config = await updateUserClientSettings({ sidebarWidth: 400 }, configPath);
+
+      expect(config.client).toEqual({ diffViewMode: 'split', sidebarWidth: 400 });
+      expect(config.server).toEqual({ port: 4966 });
+      const stored = JSON.parse(await fs.readFile(configPath, 'utf-8'));
+      expect(stored.server).toEqual({ port: 4966 });
     });
 
     it('rejects settings exceeding the size limit', async () => {

--- a/src/server/user-config.ts
+++ b/src/server/user-config.ts
@@ -1,13 +1,41 @@
+import { readFileSync } from 'fs';
 import { promises as fs } from 'fs';
 import { homedir } from 'os';
 import { dirname, join } from 'path';
 
+export interface ServerConfig {
+  port?: number;
+  host?: string;
+  open?: boolean;
+  comment?: string[];
+  clean?: boolean;
+  includeUntracked?: boolean;
+  keepAlive?: boolean;
+  background?: boolean;
+  context?: number;
+  mergeBase?: boolean;
+}
+
 export interface UserConfig {
   version: 1;
   client: Record<string, unknown>;
+  server: Partial<ServerConfig>;
 }
 
 const CONFIG_VERSION = 1 as const;
+
+const SERVER_CONFIG_KEYS = new Set<string>([
+  'port',
+  'host',
+  'open',
+  'comment',
+  'clean',
+  'includeUntracked',
+  'keepAlive',
+  'background',
+  'context',
+  'mergeBase',
+]);
 
 // Generous ceiling for UI preferences; anything larger is a bug or abuse.
 export const MAX_USER_CONFIG_BYTES = 64 * 1024;
@@ -21,11 +49,117 @@ export function getUserConfigPath(): string {
 }
 
 function createDefaultUserConfig(): UserConfig {
-  return { version: CONFIG_VERSION, client: {} };
+  return { version: CONFIG_VERSION, client: {}, server: {} };
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function validateServerConfigValue(key: string, value: unknown): unknown {
+  switch (key) {
+    case 'port':
+      if (typeof value !== 'number' || !Number.isInteger(value) || value < 0) {
+        throw new Error(`"${key}" must be a non-negative integer`);
+      }
+      return value;
+    case 'host':
+      if (typeof value !== 'string') {
+        throw new Error(`"${key}" must be a string`);
+      }
+      return value;
+    case 'open':
+    case 'clean':
+    case 'includeUntracked':
+    case 'keepAlive':
+    case 'background':
+    case 'mergeBase':
+      if (typeof value !== 'boolean') {
+        throw new Error(`"${key}" must be a boolean`);
+      }
+      return value;
+    case 'context':
+      if (typeof value !== 'number' || !Number.isInteger(value) || value < 0) {
+        throw new Error(`"${key}" must be a non-negative integer`);
+      }
+      return value;
+    case 'comment':
+      if (typeof value === 'string') {
+        return [value];
+      }
+      if (Array.isArray(value) && value.every((item) => typeof item === 'string')) {
+        return value;
+      }
+      throw new Error(`"${key}" must be a string or array of strings`);
+  }
+}
+
+function parseServerSettings(
+  source: Record<string, unknown>,
+  configPath?: string,
+): Partial<ServerConfig> {
+  const config: Partial<ServerConfig> = {};
+  const location = configPath ? ` in ${configPath}` : '';
+
+  for (const [key, value] of Object.entries(source)) {
+    if (!SERVER_CONFIG_KEYS.has(key)) {
+      console.warn(`Warning: Ignoring unknown config key "${key}"${location}`);
+      continue;
+    }
+    const validated = validateServerConfigValue(key, value);
+    Object.assign(config, { [key]: validated });
+  }
+
+  return config;
+}
+
+function parseStoredUserConfig(parsed: unknown, path?: string): UserConfig {
+  if (!isPlainObject(parsed) || !isPlainObject(parsed.client)) {
+    return createDefaultUserConfig();
+  }
+
+  const server = isPlainObject(parsed.server) ? parseServerSettings(parsed.server, path) : {};
+
+  return {
+    version: CONFIG_VERSION,
+    client: parsed.client,
+    server,
+  };
+}
+
+export function readServerConfigFile(path: string): Partial<ServerConfig> {
+  let raw: string;
+  try {
+    raw = readFileSync(path, 'utf-8');
+  } catch (error) {
+    if (isErrnoException(error) && error.code === 'ENOENT') {
+      return {};
+    }
+    throw new Error(
+      `Failed to read config file ${path}: ${error instanceof Error ? error.message : 'Unknown error'}`,
+    );
+  }
+
+  if (Buffer.byteLength(raw, 'utf-8') > MAX_USER_CONFIG_BYTES) {
+    throw new Error(`Config file ${path} exceeds the maximum allowed size`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(`Invalid JSON in config file ${path}`);
+  }
+
+  if (!isPlainObject(parsed)) {
+    throw new Error(`Config file ${path} must contain a JSON object`);
+  }
+
+  if (!isPlainObject(parsed.server)) {
+    return {};
+  }
+
+  return parseServerSettings(parsed.server, path);
 }
 
 export function parseUserSettingsPatch(body: unknown): Record<string, unknown> | null {
@@ -42,9 +176,7 @@ export async function readUserConfig(path: string = getUserConfigPath()): Promis
   try {
     const raw = await fs.readFile(path, 'utf-8');
     const parsed: unknown = JSON.parse(raw);
-    if (isPlainObject(parsed) && isPlainObject(parsed.client)) {
-      return { version: CONFIG_VERSION, client: parsed.client };
-    }
+    return parseStoredUserConfig(parsed, path);
   } catch {
     // Missing or unreadable config falls back to defaults.
   }
@@ -62,6 +194,7 @@ export async function updateUserClientSettings(
   const next: UserConfig = {
     version: CONFIG_VERSION,
     client: { ...current.client, ...patch },
+    server: current.server,
   };
 
   const serialized = `${JSON.stringify(next, null, 2)}\n`;
@@ -75,4 +208,8 @@ export async function updateUserClientSettings(
   await fs.writeFile(tmpPath, serialized, 'utf-8');
   await fs.rename(tmpPath, path);
   return next;
+}
+
+function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
+  return typeof error === 'object' && error !== null && 'code' in error;
 }


### PR DESCRIPTION

## Summary

Adds JSON configuration for CLI defaults so common flags (`port`, `open`, `keepAlive`, `includeUntracked`, etc.) do not need to be repeated on every invocation.

This extends the existing user config file introduced in [#431](https://github.com/yoshiko-pg/difit/pull/431) rather than introducing a second global config path. UI preferences stay under `client`; CLI/server defaults live under `server` in the same `~/.difit/config.json` file.

Defaults are loaded before Commander parses argv, so explicit CLI flags still win.

## What changed

**Config**
- Extended `src/server/user-config.ts`:
  - New `ServerConfig` type and `server` field on `UserConfig` (`{ version, client, server }`)
  - `parseServerSettings()` validates known keys; unknown keys log a warning and are ignored
  - `readServerConfigFile()` sync-reads the `server` section from any JSON config file
  - `readUserConfig()` / `updateUserClientSettings()` preserve `server` when UI settings are read or written
- New `src/cli/cli-config.ts`:
  - Loads global defaults from `~/.difit/config.json` (`DIFIT_CONFIG_DIR` for tests)
  - Loads local overrides from the nearest ancestor `.difitrc` (also under a `server` object)
  - Merge order: global → local `.difitrc` → CLI flags

**CLI**
- `src/cli/index.ts` loads config at startup and applies defaults via Commander `Option` defaults
- Added `--open` alongside `--no-open` so config `open: false` can be overridden from the CLI
- `difit comment` subcommands (`add`, `get`, `resolve`) use configured `port` when `--port` is omitted

**Dev workflow**
- `scripts/dev.js` sets `DIFIT_DEV=1`; config loading ignores `background` in dev so `pnpm run dev` still starts a foreground CLI server and can launch Vite
- `dev/dev-stdout.js` recognizes background JSON output (`parsed?.url`) as a fallback when detecting the API URL

**Docs**
- README CLI options table includes a **Config key** column (`—` for unsupported options)
- Configuration section documents `server` in `~/.difit/config.json` and `.difitrc`

## Example

`~/.difit/config.json`:

```json
{
  "version": 1,
  "client": {
    "diffViewMode": "split"
  },
  "server": {
    "port": 4966,
    "open": false,
    "includeUntracked": true,
    "keepAlive": true
  }
}
```

`.difitrc` in a repo:

```json
{
  "server": {
    "includeUntracked": true
  }
}
```

## Notes for review

- Intentionally **not** configurable via files: positional `[commit-ish]` / `[compare-with]`, `--pr`, and `--version`
- `includeUntracked` still only applies in `.` / `working` mode (same as the flag)
- `GET /api/user-settings` now returns `server: {}` by default alongside `client`
- Tests: `src/server/user-config.test.ts` (server parsing, preservation on client writes), `src/cli/cli-config.test.ts` (merge + `DIFIT_DEV`), integration coverage in `src/cli/index.test.ts` and `src/cli/comment.test.ts`, plus `dev/dev-stdout.test.ts`

## Test plan

- [ ] `~/.difit/config.json` with `server.open: false` → `difit HEAD` does not auto-open the browser
- [ ] `difit HEAD --open` overrides config `open: false`
- [ ] `server.includeUntracked: true` + `difit .` auto-includes untracked files
- [ ] `.difitrc` `server` overrides global `server` for the same key
- [ ] Unknown `server` key logs a warning and does not fail startup
- [ ] `server.background: true` works for normal `difit`; `pnpm run dev` still starts Vite
- [ ] Changing a UI setting via the app preserves existing `server` values in the config file
- [ ] `difit comment get` works with only `port` in `server` (no `--port` flag)