### PR TITLE
feat: include diff context in comment text output

### DIFF
--- a/src/client/App.test.tsx
+++ b/src/client/App.test.tsx
@@ -37,7 +37,7 @@ vi.mock('./hooks/useDiffComments', () => ({
     applyCommentImports: mockApplyCommentImports,
     generatePrompt: vi.fn(),
     generateThreadPrompt: vi.fn(),
-    generateAllCommentsPrompt: vi.fn(),
+    generateAllCommentsPrompt: mockGenerateAllCommentsPrompt,
   })),
 }));
 
@@ -124,6 +124,7 @@ let mockComments: DiffCommentThread[] = [];
 const mockReplaceThreads = vi.fn();
 const mockClearAllComments = vi.fn();
 const mockApplyCommentImports = vi.fn(() => []);
+const mockGenerateAllCommentsPrompt = vi.fn(() => 'formatted prompt');
 
 function createMockThread({
   id,
@@ -173,6 +174,7 @@ beforeEach(() => {
   mockViewedFiles = new Set<string>();
   mockHasLoadedInitialViewedFiles = true;
   mockReplaceThreads.mockReset();
+  mockGenerateAllCommentsPrompt.mockClear();
 });
 
 const mockDiffResponse: DiffResponse = {
@@ -202,6 +204,36 @@ describe('App Component - Clear Comments Functionality', () => {
     mockApplyCommentImports.mockReturnValue([]);
     mockConfirm.mockReturnValue(false);
     mockFetch(mockDiffResponse);
+  });
+
+  describe('Copy All Prompt Button', () => {
+    it('should generate Copy All Prompt with requested and resolved diff context', async () => {
+      mockComments = [
+        createMockThread({ id: 'test-1', filePath: 'test.ts', line: 10, body: 'Test comment' }),
+      ];
+      mockFetch({
+        ...mockDiffResponse,
+        baseCommitish: 'abcdef1',
+        targetCommitish: '1234567',
+        requestedBaseCommitish: 'main',
+        requestedTargetCommitish: 'feature/docs-update',
+        requestedBaseMode: 'merge-base',
+      });
+
+      renderApp();
+
+      fireEvent.click(await screen.findByText(/Copy All Prompt/));
+
+      await waitFor(() => {
+        expect(mockGenerateAllCommentsPrompt).toHaveBeenCalledWith({
+          requestedBaseCommitish: 'main',
+          requestedTargetCommitish: 'feature/docs-update',
+          baseMode: 'merge-base',
+          resolvedBaseCommitish: 'abcdef1',
+          resolvedTargetCommitish: '1234567',
+        });
+      });
+    });
   });
 
   describe('Cleanup All Prompt Button', () => {

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1073,7 +1073,13 @@ function App() {
 
   const handleCopyAllComments = async () => {
     try {
-      const prompt = generateAllCommentsPrompt();
+      const prompt = generateAllCommentsPrompt({
+        requestedBaseCommitish: diffData?.requestedBaseCommitish,
+        requestedTargetCommitish: diffData?.requestedTargetCommitish,
+        baseMode: normalizeBaseMode(diffData?.requestedBaseMode),
+        resolvedBaseCommitish: diffData?.baseCommitish,
+        resolvedTargetCommitish: diffData?.targetCommitish,
+      });
       await copyTextToClipboard(prompt);
       setIsCopiedAll(true);
       setTimeout(() => setIsCopiedAll(false), 2000);

--- a/src/client/hooks/useDiffComments.test.ts
+++ b/src/client/hooks/useDiffComments.test.ts
@@ -71,7 +71,7 @@ describe('useDiffComments', () => {
       expect(comment).toBeDefined();
       const prompt = result.current.generatePrompt(comment!.id);
 
-      expect(prompt).toBe('src/client/components/CommentForm.tsx:L42 side=new\nコメント内容');
+      expect(prompt).toBe('src/client/components/CommentForm.tsx:L42\nコメント内容');
     });
 
     it('should format multi-line comment correctly', () => {
@@ -90,7 +90,7 @@ describe('useDiffComments', () => {
       expect(comment).toBeDefined();
       const prompt = result.current.generatePrompt(comment!.id);
 
-      expect(prompt).toBe('src/client/components/CommentForm.tsx:L36-L39 side=new\n複数行');
+      expect(prompt).toBe('src/client/components/CommentForm.tsx:L36-L39\n複数行');
     });
 
     it('should return empty string for non-existent comment', () => {
@@ -143,12 +143,12 @@ describe('useDiffComments', () => {
       expect(result.current.comments[0]?.position.line).toEqual({ start: 36, end: 39 });
       expect(result.current.comments[1]?.position.line).toBe(42);
 
-      const expected = `diff base=main target=feature-branch mode=merge-base resolved-base=abc1234 resolved-target=def5678
+      const expected = `diff main...feature-branch (abc1234...def5678)
 =====
-src/client/components/CommentForm.tsx:L36-L39 side=new
+src/client/components/CommentForm.tsx:L36-L39
 複数行
 =====
-src/client/components/CommentForm.tsx:L42 side=new
+src/client/components/CommentForm.tsx:L42
 コメント内容`;
 
       expect(prompt).toBe(expected);
@@ -182,10 +182,10 @@ src/client/components/CommentForm.tsx:L42 side=new
       expect(result.current.comments[0]?.filePath).toBe('src/client/App.tsx');
       expect(result.current.comments[1]?.filePath).toBe('src/server/server.ts');
 
-      const expected = `src/client/App.tsx:L10 side=new
+      const expected = `src/client/App.tsx:L10
 App comment
 =====
-src/server/server.ts:L20-L25 side=new
+src/server/server.ts:L20-L25
 Server comment`;
 
       expect(prompt).toBe(expected);

--- a/src/client/hooks/useDiffComments.test.ts
+++ b/src/client/hooks/useDiffComments.test.ts
@@ -71,7 +71,7 @@ describe('useDiffComments', () => {
       expect(comment).toBeDefined();
       const prompt = result.current.generatePrompt(comment!.id);
 
-      expect(prompt).toBe('src/client/components/CommentForm.tsx:L42\nコメント内容');
+      expect(prompt).toBe('src/client/components/CommentForm.tsx:L42 side=new\nコメント内容');
     });
 
     it('should format multi-line comment correctly', () => {
@@ -90,7 +90,7 @@ describe('useDiffComments', () => {
       expect(comment).toBeDefined();
       const prompt = result.current.generatePrompt(comment!.id);
 
-      expect(prompt).toBe('src/client/components/CommentForm.tsx:L36-L39\n複数行');
+      expect(prompt).toBe('src/client/components/CommentForm.tsx:L36-L39 side=new\n複数行');
     });
 
     it('should return empty string for non-existent comment', () => {
@@ -130,17 +130,25 @@ describe('useDiffComments', () => {
         });
       });
 
-      const prompt = result.current.generateAllCommentsPrompt();
+      const prompt = result.current.generateAllCommentsPrompt({
+        requestedBaseCommitish: 'main',
+        requestedTargetCommitish: 'feature-branch',
+        baseMode: 'merge-base',
+        resolvedBaseCommitish: 'abc1234',
+        resolvedTargetCommitish: 'def5678',
+      });
 
       // Check if comments are in the correct order
       expect(result.current.comments).toHaveLength(2);
       expect(result.current.comments[0]?.position.line).toEqual({ start: 36, end: 39 });
       expect(result.current.comments[1]?.position.line).toBe(42);
 
-      const expected = `src/client/components/CommentForm.tsx:L36-L39
+      const expected = `diff base=main target=feature-branch mode=merge-base resolved-base=abc1234 resolved-target=def5678
+=====
+src/client/components/CommentForm.tsx:L36-L39 side=new
 複数行
 =====
-src/client/components/CommentForm.tsx:L42
+src/client/components/CommentForm.tsx:L42 side=new
 コメント内容`;
 
       expect(prompt).toBe(expected);
@@ -174,10 +182,10 @@ src/client/components/CommentForm.tsx:L42
       expect(result.current.comments[0]?.filePath).toBe('src/client/App.tsx');
       expect(result.current.comments[1]?.filePath).toBe('src/server/server.ts');
 
-      const expected = `src/client/App.tsx:L10
+      const expected = `src/client/App.tsx:L10 side=new
 App comment
 =====
-src/server/server.ts:L20-L25
+src/server/server.ts:L20-L25 side=new
 Server comment`;
 
       expect(prompt).toBe(expected);

--- a/src/client/hooks/useDiffComments.ts
+++ b/src/client/hooks/useDiffComments.ts
@@ -10,6 +10,7 @@ import {
   type LegacyDiffComment,
 } from '../../types/diff';
 import {
+  type CommentPromptDiffContext,
   formatCommentThreadPrompt,
   formatAllCommentThreadsPrompt,
 } from '../../utils/commentFormatting';
@@ -48,7 +49,7 @@ interface UseDiffCommentsReturn {
   applyCommentImports: (imports: CommentImport[], importId: string) => string[];
   generatePrompt: (commentId: string) => string;
   generateThreadPrompt: (threadId: string) => string;
-  generateAllCommentsPrompt: () => string;
+  generateAllCommentsPrompt: (context?: CommentPromptDiffContext) => string;
 }
 
 function normalizeThread(thread: DiffCommentThread): CommentThread {
@@ -437,9 +438,12 @@ export function useDiffComments(
     [generateThreadPrompt],
   );
 
-  const generateAllCommentsPrompt = useCallback((): string => {
-    return formatAllCommentThreadsPrompt(threads.map(normalizeThread));
-  }, [threads]);
+  const generateAllCommentsPrompt = useCallback(
+    (context?: CommentPromptDiffContext): string => {
+      return formatAllCommentThreadsPrompt(threads.map(normalizeThread), context);
+    },
+    [threads],
+  );
 
   const comments = threads
     .map((thread) => normalizeRootComment(thread))

--- a/src/server/server.test.ts
+++ b/src/server/server.test.ts
@@ -795,8 +795,8 @@ describe('Server Integration Tests', () => {
     it('GET /api/comments-output returns formatted comments', async () => {
       // First post some comments
       const comments = [
-        { file: 'test.js', line: 10, body: 'First comment' },
-        { file: 'test.js', line: 20, body: 'Second comment' },
+        { file: 'test.js', line: 10, side: 'old', body: 'First comment' },
+        { file: 'test.js', line: 20, side: 'new', body: 'Second comment' },
       ];
 
       await fetch(`http://localhost:${port}/api/comments`, {
@@ -812,9 +812,9 @@ describe('Server Integration Tests', () => {
       expect(response.ok).toBe(true);
       expect(response.headers.get('Content-Type')).toContain('text/plain');
       expect(output).toContain('Comments from review session');
-      expect(output).toContain('test.js:L10');
+      expect(output).toContain('test.js:L10 side=old');
       expect(output).toContain('First comment');
-      expect(output).toContain('test.js:L20');
+      expect(output).toContain('test.js:L20 side=new');
       expect(output).toContain('Second comment');
       expect(output).toContain('Total comments: 2');
     });

--- a/src/server/server.test.ts
+++ b/src/server/server.test.ts
@@ -812,9 +812,9 @@ describe('Server Integration Tests', () => {
       expect(response.ok).toBe(true);
       expect(response.headers.get('Content-Type')).toContain('text/plain');
       expect(output).toContain('Comments from review session');
-      expect(output).toContain('test.js:L10 side=old');
+      expect(output).toContain('test.js:L10 (old)');
       expect(output).toContain('First comment');
-      expect(output).toContain('test.js:L20 side=new');
+      expect(output).toContain('test.js:L20\nSecond comment');
       expect(output).toContain('Second comment');
       expect(output).toContain('Total comments: 2');
     });

--- a/src/utils/commentFormatting.test.ts
+++ b/src/utils/commentFormatting.test.ts
@@ -42,9 +42,15 @@ describe('commentFormatting', () => {
       expect(result).toBe('<unknown file>:L10\nComment body');
     });
 
-    it('should include the diff side when available', () => {
+    it('should mark only the old diff side', () => {
       const result = formatCommentPrompt('src/removed.ts', 10, 'Why?', undefined, 'old');
-      expect(result).toBe('src/removed.ts:L10 side=old\nWhy?');
+      expect(result).toBe('src/removed.ts:L10 (old)\nWhy?');
+      expect(formatCommentPrompt('src/added.ts', 11, 'New line', undefined, 'new')).toBe(
+        'src/added.ts:L11\nNew line',
+      );
+      expect(formatCommentPrompt('src/legacy.ts', 12, 'Legacy comment')).toBe(
+        'src/legacy.ts:L12\nLegacy comment',
+      );
     });
 
     it('should format suggestion block with ORIGINAL/SUGGESTED structure', () => {
@@ -125,7 +131,7 @@ const newCode = 42;
       },
     ];
 
-    it('should include one diff header and compact separators', () => {
+    it('should format a merge-base range with resolved hashes', () => {
       const result = formatAllCommentThreadsPrompt(threads, {
         requestedBaseCommitish: 'main',
         requestedTargetCommitish: 'feature/docs-update',
@@ -134,34 +140,75 @@ const newCode = 42;
         resolvedTargetCommitish: '1234567',
       });
 
-      expect(result)
-        .toBe(`diff base=main target=feature/docs-update mode=merge-base resolved-base=abcdef1 resolved-target=1234567
+      expect(result).toBe(`diff main...feature/docs-update (abcdef1...1234567)
 =====
-docs/SUMMARY.md:L85 side=old
+docs/SUMMARY.md:L85 (old)
 Explain why this was removed.
 =====
-docs/SUMMARY.md:L242-L244 side=new
+docs/SUMMARY.md:L242-L244
 Should this remain grouped?
 Reply 1 (Reviewer)
 Related entries are below.`);
     });
 
-    it('should omit unavailable and redundant diff metadata', () => {
-      const result = formatAllCommentThreadsPrompt([threads[0]!], {
-        requestedTargetCommitish: 'working',
+    it('should use a direct range and omit identical resolved refs', () => {
+      const result = formatAllCommentThreadsPrompt([threads[1]!], {
+        requestedBaseCommitish: 'abcdef1',
+        requestedTargetCommitish: '1234567',
         baseMode: 'direct',
-        resolvedTargetCommitish: 'working',
+        resolvedBaseCommitish: 'abcdef1',
+        resolvedTargetCommitish: '1234567',
       });
 
-      expect(result).toBe(`diff target=working mode=direct
+      expect(result).toBe(`diff abcdef1..1234567
 =====
-docs/SUMMARY.md:L85 side=old
+docs/SUMMARY.md:L242-L244
+Should this remain grouped?
+Reply 1 (Reviewer)
+Related entries are below.`);
+    });
+
+    it.each(['working', 'staged', '.', 'stdin'])(
+      'should omit the header for non-range target %s',
+      (target) => {
+        const result = formatAllCommentThreadsPrompt([threads[0]!], {
+          requestedBaseCommitish: 'HEAD',
+          requestedTargetCommitish: target,
+          baseMode: 'direct',
+          resolvedBaseCommitish: 'abcdef1',
+        });
+
+        expect(result).toBe(`docs/SUMMARY.md:L85 (old)
+Explain why this was removed.`);
+      },
+    );
+
+    it('should omit an incomplete resolved range', () => {
+      const result = formatAllCommentThreadsPrompt([threads[1]!], {
+        requestedBaseCommitish: 'main',
+        requestedTargetCommitish: 'feature/docs-update',
+        baseMode: 'merge-base',
+        resolvedBaseCommitish: 'abcdef1',
+      });
+
+      expect(result).toContain('diff main...feature/docs-update\n=====');
+      expect(result).not.toContain('abcdef1');
+    });
+
+    it('should omit the header when the requested range is incomplete', () => {
+      const result = formatAllCommentThreadsPrompt([threads[0]!], {
+        requestedTargetCommitish: 'feature/docs-update',
+        baseMode: 'merge-base',
+        resolvedTargetCommitish: '1234567',
+      });
+
+      expect(result).toBe(`docs/SUMMARY.md:L85 (old)
 Explain why this was removed.`);
     });
 
     it('should keep individual thread prompts free of the diff header', () => {
       const result = formatCommentThreadPrompt(threads[0]!);
-      expect(result).toBe('docs/SUMMARY.md:L85 side=old\nExplain why this was removed.');
+      expect(result).toBe('docs/SUMMARY.md:L85 (old)\nExplain why this was removed.');
     });
   });
 

--- a/src/utils/commentFormatting.test.ts
+++ b/src/utils/commentFormatting.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect } from 'vitest';
 
-import type { Comment } from '../types/diff';
+import type { Comment, CommentThread } from '../types/diff';
 
 import {
   formatCommentPrompt,
+  formatCommentThreadPrompt,
   formatAllCommentsPrompt,
+  formatAllCommentThreadsPrompt,
   formatCommentsOutput,
 } from './commentFormatting';
 
@@ -40,6 +42,11 @@ describe('commentFormatting', () => {
       expect(result).toBe('<unknown file>:L10\nComment body');
     });
 
+    it('should include the diff side when available', () => {
+      const result = formatCommentPrompt('src/removed.ts', 10, 'Why?', undefined, 'old');
+      expect(result).toBe('src/removed.ts:L10 side=old\nWhy?');
+    });
+
     it('should format suggestion block with ORIGINAL/SUGGESTED structure', () => {
       const body = `\`\`\`suggestion
 const newCode = 42;
@@ -71,6 +78,90 @@ const newCode = 42;
       expect(result).not.toContain('ORIGINAL:');
       expect(result).toContain('SUGGESTED:');
       expect(result).toContain('const newCode = 42;');
+    });
+  });
+
+  describe('formatAllCommentThreadsPrompt', () => {
+    const timestamp = '2024-01-01T00:00:00Z';
+    const threads: CommentThread[] = [
+      {
+        id: 'old-thread',
+        file: 'docs/SUMMARY.md',
+        line: 85,
+        side: 'old',
+        createdAt: timestamp,
+        updatedAt: timestamp,
+        messages: [
+          {
+            id: 'old-message',
+            body: 'Explain why this was removed.',
+            createdAt: timestamp,
+            updatedAt: timestamp,
+          },
+        ],
+      },
+      {
+        id: 'new-thread',
+        file: 'docs/SUMMARY.md',
+        line: [242, 244],
+        side: 'new',
+        createdAt: timestamp,
+        updatedAt: timestamp,
+        messages: [
+          {
+            id: 'new-message',
+            body: 'Should this remain grouped?',
+            createdAt: timestamp,
+            updatedAt: timestamp,
+          },
+          {
+            id: 'reply-message',
+            body: 'Related entries are below.',
+            author: 'Reviewer',
+            createdAt: timestamp,
+            updatedAt: timestamp,
+          },
+        ],
+      },
+    ];
+
+    it('should include one diff header and compact separators', () => {
+      const result = formatAllCommentThreadsPrompt(threads, {
+        requestedBaseCommitish: 'main',
+        requestedTargetCommitish: 'feature/docs-update',
+        baseMode: 'merge-base',
+        resolvedBaseCommitish: 'abcdef1',
+        resolvedTargetCommitish: '1234567',
+      });
+
+      expect(result)
+        .toBe(`diff base=main target=feature/docs-update mode=merge-base resolved-base=abcdef1 resolved-target=1234567
+=====
+docs/SUMMARY.md:L85 side=old
+Explain why this was removed.
+=====
+docs/SUMMARY.md:L242-L244 side=new
+Should this remain grouped?
+Reply 1 (Reviewer)
+Related entries are below.`);
+    });
+
+    it('should omit unavailable and redundant diff metadata', () => {
+      const result = formatAllCommentThreadsPrompt([threads[0]!], {
+        requestedTargetCommitish: 'working',
+        baseMode: 'direct',
+        resolvedTargetCommitish: 'working',
+      });
+
+      expect(result).toBe(`diff target=working mode=direct
+=====
+docs/SUMMARY.md:L85 side=old
+Explain why this was removed.`);
+    });
+
+    it('should keep individual thread prompts free of the diff header', () => {
+      const result = formatCommentThreadPrompt(threads[0]!);
+      expect(result).toBe('docs/SUMMARY.md:L85 side=old\nExplain why this was removed.');
     });
   });
 

--- a/src/utils/commentFormatting.ts
+++ b/src/utils/commentFormatting.ts
@@ -16,27 +16,38 @@ export interface CommentPromptDiffContext {
 
 function formatCommentLocation(file: string, line: number | number[], side?: DiffSide): string {
   const filePath = file || '<unknown file>';
-  return `${filePath}:${getLineInfo(line)}${side ? ` side=${side}` : ''}`;
+  return `${filePath}:${getLineInfo(line)}${side === 'old' ? ' (old)' : ''}`;
 }
 
-function formatDiffContextHeader(context: CommentPromptDiffContext): string {
-  const resolvedBaseCommitish =
-    context.resolvedBaseCommitish !== context.requestedBaseCommitish
-      ? context.resolvedBaseCommitish
-      : undefined;
-  const resolvedTargetCommitish =
-    context.resolvedTargetCommitish !== context.requestedTargetCommitish
-      ? context.resolvedTargetCommitish
-      : undefined;
-  const fields = [
-    context.requestedBaseCommitish ? `base=${context.requestedBaseCommitish}` : '',
-    context.requestedTargetCommitish ? `target=${context.requestedTargetCommitish}` : '',
-    context.baseMode ? `mode=${context.baseMode}` : '',
-    resolvedBaseCommitish ? `resolved-base=${resolvedBaseCommitish}` : '',
-    resolvedTargetCommitish ? `resolved-target=${resolvedTargetCommitish}` : '',
-  ].filter(Boolean);
+function isNonRangeCommitish(commitish: string): boolean {
+  return (
+    commitish === 'working' || commitish === 'staged' || commitish === '.' || commitish === 'stdin'
+  );
+}
 
-  return ['diff', ...fields].join(' ');
+function formatDiffContextHeader(context: CommentPromptDiffContext): string | null {
+  const { requestedBaseCommitish, requestedTargetCommitish } = context;
+  if (
+    !requestedBaseCommitish ||
+    !requestedTargetCommitish ||
+    isNonRangeCommitish(requestedBaseCommitish) ||
+    isNonRangeCommitish(requestedTargetCommitish)
+  ) {
+    return null;
+  }
+
+  const separator = context.baseMode === 'merge-base' ? '...' : '..';
+  const requestedRange = `${requestedBaseCommitish}${separator}${requestedTargetCommitish}`;
+  const { resolvedBaseCommitish, resolvedTargetCommitish } = context;
+  const resolvedRange =
+    resolvedBaseCommitish &&
+    resolvedTargetCommitish &&
+    (resolvedBaseCommitish !== requestedBaseCommitish ||
+      resolvedTargetCommitish !== requestedTargetCommitish)
+      ? ` (${resolvedBaseCommitish}${separator}${resolvedTargetCommitish})`
+      : '';
+
+  return `diff ${requestedRange}${resolvedRange}`;
 }
 
 function formatCommentContent(body: string, codeContent?: string): string {
@@ -144,7 +155,10 @@ export function formatAllCommentThreadsPrompt(
 
   const sections = threads.map((thread) => formatCommentThreadPrompt(thread));
   if (context) {
-    sections.unshift(formatDiffContextHeader(context));
+    const header = formatDiffContextHeader(context);
+    if (header) {
+      sections.unshift(header);
+    }
   }
 
   return sections.join('\n=====\n');

--- a/src/utils/commentFormatting.ts
+++ b/src/utils/commentFormatting.ts
@@ -1,9 +1,42 @@
-import type { Comment, CommentThread } from '../types/diff';
+import type { BaseMode, Comment, CommentThread, DiffSide } from '../types/diff';
 
 import { hasSuggestionBlock, parseSuggestionBlocks } from './suggestionUtils.js';
 
 function getLineInfo(line: number | number[]): string {
   return typeof line === 'number' ? `L${line}` : `L${line[0]}-L${line[1]}`;
+}
+
+export interface CommentPromptDiffContext {
+  requestedBaseCommitish?: string;
+  requestedTargetCommitish?: string;
+  baseMode?: BaseMode;
+  resolvedBaseCommitish?: string;
+  resolvedTargetCommitish?: string;
+}
+
+function formatCommentLocation(file: string, line: number | number[], side?: DiffSide): string {
+  const filePath = file || '<unknown file>';
+  return `${filePath}:${getLineInfo(line)}${side ? ` side=${side}` : ''}`;
+}
+
+function formatDiffContextHeader(context: CommentPromptDiffContext): string {
+  const resolvedBaseCommitish =
+    context.resolvedBaseCommitish !== context.requestedBaseCommitish
+      ? context.resolvedBaseCommitish
+      : undefined;
+  const resolvedTargetCommitish =
+    context.resolvedTargetCommitish !== context.requestedTargetCommitish
+      ? context.resolvedTargetCommitish
+      : undefined;
+  const fields = [
+    context.requestedBaseCommitish ? `base=${context.requestedBaseCommitish}` : '',
+    context.requestedTargetCommitish ? `target=${context.requestedTargetCommitish}` : '',
+    context.baseMode ? `mode=${context.baseMode}` : '',
+    resolvedBaseCommitish ? `resolved-base=${resolvedBaseCommitish}` : '',
+    resolvedTargetCommitish ? `resolved-target=${resolvedTargetCommitish}` : '',
+  ].filter(Boolean);
+
+  return ['diff', ...fields].join(' ');
 }
 
 function formatCommentContent(body: string, codeContent?: string): string {
@@ -64,23 +97,29 @@ export function formatCommentPrompt(
   line: number | number[],
   body: string,
   codeContent?: string,
+  side?: DiffSide,
 ): string {
-  const filePath = file || '<unknown file>';
-  return `${filePath}:${getLineInfo(line)}\n${formatCommentContent(body, codeContent)}`;
+  return `${formatCommentLocation(file, line, side)}\n${formatCommentContent(body, codeContent)}`;
 }
 
 export function formatAllCommentsPrompt(comments: Comment[]): string {
   if (comments.length === 0) return '';
 
   const prompts = comments.map((comment) =>
-    formatCommentPrompt(comment.file, comment.line, comment.body, comment.codeContent),
+    formatCommentPrompt(
+      comment.file,
+      comment.line,
+      comment.body,
+      comment.codeContent,
+      comment.side,
+    ),
   );
 
   return prompts.join('\n=====\n');
 }
 
 export function formatCommentThreadPrompt(thread: CommentThread): string {
-  const sections: string[] = [`${thread.file || '<unknown file>'}:${getLineInfo(thread.line)}`];
+  const sections: string[] = [formatCommentLocation(thread.file, thread.line, thread.side)];
 
   thread.messages.forEach((message, index) => {
     if (index === 0) {
@@ -97,10 +136,18 @@ export function formatCommentThreadPrompt(thread: CommentThread): string {
   return sections.filter(Boolean).join('\n');
 }
 
-export function formatAllCommentThreadsPrompt(threads: CommentThread[]): string {
+export function formatAllCommentThreadsPrompt(
+  threads: CommentThread[],
+  context?: CommentPromptDiffContext,
+): string {
   if (threads.length === 0) return '';
 
-  return threads.map((thread) => formatCommentThreadPrompt(thread)).join('\n=====\n');
+  const sections = threads.map((thread) => formatCommentThreadPrompt(thread));
+  if (context) {
+    sections.unshift(formatDiffContextHeader(context));
+  }
+
+  return sections.join('\n=====\n');
 }
 
 export function formatCommentsOutput(input: Comment[] | CommentThread[]): string {


### PR DESCRIPTION
Closes #454

## Summary

- Mark comments on the old side with `(old)` in `Copy Prompt`, `Copy All Prompt`, the text API, CLI text output, and terminal shutdown output.
- Add the requested and resolved diff selection once at the top of `Copy All Prompt` using Git range notation.
- Keep new-side and legacy comment locations unchanged, preserving the common output format.

The human-readable output remains neutral so it can be used by people and tools without prescribing what to do with the comments.

The old-side marker is part of each comment location, so it appears in every human-readable output. The comparison header remains specific to `Copy All Prompt`, which is the aggregate export path with access to the displayed diff metadata. Adding it elsewhere would require broader metadata plumbing and output-contract changes, which are outside the scope of this PR.

## Implementation notes

- `App` passes the existing `DiffResponse` selection metadata through the `Copy All Prompt` path.
- The shared comment formatter owns the location and prompt-context serialization, keeping copied prompts and other human-readable text output consistent.
- Direct comparisons use `..`; merge-base comparisons use `...`.
- Resolved hashes appear as a parenthesized range only when they differ from the requested refs.
- The comparison header is omitted when a meaningful Git range is unavailable (`working`, `staged`, `.`, and stdin-backed diffs).
- New-side comments and legacy comments without side metadata retain the previous location format.
- Stored comments and structured JSON output are unchanged; JSON already exposes the side through `position.side`.

## Copy Prompt

### Before

```text
docs/SUMMARY.md:L85
Explain why this was removed.
```

### After

```text
docs/SUMMARY.md:L85 (old)
Explain why this was removed.
```

## Copy All Prompt

### Before

```text
docs/SUMMARY.md:L85
Explain why this was removed.
=====
docs/SUMMARY.md:L242
Should this remain grouped with the related entries?
```

### After

```text
diff main...feature/docs-update (abcdef1...1234567)
=====
docs/SUMMARY.md:L85 (old)
Explain why this was removed.
=====
docs/SUMMARY.md:L242
Should this remain grouped with the related entries?
```

Direct comparisons use the same format with `..`. Working-tree and stdin-backed comparisons omit the header.

## Human-readable comment output

This output is shared by `/api/comments-output`, `difit comment get --format text`, and terminal shutdown output.

### Before

```text
📝 Comments from review session:
==================================================
docs/SUMMARY.md:L85
Explain why this was removed.
==================================================
Total comments: 1
```

### After

```text
📝 Comments from review session:
==================================================
docs/SUMMARY.md:L85 (old)
Explain why this was removed.
==================================================
Total comments: 1
```

## Test plan

- [x] `pnpm check`, `pnpm format`, and `pnpm knip`
- [x] `pnpm test` (856 passed, 2 skipped)
- [x] `pnpm build`
- [x] Manually verify `Copy Prompt` and `Copy All Prompt` for old/new comments and direct/merge-base/working-tree comparisons
- [x] Update `/api/comments-output` coverage to assert the old-side marker and unchanged new-side output
