### PR TITLE
fix(cli): --background parent exits and detached server stays alive

### DIFF
--- a/src/cli/background.test.ts
+++ b/src/cli/background.test.ts
@@ -1,0 +1,132 @@
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+import type { ChildProcess } from 'child_process';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  BACKGROUND_CHILD_ENV,
+  parseBackgroundHandshakeMessage,
+  releaseBackgroundChild,
+  startBackgroundProcess,
+} = await import('./background.js');
+
+interface MockChildProcess extends EventEmitter {
+  connected: boolean;
+  stderr: PassThrough;
+  disconnect: ReturnType<typeof vi.fn>;
+  kill: ReturnType<typeof vi.fn>;
+  unref: ReturnType<typeof vi.fn>;
+}
+
+function createMockChild(): MockChildProcess {
+  const child = Object.assign(new EventEmitter(), {
+    connected: true,
+    stderr: new PassThrough(),
+    disconnect: vi.fn(),
+    kill: vi.fn(() => true),
+    unref: vi.fn(),
+  });
+  child.disconnect.mockImplementation(() => {
+    child.connected = false;
+  });
+  return child;
+}
+
+describe('background process lifecycle', () => {
+  const originalArgv = process.argv;
+  let child: MockChildProcess;
+  let spawnProcess: typeof import('child_process').spawn;
+
+  beforeEach(() => {
+    child = createMockChild();
+    spawnProcess = vi.fn(() => child as unknown as ChildProcess) as unknown as typeof spawnProcess;
+    process.argv = [originalArgv[0], '/tmp/difit-entry.js', 'HEAD', '--background'];
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('accepts only complete background handshake messages', () => {
+    expect(
+      parseBackgroundHandshakeMessage({
+        port: 4966,
+        url: 'http://localhost:4966',
+        pid: 12345,
+      }),
+    ).toEqual({
+      port: 4966,
+      url: 'http://localhost:4966',
+      pid: 12345,
+    });
+    expect(parseBackgroundHandshakeMessage({ port: 4966 })).toBeNull();
+    expect(parseBackgroundHandshakeMessage('not an object')).toBeNull();
+  });
+
+  it('prints the handshake and releases the detached child', async () => {
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const stderrDestroy = vi.spyOn(child.stderr, 'destroy');
+
+    const result = startBackgroundProcess(spawnProcess);
+    child.emit('message', { port: 4967, url: 'http://localhost:4967', pid: 42 });
+    await result;
+
+    expect(spawnProcess).toHaveBeenCalledWith(
+      process.execPath,
+      ['/tmp/difit-entry.js', 'HEAD', '--keep-alive', '--no-open'],
+      expect.objectContaining({
+        detached: true,
+        stdio: ['ignore', 'ignore', 'pipe', 'ipc'],
+        env: expect.objectContaining({ [BACKGROUND_CHILD_ENV]: '1' }),
+      }),
+    );
+    expect(consoleLog).toHaveBeenCalledWith(
+      JSON.stringify({ port: 4967, url: 'http://localhost:4967', pid: 42 }),
+    );
+    expect(child.disconnect).toHaveBeenCalledOnce();
+    expect(stderrDestroy).toHaveBeenCalledOnce();
+    expect(child.unref).toHaveBeenCalledOnce();
+    expect(child.listenerCount('message')).toBe(0);
+    expect(child.listenerCount('error')).toBe(0);
+    expect(child.listenerCount('close')).toBe(0);
+  });
+
+  it('preserves stderr when the child exits before the handshake', async () => {
+    const result = startBackgroundProcess(spawnProcess);
+    child.stderr.write('Error: Invalid or non-existent commit: bad-ref\n');
+    child.connected = false;
+    child.emit('close', 1);
+
+    await expect(result).rejects.toThrow('Error: Invalid or non-existent commit: bad-ref');
+    expect(child.disconnect).not.toHaveBeenCalled();
+    expect(child.unref).toHaveBeenCalledOnce();
+  });
+
+  it('does not disconnect an IPC channel that is already closed', () => {
+    child.connected = false;
+
+    releaseBackgroundChild(child as unknown as ChildProcess);
+
+    expect(child.disconnect).not.toHaveBeenCalled();
+    expect(child.unref).toHaveBeenCalledOnce();
+  });
+
+  it('kills a child that times out instead of orphaning it', async () => {
+    vi.useFakeTimers();
+
+    const result = startBackgroundProcess(spawnProcess);
+    const rejection = expect(result).rejects.toThrow(
+      'Timed out while starting background difit server',
+    );
+    await vi.advanceTimersByTimeAsync(10_000);
+    await rejection;
+
+    expect(child.kill).toHaveBeenCalledOnce();
+    expect(child.unref).not.toHaveBeenCalled();
+    expect(child.listenerCount('message')).toBe(0);
+    expect(child.listenerCount('error')).toBe(0);
+    expect(child.listenerCount('close')).toBe(0);
+  });
+});

--- a/src/cli/background.ts
+++ b/src/cli/background.ts
@@ -1,0 +1,141 @@
+import { spawn, type ChildProcess } from 'child_process';
+
+export interface BackgroundServerInfo {
+  port: number;
+  url: string;
+  pid: number;
+}
+
+export const BACKGROUND_CHILD_ENV = 'DIFIT_BACKGROUND_CHILD';
+
+export function parseBackgroundHandshakeMessage(message: unknown): BackgroundServerInfo | null {
+  if (!message || typeof message !== 'object') {
+    return null;
+  }
+
+  const parsed = message as Partial<BackgroundServerInfo>;
+  if (
+    typeof parsed.port === 'number' &&
+    typeof parsed.url === 'string' &&
+    typeof parsed.pid === 'number'
+  ) {
+    return { port: parsed.port, url: parsed.url, pid: parsed.pid };
+  }
+
+  return null;
+}
+
+export function emitBackgroundHandshake(info: BackgroundServerInfo): void {
+  process.send?.(info);
+  process.disconnect?.();
+}
+
+export function releaseBackgroundChild(child: ChildProcess): void {
+  if (child.connected) {
+    child.disconnect();
+  }
+  child.stderr?.destroy();
+  child.unref();
+}
+
+export function ignoreStdioErrorsForBackgroundDaemon(): void {
+  process.stdout?.on?.('error', () => {});
+  process.stderr?.on?.('error', () => {});
+}
+
+export async function startBackgroundProcess(spawnProcess: typeof spawn = spawn): Promise<void> {
+  const scriptPath = process.argv[1];
+  if (!scriptPath) {
+    throw new Error('Unable to determine difit entrypoint for background process');
+  }
+
+  const childArgs = process.argv.slice(2).filter((arg) => arg !== '--background');
+  if (!childArgs.includes('--keep-alive')) {
+    childArgs.push('--keep-alive');
+  }
+  if (!childArgs.includes('--no-open')) {
+    childArgs.push('--no-open');
+  }
+
+  const child = spawnProcess(process.execPath, [scriptPath, ...childArgs], {
+    detached: true,
+    stdio: ['ignore', 'ignore', 'pipe', 'ipc'],
+    env: {
+      ...process.env,
+      [BACKGROUND_CHILD_ENV]: '1',
+    },
+  });
+
+  child.stderr?.setEncoding('utf8');
+
+  await new Promise<void>((resolve, reject) => {
+    let settled = false;
+    let stderr = '';
+
+    const cleanupListeners = (): void => {
+      child.removeListener('message', onMessage);
+      child.removeListener('error', onError);
+      child.removeListener('close', onClose);
+      child.stderr?.removeListener('data', onStderr);
+    };
+
+    const finish = (callback: () => void): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      cleanupListeners();
+      callback();
+    };
+
+    const onStderr = (chunk: string): void => {
+      stderr += chunk;
+    };
+
+    const onMessage = (message: unknown): void => {
+      const handshake = parseBackgroundHandshakeMessage(message);
+      if (!handshake) {
+        return;
+      }
+
+      finish(() => {
+        console.log(JSON.stringify(handshake));
+        releaseBackgroundChild(child);
+        resolve();
+      });
+    };
+
+    const onError = (error: Error): void => {
+      finish(() => {
+        releaseBackgroundChild(child);
+        reject(error);
+      });
+    };
+
+    const onClose = (code: number | null): void => {
+      finish(() => {
+        releaseBackgroundChild(child);
+        const startupError = stderr.trim();
+        reject(
+          new Error(
+            startupError || `Background difit server exited early (code ${code ?? 'unknown'})`,
+          ),
+        );
+      });
+    };
+
+    const timeout = setTimeout(() => {
+      finish(() => {
+        child.kill();
+        child.stderr?.destroy();
+        reject(new Error('Timed out while starting background difit server'));
+      });
+    }, 10_000);
+
+    child.stderr?.on('data', onStderr);
+    child.on('message', onMessage);
+    child.once('error', onError);
+    child.once('close', onClose);
+  });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { spawn } from 'child_process';
+import { spawn, type ChildProcess } from 'child_process';
 import { Command } from 'commander';
 import { simpleGit, type SimpleGit } from 'simple-git';
 
@@ -73,6 +73,47 @@ function determineDiffMode(selection: DiffSelection, compareWith?: string): Diff
   return DiffMode.DEFAULT;
 }
 
+interface BackgroundServerInfo {
+  port: number;
+  url: string;
+  pid: number;
+}
+
+const BACKGROUND_CHILD_ENV = 'DIFIT_BACKGROUND_CHILD';
+
+function parseBackgroundHandshakeMessage(message: unknown): BackgroundServerInfo | null {
+  if (!message || typeof message !== 'object') {
+    return null;
+  }
+
+  const parsed = message as Partial<BackgroundServerInfo>;
+  if (
+    typeof parsed.port === 'number' &&
+    typeof parsed.url === 'string' &&
+    typeof parsed.pid === 'number'
+  ) {
+    return { port: parsed.port, url: parsed.url, pid: parsed.pid };
+  }
+
+  return null;
+}
+
+function emitBackgroundHandshake(info: BackgroundServerInfo): void {
+  process.send?.(info);
+  process.disconnect?.();
+}
+
+function releaseBackgroundChild(child: ChildProcess): void {
+  child.removeAllListeners();
+  child.disconnect();
+  child.unref();
+}
+
+function ignoreStdioErrorsForBackgroundDaemon(): void {
+  process.stdout?.on?.('error', () => {});
+  process.stderr?.on?.('error', () => {});
+}
+
 async function startBackgroundProcess(): Promise<void> {
   const scriptPath = process.argv[1];
   if (!scriptPath) {
@@ -89,21 +130,20 @@ async function startBackgroundProcess(): Promise<void> {
 
   const child = spawn(process.execPath, [scriptPath, ...childArgs], {
     detached: true,
-    stdio: ['ignore', 'pipe', 'pipe'],
+    stdio: ['ignore', 'ignore', 'ignore', 'ipc'],
     env: {
       ...process.env,
       [BACKGROUND_CHILD_ENV]: '1',
     },
   });
 
-  child.stdout.setEncoding('utf8');
-  child.stderr.setEncoding('utf8');
-
   await new Promise<void>((resolve, reject) => {
     const timeout = setTimeout(() => {
-      reject(new Error('Timed out while starting background difit server'));
+      finish(() => {
+        releaseBackgroundChild(child);
+        reject(new Error('Timed out while starting background difit server'));
+      });
     }, 10_000);
-    let stderr = '';
     let settled = false;
 
     const finish = (callback: () => void) => {
@@ -115,41 +155,30 @@ async function startBackgroundProcess(): Promise<void> {
       callback();
     };
 
-    child.stdout.on('data', (chunk: string) => {
-      const line = chunk
-        .split(/\r?\n/u)
-        .map((value) => value.trim())
-        .find((value) => value.length > 0);
-
-      if (!line) {
+    child.on('message', (message: unknown) => {
+      const handshake = parseBackgroundHandshakeMessage(message);
+      if (!handshake) {
         return;
       }
 
       finish(() => {
-        console.log(line);
-        child.unref();
+        console.log(JSON.stringify(handshake));
+        releaseBackgroundChild(child);
         resolve();
       });
     });
 
-    child.stderr.on('data', (chunk: string) => {
-      stderr += chunk;
-    });
-
     child.once('error', (error) => {
       finish(() => {
+        releaseBackgroundChild(child);
         reject(error);
       });
     });
 
     child.once('exit', (code) => {
       finish(() => {
-        const trimmedStderr = stderr.trim();
-        reject(
-          new Error(
-            trimmedStderr || `Background difit server exited early (code ${code ?? 'unknown'})`,
-          ),
-        );
+        releaseBackgroundChild(child);
+        reject(new Error(`Background difit server exited early (code ${code ?? 'unknown'})`));
       });
     });
   });
@@ -168,8 +197,6 @@ interface CliOptions {
   context?: number;
   mergeBase?: boolean;
 }
-
-const BACKGROUND_CHILD_ENV = 'DIFIT_BACKGROUND_CHILD';
 
 const program = new Command();
 
@@ -317,7 +344,10 @@ program
         });
 
         if (backgroundMode) {
-          console.log(JSON.stringify({ port, url, pid: process.pid }));
+          emitBackgroundHandshake({ port, url, pid: process.pid });
+          if (isBackgroundChild) {
+            ignoreStdioErrorsForBackgroundDaemon();
+          }
           return;
         }
 
@@ -377,7 +407,10 @@ program
       });
 
       if (backgroundMode) {
-        console.log(JSON.stringify({ port, url, pid: process.pid }));
+        emitBackgroundHandshake({ port, url, pid: process.pid });
+        if (isBackgroundChild) {
+          ignoreStdioErrorsForBackgroundDaemon();
+        }
         return;
       }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-import { spawn, type ChildProcess } from 'child_process';
 import { Command } from 'commander';
 import { simpleGit, type SimpleGit } from 'simple-git';
 
@@ -22,6 +21,12 @@ import {
 } from './utils.js';
 import { createCommentCommand } from './comment.js';
 import { getPrPatch, getPrCommentImports } from './github.js';
+import {
+  BACKGROUND_CHILD_ENV,
+  emitBackgroundHandshake,
+  ignoreStdioErrorsForBackgroundDaemon,
+  startBackgroundProcess,
+} from './background.js';
 
 type SpecialArg = 'working' | 'staged' | '.';
 
@@ -71,117 +76,6 @@ function determineDiffMode(selection: DiffSelection, compareWith?: string): Diff
   }
   // Default mode: HEAD^ vs HEAD or HEAD vs other commits (watch for HEAD changes)
   return DiffMode.DEFAULT;
-}
-
-interface BackgroundServerInfo {
-  port: number;
-  url: string;
-  pid: number;
-}
-
-const BACKGROUND_CHILD_ENV = 'DIFIT_BACKGROUND_CHILD';
-
-function parseBackgroundHandshakeMessage(message: unknown): BackgroundServerInfo | null {
-  if (!message || typeof message !== 'object') {
-    return null;
-  }
-
-  const parsed = message as Partial<BackgroundServerInfo>;
-  if (
-    typeof parsed.port === 'number' &&
-    typeof parsed.url === 'string' &&
-    typeof parsed.pid === 'number'
-  ) {
-    return { port: parsed.port, url: parsed.url, pid: parsed.pid };
-  }
-
-  return null;
-}
-
-function emitBackgroundHandshake(info: BackgroundServerInfo): void {
-  process.send?.(info);
-  process.disconnect?.();
-}
-
-function releaseBackgroundChild(child: ChildProcess): void {
-  child.removeAllListeners();
-  child.disconnect();
-  child.unref();
-}
-
-function ignoreStdioErrorsForBackgroundDaemon(): void {
-  process.stdout?.on?.('error', () => {});
-  process.stderr?.on?.('error', () => {});
-}
-
-async function startBackgroundProcess(): Promise<void> {
-  const scriptPath = process.argv[1];
-  if (!scriptPath) {
-    throw new Error('Unable to determine difit entrypoint for background process');
-  }
-
-  const childArgs = process.argv.slice(2).filter((arg) => arg !== '--background');
-  if (!childArgs.includes('--keep-alive')) {
-    childArgs.push('--keep-alive');
-  }
-  if (!childArgs.includes('--no-open')) {
-    childArgs.push('--no-open');
-  }
-
-  const child = spawn(process.execPath, [scriptPath, ...childArgs], {
-    detached: true,
-    stdio: ['ignore', 'ignore', 'ignore', 'ipc'],
-    env: {
-      ...process.env,
-      [BACKGROUND_CHILD_ENV]: '1',
-    },
-  });
-
-  await new Promise<void>((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      finish(() => {
-        releaseBackgroundChild(child);
-        reject(new Error('Timed out while starting background difit server'));
-      });
-    }, 10_000);
-    let settled = false;
-
-    const finish = (callback: () => void) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      clearTimeout(timeout);
-      callback();
-    };
-
-    child.on('message', (message: unknown) => {
-      const handshake = parseBackgroundHandshakeMessage(message);
-      if (!handshake) {
-        return;
-      }
-
-      finish(() => {
-        console.log(JSON.stringify(handshake));
-        releaseBackgroundChild(child);
-        resolve();
-      });
-    });
-
-    child.once('error', (error) => {
-      finish(() => {
-        releaseBackgroundChild(child);
-        reject(error);
-      });
-    });
-
-    child.once('exit', (code) => {
-      finish(() => {
-        releaseBackgroundChild(child);
-        reject(new Error(`Background difit server exited early (code ${code ?? 'unknown'})`));
-      });
-    });
-  });
 }
 
 interface CliOptions {


### PR DESCRIPTION
## Summary

- Fix `--background` so the parent process exits after printing server info, while the detached child keeps running
- Replace stdout pipe handshake with Node IPC (`process.send` / `child.on('message')`) so the parent can exit without SIGPIPE killing the detached server
- Disconnect IPC after the handshake and ignore stdout/stderr errors on the background child so a closed parent terminal does not tear down the daemon

## Root cause

`startBackgroundProcess()` spawned the detached child with piped stdout/stderr and waited for the server-ready JSON on `child.stdout`. The parent printed that line and called `child.unref()`, but the pipes stayed open until the parent exited. When the parent process ended, the broken stdout pipe could deliver SIGPIPE to the still-running child and kill the background server.

The background child also continued to use stdout for the handshake, so it remained coupled to the parent's lifecycle even though the process was meant to be detached.

## What changed

**`src/cli/index.ts`**
- Spawn background child with `stdio: ['ignore', 'ignore', 'ignore', 'ipc']` instead of piped stdout/stderr
- Child sends `{ port, url, pid }` via `process.send()` and disconnects IPC after the handshake
- Parent waits on `child.on('message')`, prints `JSON.stringify(handshake)` to its own stdout, then disconnects and unrefs the child
- Background child registers no-op handlers for stdout/stderr `error` events after handshake so closed stdio does not crash the daemon

## Reproduction (before this fix)

```bash
difit HEAD --background --no-open
# Parent hung or background server died shortly after startup when the parent exited
```

## Test plan

- [ ] `difit HEAD --background --no-open` prints one JSON line (`port`, `url`, `pid`) and the parent exits immediately
- [ ] Background server keeps responding after the parent exits: `curl http://localhost:<port>/api/diff` → 200
- [ ] `difit HEAD --background --no-open` twice on the same port behavior still works (or port retry still works when busy)
- [ ] Normal foreground `difit HEAD` still opens the browser and blocks as before
- [ ] `pnpm check` / `pnpm test` / `pnpm build` pass


# Manual validation

These checks compare the reviewed PR head (`33a17c58c4a18ad725790f3774e46785e796d34b`) with the current working tree. They use a detached Git worktree for the old code, so the current branch does not need to be changed.

## 1. Prepare the reviewed version

Run from the difit repository:

```bash
git worktree add --detach /tmp/difit-pr451-before 33a17c58c4a18ad725790f3774e46785e796d34b
cd /tmp/difit-pr451-before
pnpm install --offline --frozen-lockfile --ignore-scripts
pnpm build:cli
```

## 2. Reproduce the disconnected-IPC crash

From `/tmp/difit-pr451-before`:

```bash
node dist/cli/index.js definitely-not-a-valid-ref --background --no-open
```

Expected before the fix:

- The command exits with code 1.
- It prints an unhandled `ERR_IPC_DISCONNECTED` stack trace.
- The stack includes `releaseBackgroundChild` and `child.disconnect()`.

Validate the current fix:

```bash
cd /home/rafael/dev/difit
pnpm build:cli
node dist/cli/index.js definitely-not-a-valid-ref --background --no-open
```

Expected after the fix:

- The command exits with code 1.
- It reports `Invalid or non-existent commit: definitely-not-a-valid-ref`.
- It does not print `ERR_IPC_DISCONNECTED`, `Unhandled 'error' event`, or a Node stack trace.

## 3. Verify that startup stderr is preserved

First show the diagnostic produced by the reviewed version's child:

```bash
cd /tmp/difit-pr451-before
DIFIT_BACKGROUND_CHILD=1 node dist/cli/index.js definitely-not-a-valid-ref --keep-alive --no-open
```

Expected:

```text
Error: Invalid or non-existent commit: definitely-not-a-valid-ref
```

Now run the reviewed version through its background parent:

```bash
node dist/cli/index.js definitely-not-a-valid-ref --background --no-open
```

Expected before the fix:

- The useful invalid-ref diagnostic is not relayed by the parent.
- The disconnected-IPC stack trace masks the startup failure.

Run the equivalent command in the current working tree:

```bash
cd /home/rafael/dev/difit
node dist/cli/index.js definitely-not-a-valid-ref --background --no-open
```

Expected after the fix:

- The parent output contains the invalid-ref diagnostic.
- No disconnected-IPC stack trace is printed.

## 4. Reproduce and validate timeout cleanup

This is the hardest case to reproduce manually. The review concern is:

- **Before:** on handshake timeout, the parent calls `releaseBackgroundChild()` (disconnect + unref) instead of `kill()`, so a slow child can keep booting and hold the port.
- **After:** on timeout, the parent calls `child.kill()` so the detached server should not survive.

The preload below delays only the detached child (`DIFIT_BACKGROUND_CHILD=1`) for 12 seconds before difit starts. The parent times out at 10 seconds.

### Create the delay preload once

```bash
cat >/tmp/difit-pr451-delay-child.cjs <<'EOF'
const fs = require('node:fs');

if (process.env.DIFIT_BACKGROUND_CHILD === '1') {
  fs.writeFileSync('/tmp/difit-pr451-child.pid', String(process.pid));
  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 12_000);
}
EOF
```

### Helper: watch port 4977 for 20 seconds

Run this in a **second terminal** before starting the background command:

```bash
for i in $(seq 1 20); do
  code="$(curl --silent --output /dev/null --write-out '%{http_code}' http://localhost:4977/api/diff 2>/dev/null || echo 000)"
  pid="$(cat /tmp/difit-pr451-child.pid 2>/dev/null || echo -)"
  alive="no"
  if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then alive="yes"; fi
  printf 't=%02ds pid=%s alive=%s curl=%s\n' "$i" "$pid" "$alive" "$code"
  sleep 1
done
```

### Before the fix

In the first terminal:

```bash
cd /tmp/difit-pr451-before
rm -f /tmp/difit-pr451-child.pid
NODE_OPTIONS="--require /tmp/difit-pr451-delay-child.cjs" \
  node dist/cli/index.js HEAD --background --no-open --port 4977
```

Interpret the watcher output:

| What you see | Meaning |
| --- | --- |
| Parent prints `Timed out while starting background difit server` after ~10s | Timeout path ran (good setup). |
| `alive=yes` for several seconds after `t=10`, then `curl=200` around `t=13`–`t=16` | **Orphan reproduced:** child survived timeout and eventually served traffic. This matches the review concern. |
| `alive=no` soon after `t=10` and `curl=000` through `t=20` | Child did **not** orphan in this run. Timeout still happened, but you cannot confirm the orphan bug from this attempt alone. |

If you saw the second row (like `kill: No such process` and `curl 000` immediately after timeout), that means:

1. The timeout path did run.
2. The child PID was already gone (or never stayed alive long enough to bind port 4977).
3. That is **not** proof the orphan bug is absent in all environments — only that this preload setup did not leave a survivor on your machine.

The pre-fix code still does **not** call `child.kill()` on timeout; a slower or partially-started child can still orphan in other conditions.

Cleanup if anything is still running:

```bash
kill "$(cat /tmp/difit-pr451-child.pid 2>/dev/null)" 2>/dev/null || true
```

### After the fix

Repeat with the watcher running, then in the first terminal:

```bash
cd /home/rafael/dev/difit
rm -f /tmp/difit-pr451-child.pid
NODE_OPTIONS="--require /tmp/difit-pr451-delay-child.cjs" \
  node dist/cli/index.js HEAD --background --no-open --port 4977
```

Expected after the fix:

- Parent still times out after ~10s.
- Within 1–2 seconds after timeout (`t=11` or `t=12`), watcher shows `alive=no`.
- `curl` stays `000` for the full 20s window.

That confirms the timed-out child was killed instead of released to keep running.

## 5. Validate successful background startup

From the current working tree:

```bash
cd /home/rafael/dev/difit
SECONDS=0
server_json="$(node dist/cli/index.js HEAD --background --no-open --port 4978)"
elapsed="$SECONDS"
server_pid="$(node -e 'process.stdout.write(String(JSON.parse(process.argv[1]).pid))' "$server_json")"
server_url="$(node -e 'process.stdout.write(JSON.parse(process.argv[1]).url)' "$server_json")"
printf 'parent elapsed: %ss\nserver: %s\n' "$elapsed" "$server_json"
curl --fail --silent --output /dev/null --write-out '%{http_code}\n' \
  "$server_url/api/diff"
kill "$server_pid"
```

Expected after the fix:

- The parent exits promptly and prints one JSON object containing `port`, `url`, and `pid`.
- Curl returns `200` after the parent has exited.
- The final `kill` stops the detached server.

## 6. Cleanup

```bash
cd /home/rafael/dev/difit
git worktree remove /tmp/difit-pr451-before
rm -f /tmp/difit-pr451-delay-child.cjs /tmp/difit-pr451-child.pid
```

